### PR TITLE
Feature/rspec let

### DIFF
--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_no_content_type/checks_the_annotation_ID.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_no_content_type/checks_the_annotation_ID.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"93fe4de672e7a3481db87dbdaafce3fd"
+      - W/"d6f9de9013a5b5f0f1e146a8bc294938"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - b9f7cb1a-95da-4235-a433-2d90c7751cf3
+      - 442eb4ec-a4ce-4d12-a18a-ed6de365a8b8
       X-Runtime:
-      - '1.478793'
+      - '1.471702'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Tue, 28 Apr 2015 23:58:50 GMT
+      - Mon, 04 May 2015 17:52:17 GMT
       Content-Length:
       - '431'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=NUhXRXZuZlRJSzZ0RG8rSm5id3liUk43dXZzajJ3YWpUUDRPK05wSmgyNldmMzdNTnA2Nk9VbjRZRzhJMjVCSEUyVm43KzVTeGFjU3hsUHVQSzNrZjJ5UkViNFpYU2VjWDRyTHJzbFJsMHE0cFFtb2g5MmM4aHpmM3k4NU8raVhPYXhMeGFuamZXTUxjak1Fc1BLS0NnR21zREVDTE5yYnRFdWRtV0NxcS9Xb3Flb0dtV0FXb1hQZDhqck5ZWlBHb2d5WkozUHA2ZlJjZjgzcytzcmxSOGcyd29uWXQySnNjZ3RaZ25mVis2dz0tLWdHak5yQ1ljV01YVnpUQ1UxeGJxclE9PQ%3D%3D--30aea0ce980812f60f9cc6224c42184c8afcf120;
+      - _internal_session=b2pXMTdTZGxabFVia0xqdEhnVzd4RzNVYXlFMnNKVDNPSitxTjRPbm5nbVFNcXkyZmZsY1BUMFhTOUdMSkp2eEtuR2RDNDJpelBraGxWZHZpUkVGMUtkZkJ6QjUvMnhsR3d6RVdVZktPMWVWS2ZhdnFIZU1kSWM5akMwcEtCQlp4cW5qbVpEckRwNm5Wd1g0RXRVOHorMi83TjUvS3pxeHBnOTVsZGNLSnV0YjJkMDN3QmRPSXd0WElQdktyMXRxZXJqZEJtYU12RU5CM29VQU9KSDFBbzlDK3pKWWdIYnpCblhsZkVPWng3OD0tLU8yRGp4b2dwSVdoU2FoUG1HMkt1M1E9PQ%3D%3D--f931fd4c463994e1c20d037bb6f1a296e6ac45ff;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69850788352920","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/14de89ad-c607-4493-9b89-bb9d12f62e95","@type":"oa:Annotation","hasBody":"_:g69850788352920","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70075067637960","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/70789920-9b0f-4f5b-bd74-4ba30d5c9068","@type":"oa:Annotation","hasBody":"_:g70075067637960","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:58:50 GMT
+  recorded_at: Mon, 04 May 2015 17:52:17 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:58:50 GMT
+      - Mon, 04 May 2015 17:52:17 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:58:50 GMT
+      - Mon, 04 May 2015 23:52:17 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:58:50 GMT
+  recorded_at: Mon, 04 May 2015 17:52:17 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:58:50 GMT
+      - Mon, 04 May 2015 17:52:18 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,9 +135,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:58:50 GMT
+      - Mon, 04 May 2015 23:52:18 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -1251,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:58:51 GMT
+  recorded_at: Mon, 04 May 2015 17:52:18 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1271,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:58:51 GMT
+      - Mon, 04 May 2015 17:52:18 GMT
       Server:
       - Apache/2
       Location:
@@ -1279,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:58:51 GMT
+      - Mon, 04 May 2015 23:52:18 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1295,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:58:51 GMT
+  recorded_at: Mon, 04 May 2015 17:52:18 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1317,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:59:01 GMT
+      - Mon, 04 May 2015 17:52:18 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1331,9 +1333,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:59:01 GMT
+      - Mon, 04 May 2015 23:52:18 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -2447,7 +2451,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:01 GMT
+  recorded_at: Mon, 04 May 2015 17:52:18 GMT
 - request:
     method: get
     uri: http://localhost:3000/annotations/anything_here_is_OK
@@ -2477,13 +2481,13 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 987f2610-e16d-48fa-b097-17cca3e1d72c
+      - b3ebc0a0-be88-40c1-b4a3-ca3aa9023f25
       X-Runtime:
-      - '0.012273'
+      - '0.012074'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Tue, 28 Apr 2015 23:59:01 GMT
+      - Mon, 04 May 2015 17:52:18 GMT
       Content-Length:
       - '1452'
       Connection:
@@ -2506,10 +2510,10 @@ http_interactions:
         \                                               \n<br/>                                                \n<br/>
         \                                               \n\n</body>\n</html>\n"
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:01 GMT
+  recorded_at: Mon, 04 May 2015 17:52:18 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/14de89ad-c607-4493-9b89-bb9d12f62e95
+    uri: http://localhost:3000/annotations/70789920-9b0f-4f5b-bd74-4ba30d5c9068
     body:
       encoding: US-ASCII
       string: ''
@@ -2536,22 +2540,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 293c3506-aa61-4b68-97ee-b07814090dc4
+      - d3dc60d6-1821-441c-888b-bbce44f48c74
       X-Runtime:
-      - '0.180241'
+      - '0.176905'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Tue, 28 Apr 2015 23:59:01 GMT
+      - Mon, 04 May 2015 17:52:19 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=dDRCY1hVY2xVOU9yUEQvUUVnVWdNVnc0cFJsaGxzcDhPWnppVW5ZVkZoc3JxTGg2WHVwa290cVcyNmYyT2l0eUM4L3EwQlFIZ3lBRG01Yy9xTDlESERZNjFTQmdWRldEQ3YxZEdHemZESTVraFBCbTN4VkhXNVptVHcyOXlYYkxBRmRHaDZaWDBWQ0dPNG1hbjhacno4QTJNZS9WK09yNXNGb0J6SmJjajZnVnJXSjRuUldZdHgzVHJranFXMkp1LS1Oclg1Z3ZiNWlma1ZZTkZ4RHUrZ213PT0%3D--702da821b9c3478328f4ca94dc1e8936b36ea925;
+      - _internal_session=OEtvZUM2T0VmTXc4UU1DVFJYL1hxcDYzNHVrRG9YbFhQRGs2UUw1UkQ5OUpSMkFGdHc1RXlXNjJ3VzRuR3pETGtDRVVWMWx0UDdRV2RyR2Y1VU9qamFXTHd6YlFYbThrS1ZONkF6MXhldlBzWEsvOE1Ra3dJTUR6S1ZzNDJESm5xR3hoc2d0QTRkRWV4dmNVTEpxSUhRb2U5NC9wcmhub1FPUkx4enFmVkw3cXdQUG5tSDRNQndqbjlGbVlGNW1lLS1OODdvRWRTT2cvai9yWjJqbmtobk5RPT0%3D--08b1fb21df295d1b6e4f9482487aafa1d471a0ab;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:01 GMT
+  recorded_at: Mon, 04 May 2015 17:52:19 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_no_content_type/logs_exceptions.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_no_content_type/logs_exceptions.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"475a5279575740a8b732de6081dbb781"
+      - W/"a8133c26355d1c729665df1c2e9a2f3e"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - e1930843-0014-4b34-a916-bc8baf944387
+      - e2173898-d529-485c-902e-1859cbf74f02
       X-Runtime:
-      - '1.377762'
+      - '1.385071'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Tue, 28 Apr 2015 23:59:36 GMT
+      - Mon, 04 May 2015 17:52:40 GMT
       Content-Length:
       - '431'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=cXZVR2REaW1MbERuTEozOUY1d1hmTmVVZnBNNGtJTkZxU2FnTlBCWS9FTGUwcDljYUhlTEZFMUNKS1dBQnBsSm4rQW9wOFhWbmp4V1VqalBacS9HMlBSdHd6NmdLaUw5OEhQRW5qOXd2cWxBb0s3b1JxdWFhOUpmcmtGb21KN09Jc1MzVkMvUmpKU2lpK2JzU1ZINHQ5ZDVsL3VIRWtQN01oNVo1dGNrLzl3cDEzTFdPNkRLam01T3ZBdjZzd0FTMG1ZK2dxTkJ2QnF0ZlBOQzdUY2FhbzRxTEJRQ3hvdmhPL1g4R0FYS1k4az0tLXh2Y1V3VjNmVVArMnhmUkpiRXdmeVE9PQ%3D%3D--271fff540e1560fb09d2fc3d661d5e798c465782;
+      - _internal_session=KzZkZFhJZWgzc0ZVL1dHN3dRM3BacDhTL2I5aTRLZjFtS2dzSmdGNVhCN0dncXRFNWFOZEhCM0E5bFowc3RyTnR3TW1yOVVxYnRBUGJHUUpMYTdvS0pNMGJxckhTaW9JcCswd20xK1AzMHErSlFUT0ZFRUVPYVV6eWYwTnI2b2JVNW5zd3NReUFzelNPVzhpa0E0dGlIOUpMMUs5MmJ1UkFKQUZEOG9HN3h4VzRtekpFNUZQQ1BJTFpLb1ZsL1ZqdTBubWdoYWRvWFMwN3dpTEhHUVovL0FNM2dtMnR2MVlYMHdrdjNtbXJXWT0tLW9JQTNXNC9WQmI1WjA1a05pWW1PMUE9PQ%3D%3D--d885ef16a1eb7d78c39b85b74e49f8f445315c4f;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69850615310480","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/c92d0f1e-4a9b-48ba-be8f-3d21a5690e2e","@type":"oa:Annotation","hasBody":"_:g69850615310480","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70075064216320","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/1585f1aa-ed5b-433e-8e30-d2b4f9d9ce81","@type":"oa:Annotation","hasBody":"_:g70075064216320","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:36 GMT
+  recorded_at: Mon, 04 May 2015 17:52:40 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:59:37 GMT
+      - Mon, 04 May 2015 17:52:40 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:59:37 GMT
+      - Mon, 04 May 2015 23:52:40 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:37 GMT
+  recorded_at: Mon, 04 May 2015 17:52:40 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:59:42 GMT
+      - Mon, 04 May 2015 17:52:40 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,9 +135,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:59:42 GMT
+      - Mon, 04 May 2015 23:52:40 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -1251,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:42 GMT
+  recorded_at: Mon, 04 May 2015 17:52:40 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1271,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:59:42 GMT
+      - Mon, 04 May 2015 17:52:40 GMT
       Server:
       - Apache/2
       Location:
@@ -1279,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:59:42 GMT
+      - Mon, 04 May 2015 23:52:40 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1295,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:42 GMT
+  recorded_at: Mon, 04 May 2015 17:52:40 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1317,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:59:42 GMT
+      - Mon, 04 May 2015 17:52:41 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1331,9 +1333,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:59:42 GMT
+      - Mon, 04 May 2015 23:52:41 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -2447,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:43 GMT
+  recorded_at: Mon, 04 May 2015 17:52:41 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/c92d0f1e-4a9b-48ba-be8f-3d21a5690e2e
+    uri: http://localhost:3000/annotations/1585f1aa-ed5b-433e-8e30-d2b4f9d9ce81
     body:
       encoding: US-ASCII
       string: ''
@@ -2477,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 75e39296-54a1-40ef-af94-2b67f4ded9c4
+      - d33efb17-8f37-4e99-a84c-99d956654d93
       X-Runtime:
-      - '0.135638'
+      - '0.135406'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Tue, 28 Apr 2015 23:59:43 GMT
+      - Mon, 04 May 2015 17:52:41 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=YjhTWHR4YTNjVUJnRUQrampHRC8venkwRUtERW15K2JoOVpnaXduUFoxTUFzK0Y4eldmckJ0ZjV6eFAvSVp5cVRTTVlOc0grMk1Va1grY2ZFTFF1Q3dvcmR3T1pxVzFNWElCWWpjeUZyVWdNdVN3VUNxUzBESlkzVjVtRTRiekxYMDFLczRpbG5GcmxuWlFxZDJzcjRRWkw0OTZFN2d2aUxoWDNiWEZrZUZwWXd0RjFTT2lQZzFCT05YbittdVRMLS15MnNOaTgzMm5JbEkvczZUK1ozdWRBPT0%3D--908a70ebfc2131bf970e671141a1262815404511;
+      - _internal_session=VzNqN1daYW55Z0V2aXYraWVRZ2ZCSDVkb254TG93VVVveUtkTmNxTE02YUxndUZIZVF4dGFudC8vNVp5T0NaTFplL1hEYmFJc3F3T3JuVWc1TFdZRTlyU1JDU1Z2TWJ6aXgveU9VVmZIdFhXUSt1WkRsNlk3R3BKWm9hNkk4SFRHODVoT3lMUWM3QmYxVEVkZ2FjaXJhWkovSmk0bUVHTENaaGxnQ3hJQnFjZlM3eDM3SmRUQjY3WkVyUTFhOG14LS0xcWhKWGlKL1F1LzZDUk1OSlJPYjlRPT0%3D--3d475d6951d1a5a532b91e3681868c4416cda705;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:43 GMT
+  recorded_at: Mon, 04 May 2015 17:52:41 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_no_content_type/raises_an_argument_error_with_a_nil_ID.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_no_content_type/raises_an_argument_error_with_a_nil_ID.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"de3daf8f48136a59f839906a957ebad4"
+      - W/"fb4539387e36541e23a08e890c6d540b"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 5d0c7547-f572-4c21-bbb4-9b047804bdfe
+      - 45d897cb-4d41-4aab-b127-69f2de886bc5
       X-Runtime:
-      - '1.446833'
+      - '1.479024'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Tue, 28 Apr 2015 23:59:03 GMT
+      - Mon, 04 May 2015 17:52:20 GMT
       Content-Length:
       - '431'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=cGcwVGY3OFFuTG9ONFIvd1lEcEZGMXJpMGlKK3RYMGU3bmtkdWlBTGJQaU5BTkdaRWlHckxJMERyd2prZU9vZWRkSWlLTUM4NmYzbHBBb2F6THQzUXl3ZHc5MFB5cEhxelJRU3MxYmxKMkk0eHFtZXIwUHBmTHVHSURSMWpZY0RwTDNDRFY1aDM4bkZIQXFCQVNvTTVqcUxheFN1SjB1QmpBZ08yNE5GR0RrRFR1QTM5Y0RRYVdkbWxBb05yTVJNT2k3WXVjSGJpYjZJQkpXNHNQbmRxeDNHRXlLNjBQb3pxcjNyaElCQ3pwST0tLUdUNXl4SjAyRWFOWU4xRmNESlpPTGc9PQ%3D%3D--7b8e32d5c9f7e15597ca22b324bcd414246ae319;
+      - _internal_session=a0g2VjZpTk1QbkRKOFRkUnJRVmxuM1Y5Vm5XNWNUOHlic0dWUVFSYlJVMWlOeHBIalkvcklaTm1TaGdZeWR6emdqSEY5WHdXZWI4RlIzd1BtaDlWWFhqb2JQSXM1K0FNaGdLa0tGaWUxdmFoTnlNZGlzM0FldTNYSHdvelVxZGc3SzVWajV2ZE1LMk40cldYSlduMktrcjZ3S08xb0daMGl1a1FaY3FuOTVGcllqcFg5dnhmT2U0dm01RTd4Vlp0eExncm4xbDhTYjFaT0JkeWw3OEYwVW1ZTjlibWhBaDlJS0VnbHUyclNnTT0tLTR3QVR3RE9udkZxYTBMRGZlS1FKaHc9PQ%3D%3D--b0f06acfdf02ea3d330f9670f387c2635b4f2088;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69850625282220","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/0f7e3a7c-cfc0-4642-80a7-562c9f532150","@type":"oa:Annotation","hasBody":"_:g69850625282220","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70075071425120","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/7c37f85b-0ab7-4531-9a41-4047a3983ded","@type":"oa:Annotation","hasBody":"_:g70075071425120","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:03 GMT
+  recorded_at: Mon, 04 May 2015 17:52:20 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:59:03 GMT
+      - Mon, 04 May 2015 17:52:20 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:59:03 GMT
+      - Mon, 04 May 2015 23:52:20 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:03 GMT
+  recorded_at: Mon, 04 May 2015 17:52:20 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:59:03 GMT
+      - Mon, 04 May 2015 17:52:20 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,9 +135,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:59:03 GMT
+      - Mon, 04 May 2015 23:52:20 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -1251,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:04 GMT
+  recorded_at: Mon, 04 May 2015 17:52:22 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1271,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:59:04 GMT
+      - Mon, 04 May 2015 17:52:22 GMT
       Server:
       - Apache/2
       Location:
@@ -1279,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:59:04 GMT
+      - Mon, 04 May 2015 23:52:22 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1295,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:04 GMT
+  recorded_at: Mon, 04 May 2015 17:52:22 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1317,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:59:04 GMT
+      - Mon, 04 May 2015 17:52:22 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1331,9 +1333,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:59:04 GMT
+      - Mon, 04 May 2015 23:52:22 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -2447,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:04 GMT
+  recorded_at: Mon, 04 May 2015 17:52:23 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/0f7e3a7c-cfc0-4642-80a7-562c9f532150
+    uri: http://localhost:3000/annotations/7c37f85b-0ab7-4531-9a41-4047a3983ded
     body:
       encoding: US-ASCII
       string: ''
@@ -2477,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 893f6179-bff6-4671-9bbb-253bc9b2f353
+      - 3600a760-e4d5-4b99-b71e-374ac570216e
       X-Runtime:
-      - '0.158289'
+      - '0.159759'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Tue, 28 Apr 2015 23:59:04 GMT
+      - Mon, 04 May 2015 17:52:23 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=U1pDYWJMNDA1Z0plejNXQVcvQkNHMXBQNThTazUvYnlqVEQydzJoa2YyNUJCVXQvNTREQXNueUd0Tyt1OVFHR3NhMDNvdW51RFQ0Rmwwemc0L2VZdmNacGJqRTAwUWdNOXhVR3Y1Qm9mWnM0VVd0MFdWZ2ZONDZOY0p5Y0x2Z1RrWmdKbXJ1NG1MS0Z4T3dJOXNKSG1YQ0I4UC8zYXM5TmtJRkw3RlNpL2h1TmdlQXRYa2k1SElQdTA3SSsvaTRDLS1yRW82d2U2bDRCK2xTUmVVT1JLQ0JRPT0%3D--bc672019ebf5ff09e2c9c28d3b56e856ce7bb5f7;
+      - _internal_session=dTE1TzVYOFk2bE5nczJRR3NYYXFaT1IrRzZaWi9WYXpwTVpNVldCejV6YTJWZkE2U2VsaHlyeUEyWXMxaDNpSUxmRUlhZFprUWxod2pqTFAvNU4vZElOMGc0cUZDY2F0NXBqVEtFQU5TeXp1ZHZTTkU5RVg4U0lQTVNCNFpLL0doaHRnemxoL2lCZzhzbkRvc01uNUZ5YkVRMTVOM3IvNXZsL3Fvc0pBY2hFWXVIR3JYT292bklmbzNjL0MwYVBxLS1PSWl5VkJLV3VjZHNrRGQ1c0hpSnJnPT0%3D--dc73013bbfc53c6897f225fec38ca70949d8d31d;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:04 GMT
+  recorded_at: Mon, 04 May 2015 17:52:23 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_no_content_type/raises_an_argument_error_with_an_empty_string_ID.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_no_content_type/raises_an_argument_error_with_an_empty_string_ID.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"bd30d6432bf1fe2c6c41fd057f846842"
+      - W/"dc0a2a6dd3e6fe2e289b516642922ebe"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 2f2a16c0-4498-4a17-b196-a4a22770ee55
+      - d99de288-fc9c-4db5-8b37-db1ba3e70482
       X-Runtime:
-      - '1.416062'
+      - '1.461009'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Tue, 28 Apr 2015 23:59:18 GMT
+      - Mon, 04 May 2015 17:52:27 GMT
       Content-Length:
       - '431'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=VlFwUVByUTBmZnlLMnE3ZnVMUlRjUmtRRUxQZE5OeDVzRGN6eTJkOGNSUmhmbGxyVmRBdTY2SG9WWkRJWWlHY05BT3BjeHBncFNPN0c3dndRajFXR0FpZGsxeEttTmU5dERHUFE4UWs4WFg3Y2dwM0t3ODZOdktHREZBLzhqVWdybWYrZ09VeER0SkY5ODZRNDRkMnZmOXByZGZTdWkxTDAyOXV3aWxhS0FmRVFFWlN5OHVkTGJpZVVMMGhYbG1WVjREK1RFMGFhQzE2ZkxyeVpGRU9qcWlhVnNJUUhLWEJzWTJ3UUY5VS9lbz0tLUxSNVpub1RkZHdGam1rZGNVZk1OVGc9PQ%3D%3D--da72580d5573fac685f5d51be97df8fc3cc08dfb;
+      - _internal_session=UGErUmd3cGk3VlFESHYxMXVRRnN1RU1WeHhLY3E1b0l2Q0FaOHJydkFQajZKUjlPWExPWUIrOWFNclBRVjNYSWl4cGxmQzI3a0NuT3U2Q0JDWUxJTGZibGtNRUl1UVI5Mm9SeHE2V2Uyb3k2eDN6YUlvWVFINi84ZlFNd0ptMW9xZGttbHlQVVRjQXhXNC9wcUROa1A0T1R2UW9iUnpjNXo3K1R0eVJ1NCtaU21LTVhhbjA5VE5QZHZjMzNreXNKRE1TUmdjZ1hKMHJ5T1dPYS94VEpFdDJWbmlCK3RTTURwTHB6alRzV2x3Zz0tLVo2dnF6eHNvZm9adVlnVVF3dGNLT2c9PQ%3D%3D--cbfa36ba315be930d30443e3f198f3604bbe9332;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69850623926060","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/cc19493b-5d8b-40d4-9358-1eadf7b4d974","@type":"oa:Annotation","hasBody":"_:g69850623926060","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70075074455540","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/79c2795b-449c-42f0-8f07-7f4ba3b7b063","@type":"oa:Annotation","hasBody":"_:g70075074455540","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:18 GMT
+  recorded_at: Mon, 04 May 2015 17:52:27 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:59:19 GMT
+      - Mon, 04 May 2015 17:52:27 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:59:19 GMT
+      - Mon, 04 May 2015 23:52:27 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:19 GMT
+  recorded_at: Mon, 04 May 2015 17:52:27 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:59:19 GMT
+      - Mon, 04 May 2015 17:52:27 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,9 +135,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:59:19 GMT
+      - Mon, 04 May 2015 23:52:27 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -1251,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:19 GMT
+  recorded_at: Mon, 04 May 2015 17:52:28 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1271,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:59:24 GMT
+      - Mon, 04 May 2015 17:52:28 GMT
       Server:
       - Apache/2
       Location:
@@ -1279,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:59:24 GMT
+      - Mon, 04 May 2015 23:52:28 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1295,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:24 GMT
+  recorded_at: Mon, 04 May 2015 17:52:28 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1317,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:59:24 GMT
+      - Mon, 04 May 2015 17:52:28 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1331,9 +1333,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:59:24 GMT
+      - Mon, 04 May 2015 23:52:28 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -2447,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:25 GMT
+  recorded_at: Mon, 04 May 2015 17:52:28 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/cc19493b-5d8b-40d4-9358-1eadf7b4d974
+    uri: http://localhost:3000/annotations/79c2795b-449c-42f0-8f07-7f4ba3b7b063
     body:
       encoding: US-ASCII
       string: ''
@@ -2477,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - ccd29580-9b1b-4220-904b-5a6500a98cfc
+      - 6c2abc81-a40c-4cce-9c43-0bcf0438e549
       X-Runtime:
-      - '0.144522'
+      - '0.149653'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Tue, 28 Apr 2015 23:59:25 GMT
+      - Mon, 04 May 2015 17:52:28 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=Qld0S29sTGdWVFA4SFR6Tk5ia0xMalN0TVBydldlNnpUMkRERm1tSHRKY3FoWlkvNjgyOFcvbkNTdnp1UElFWWlValZ3K01XRkxJaXpjOTRBT3Mxei9mMHlMWm1HNkVvYWRiYVVvc3JoUytjc29BcGdpRFRiektDS09yTElGQ0s2TlE0dnJXNnA3S1VRL0l2b2tOWjdObFNFTzl3eXpNVmd2eVpxdytvZUIydVpmN05DRnltYUdOeU51S1VVTEFWLS00cEY0bUJEbGgyZ1lna0tNUDVlZDBBPT0%3D--1c64200228151905152133b470542934c91dd3e3;
+      - _internal_session=UC9XNU5JWnVWTlhvcCtwOHNseXVKTTRXL2pKb0ROVDZRZVE2T1JHVnMrNjArZEl6UThNd1Z4Tk9zYlMwVENGQlJZcDhSOFZmS1BQdG1EVnFtNjFUR28yRzNYSFVKeVVTODNiNFBHZVRmWkNobHBHenNVYTAxK1kwL3g5aDY2UGNwMi95cEJkb1UxVlhqYW5mc3J2cElSMHF1ejVXbUdKNVpIbkg2MTRuYTU0cTNPU2hqVlQ1RnQzNElOU2N0bTM3LS1lbU4rQUdtQXBrQ2l6QVkyemcxMVlBPT0%3D--f9c8f9ee2535011e84038110d178d4f8afc4e669;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:25 GMT
+  recorded_at: Mon, 04 May 2015 17:52:28 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_no_content_type/raises_an_argument_error_with_an_integer_ID.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_no_content_type/raises_an_argument_error_with_an_integer_ID.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"986820be16e8ea2c0e52d216d585a4dd"
+      - W/"ec7d83a637dd58bdc8fbd71a0a9ab360"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 904c6c73-ed18-4357-93a3-af5f24ab7359
+      - 91539fa4-ab64-46a0-92b1-9e2caf2f898d
       X-Runtime:
-      - '1.412980'
+      - '1.412570'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Tue, 28 Apr 2015 23:59:06 GMT
+      - Mon, 04 May 2015 17:52:24 GMT
       Content-Length:
       - '431'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=YzFCY2l2aE83eEhIVnpsMVZLUHBrSFZYTmZ5N2cwWUtrWVcwSE1waFdpWFRGVnJUMXNZd2FFNjhGakxiWmVrZS9jSytZbGltVmxwdVNzK21yZTJGMzRQTjdGLzNGdlpkSjRCMmpZeDFCZWFoUTU2eldGZ2RkQXRnSVhMZFJ5WStuTnpybXc4QTVqMFVjZlh4Mkx5Ukl1ajJwT09VM3l2U0w1bmRkUCt0UTY0ZVAxSkZBQmlXc2lTei9NaUc3WWlWTnZsOEFvV1NRUm90NEp4M3VJbGZQYUx3U0R5aGRacWR6eVBod0d0SkExND0tLXBKdWNIM0lSZEFML3l2QWNaZDlOV0E9PQ%3D%3D--512927cb4268d9073a93911fec80c36534ada8cb;
+      - _internal_session=My9OTUVGMXE4aVlhUUhGL2E0SHMrb3lhbE02aWhQY21ORDBqOHNVdFd4U3VhRnY2RzZwTXM4WCtoOGxJV2JhQ0w3TDRjdlNNTW1uamZ3SEJXWjVYUWNOYTdXWFRlcHNSODNPZCs2bW1jU3NLb3NKcmhrTzBSTWZOYytXQUZIWE16UjBqZXFLTFV4UVhuUzdQVVo2UmRFMDYrRnVrS0NTWk5ucENWWCtwM1pQQVY0bG5nU29VT3hrT2duSWxVVjRTdit2MFpRcmpPODZiaTFiMXMrWDgxb1A5YzdKdWpmeHJINWNucUp2WlNuTT0tLTlZblhwRjNXUkkrK1J3VWFjMmRoMlE9PQ%3D%3D--96a2b2cec4db1df2fbf974566ede763dbce6a2b1;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69850629620580","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/ded1c527-1f6e-4264-bd01-4f9f7140b8b1","@type":"oa:Annotation","hasBody":"_:g69850629620580","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70075067320420","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/bcd289ce-8c37-4cb7-a588-6f7ce5f9b9e7","@type":"oa:Annotation","hasBody":"_:g70075067320420","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:06 GMT
+  recorded_at: Mon, 04 May 2015 17:52:24 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:59:06 GMT
+      - Mon, 04 May 2015 17:52:24 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:59:06 GMT
+      - Mon, 04 May 2015 23:52:24 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:06 GMT
+  recorded_at: Mon, 04 May 2015 17:52:24 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:59:11 GMT
+      - Mon, 04 May 2015 17:52:25 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,9 +135,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:59:11 GMT
+      - Mon, 04 May 2015 23:52:25 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -1251,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:11 GMT
+  recorded_at: Mon, 04 May 2015 17:52:25 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1271,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:59:11 GMT
+      - Mon, 04 May 2015 17:52:25 GMT
       Server:
       - Apache/2
       Location:
@@ -1279,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:59:11 GMT
+      - Mon, 04 May 2015 23:52:25 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1295,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:11 GMT
+  recorded_at: Mon, 04 May 2015 17:52:25 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1317,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:59:17 GMT
+      - Mon, 04 May 2015 17:52:25 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1331,9 +1333,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:59:17 GMT
+      - Mon, 04 May 2015 23:52:25 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -2447,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:17 GMT
+  recorded_at: Mon, 04 May 2015 17:52:25 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/ded1c527-1f6e-4264-bd01-4f9f7140b8b1
+    uri: http://localhost:3000/annotations/bcd289ce-8c37-4cb7-a588-6f7ce5f9b9e7
     body:
       encoding: US-ASCII
       string: ''
@@ -2477,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 5dfeaae7-52b6-486d-a92c-859462c1e15e
+      - f8fb2379-7361-40dc-971c-8122edc39d87
       X-Runtime:
-      - '0.156653'
+      - '0.156001'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Tue, 28 Apr 2015 23:59:17 GMT
+      - Mon, 04 May 2015 17:52:26 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=SURZR2FyZ1F6bk5INUJ2Vm8zVjZ3TG5GSGIzMjRYd2NlTWdxNEZTaHZnODRRWnV6dVJ5ZEtzV1BxSkg1RmQ2Q0ZWRjloWlVXVlduaFFGYUoyNnVGcDR1VEpmT1J2RWtyWHdpdUw4RklDNUdsT0I4aTdQeDlqVUxFOEd2dmJvU0dVZHI0amNKcHJXZ0V5VVMwYXN3TFFjZDhHWWZJeGdMcHBUci9ZSkdSdXdkUkRybFNxODEzL1YvVjZHSTU2SllDLS1iaG5jenFyeTJZVC9Va01idmlzaktBPT0%3D--55d69847538894d7a92835e4da5ce492ddf768b4;
+      - _internal_session=RnJSNWh1ZVVhcXY4aW1obFZiVENwWjVRbHhqTUtRS3Y5NDFBUGh5a1I0NnNoMUY0Q2d5M2hPLzNXMWFkRVhWTEJoRmdXZytXOEJ4NmJhY1pRK0hoRllOWXRoaTJvMEo4cHFYWUZpWFdqN2U1by9DTzVRS3FSSjhibnVBempYczl1MUx4di9hdEgxY01kTERIVVBxZm5MNVFld2xpSVVoWFBic1lERytyTXU3UHZqOHdJZDBjUzROSlE0SWFxdkN1LS1nd3UwOE8xMTZZSHFCRi9oZHh5bWh3PT0%3D--1567b519c4e42a1351bc4cd55eb9d0c1dc68003a;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:17 GMT
+  recorded_at: Mon, 04 May 2015 17:52:26 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_no_content_type/returns_an_EMPTY_RDF_graph_for_a_500_server_response.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_no_content_type/returns_an_EMPTY_RDF_graph_for_a_500_server_response.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"f362ca28671415126f630d75864e4b30"
+      - W/"90766e1bdc4fd15c9f3e28bf588bc5ec"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - da5432c4-45ff-4506-900e-b27a07bd9587
+      - 8f4d296d-d714-47e8-bf46-b04b9bbdbf57
       X-Runtime:
-      - '1.395163'
+      - '1.404048'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Tue, 28 Apr 2015 23:59:34 GMT
+      - Mon, 04 May 2015 17:52:37 GMT
       Content-Length:
       - '431'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=dUNCSkZxUnA2eVBWcDhBMTFPY2tSdFplOStoMC9YWG41REZUSi9BVi9kYVhMakRray90NStIcmZzMTVBMnNUVVIxOUMxQjgzc0ZCU0dvdTlxK0dRK21vUmxCYVhVemwybmw0VlJ6anUvMU5BTEdSVFFXY0N0TVBJWVZ1SmNqc3A2ZC9LM3JTWHRhTXVYOVRYQkh2N2R4TWlvSDZoSXFBc2pxM3QrZk8wOHZndVR4QzF1NE9xTE1TZGxZYUpibWdqSk1nTlFMbFhFZE9rVVRoSjJKRndvT2JRZ1p4T2lma0N2T2Nmc2pVVGFUMD0tLWd1d2kxQ09IVDBkK1F0b0RZRENFR2c9PQ%3D%3D--6c9c93cd37737b9d1a3dd0f96c4d66b49cbe7e1b;
+      - _internal_session=Ny81cFV3cFJzSEhXMmVsbTRLcWQvVUxTOEgyYWFPM3MrSDhEclF6Z3dNYmxYUGpwbFdjVmNtWXdheHowMzUvaEJWRG9DdExmTDdCV3NhTDR3NjkxVlBjTjJZT1lUNHQxOG1XWXBLMzRrT2UyQjh5SEpleHlDbXpTQUZ3NUVnejBwMlZxR09MQklqZzFtbS8xc0c1eHBlU0JFU1N2OFBubjVBLzF5dkp3czdZcCtLZ2lMd1lSSk5oZHk4bUd6RUtPVXM5dEFuZndyTUxtMVY1Mjl5emlFOUpvRWphOHZ5T2hpQ012bCswNXdzcz0tLWJPY3NPQ3JwYndCTkR6dURYdGhIeHc9PQ%3D%3D--1ac24762695f2f9709f0009dfd971795face3c97;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69850776696760","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/827272bc-d876-419e-91e8-a2939a7f2749","@type":"oa:Annotation","hasBody":"_:g69850776696760","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70075211547160","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/ecfbf193-c9cf-4325-9607-da9c289e2e5f","@type":"oa:Annotation","hasBody":"_:g70075211547160","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:34 GMT
+  recorded_at: Mon, 04 May 2015 17:52:37 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:59:34 GMT
+      - Mon, 04 May 2015 17:52:37 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:59:34 GMT
+      - Mon, 04 May 2015 23:52:37 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:34 GMT
+  recorded_at: Mon, 04 May 2015 17:52:37 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:59:34 GMT
+      - Mon, 04 May 2015 17:52:37 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,9 +135,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:59:34 GMT
+      - Mon, 04 May 2015 23:52:37 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -1251,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:34 GMT
+  recorded_at: Mon, 04 May 2015 17:52:38 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1271,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:59:34 GMT
+      - Mon, 04 May 2015 17:52:38 GMT
       Server:
       - Apache/2
       Location:
@@ -1279,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:59:34 GMT
+      - Mon, 04 May 2015 23:52:38 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1295,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:34 GMT
+  recorded_at: Mon, 04 May 2015 17:52:38 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1317,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:59:35 GMT
+      - Mon, 04 May 2015 17:52:38 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1331,9 +1333,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:59:35 GMT
+      - Mon, 04 May 2015 23:52:38 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -2447,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:35 GMT
+  recorded_at: Mon, 04 May 2015 17:52:38 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/827272bc-d876-419e-91e8-a2939a7f2749
+    uri: http://localhost:3000/annotations/ecfbf193-c9cf-4325-9607-da9c289e2e5f
     body:
       encoding: US-ASCII
       string: ''
@@ -2477,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - fe85faa5-4cb1-4002-901d-894aabbc111e
+      - 3a5350a5-ed81-42cc-bfaa-d2f510f88352
       X-Runtime:
-      - '0.154811'
+      - '0.155408'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Tue, 28 Apr 2015 23:59:35 GMT
+      - Mon, 04 May 2015 17:52:38 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=dS9WYk5ZSVJWdUlweXk1UDRnU2pHWi9wSlpkNDVYTlpVU3l3UXpacFRSdXlxNndoVUROK0FPWmN1TnNPemw0aE5mVmUzZ1NuL3grOVZabW52SXQzMStiZDVQcEEzc3FhSmI2NXlRRjgxaTJJQ01BekVFbzlQOFV5Vi8vS3FNakRuMDRnRWQ4bDRGOWFmVmVwTnJYNStYVmcxVlNLU1hwazdQQTl5ZEJJdVRaMHkzYnJSdzRIaW5URHluNUU0VllnLS1jT1hzV0Rvd3Z6bldId1F0ZFlCTm9nPT0%3D--b70e945d8197d167898406cfee91c8104256ac66;
+      - _internal_session=ZVhOVmk1VzJwdDlMekVvR2l4Ym1ySFJ6RlZkaW1yaVUvd3N4OFBDd1BpUWJXTWdjZ3hnWElndmlFemJtUWZKNEt4eDFMNFdrZHNST2tKQWJwK0cyNnVGWWtGZW16dEVCS2M1N05mbm0vRVZkSkpMcjN1ZnFtL2JJMmM2dHRVakl2d1pSVk9GSVVBb1JNZW9XS0dSUm9zTmVPRGZmRW10eCtRMmh5WGd6ajM4VGNxcmNzdzJHUDZlTVB5V0FDaEFrLS1pVWRJL2s2eDhaaTZTbkJKb2pBaHRRPT0%3D--f9faf0b82721f9f016f24e291117c05eac4f50b6;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:35 GMT
+  recorded_at: Mon, 04 May 2015 17:52:38 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_no_content_type/returns_an_EMPTY_RDF_graph_with_a_valid_ID_for_NO_annotation_on_the_server.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_no_content_type/returns_an_EMPTY_RDF_graph_with_a_valid_ID_for_NO_annotation_on_the_server.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"ffc5c9a44e8192753c9b3b1bd8258f2b"
+      - W/"840e76ddd199a7442a80b356ee463b04"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 8ff2ddb5-028a-4549-ad94-b552c2770673
+      - 11c3c658-6531-4418-9355-831de1a67356
       X-Runtime:
-      - '1.390122'
+      - '1.388557'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Tue, 28 Apr 2015 23:59:31 GMT
+      - Mon, 04 May 2015 17:52:34 GMT
       Content-Length:
       - '431'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=c2FQU2FqMnlxODc0N0xpeFBTMWs3TnpaUnE0cWoxaG1jL3o5RVczUWFMUUREcjBXQWtjakpLaWU1b3g2OTc5NHU0OUZha2tvY0VVcWIwam5wMHNERDBzQ0Q4MGFmMlEvNUIyL1lDTVpzTnh4SjdUWm1yaTFDL041SGZpNnZQZU5yQlg1N3JPTGN2TDlseC9qR3JWdWNyaVRzcTJkUnpFaTRLQ3grR1JFbENGN05VdG51NFdLdy9Zbm0zVWtsTUtLcGliUGtITGIrckdUaC9LTmFVdVN2VUFtdWpkR0ptYVc3aFFCRkxLN1gzWT0tLTVxeDNna0tyWjdLQ3M2djNFaGJBYWc9PQ%3D%3D--d64c0777cbf87d40612db7d1cf956811e43c19df;
+      - _internal_session=K3A4NUtjeEhDblEyWVd6SU40dTFNWDMwZXlzeWRtVThDcy9ZTGZBa1Q5K3d1SmtiSXlua08rVkpkemp4Z0NYLzh3Qy8yNFRrbG5tUHBhSThoajFVQ21TUWJZcFI0Zm9tQUdVNG9meml3QlRiVHRjZ083WldJYzlZVnZRbGpXcy9kb29uSi9mVUpXWWpHNWtWMDUxRXlOSzJvbDd2Y3M2aXJOVjV5TiswUkgxT1paS05ROVpkYkprWFlSYlVYSFl1Zy9DWGRSTy9FUjBNaEdtbEZXR3E3enRqWVlaRS91aTI3c2c1VlhGd05uOD0tLUpNS0JVbEVkdm1ibW9pSEkvTVN4Rmc9PQ%3D%3D--606908dfae27a2018d99042bce5826ab0bc4ef29;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69850616688260","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/20ef3d0b-f83e-4ac9-878c-be8e00c22196","@type":"oa:Annotation","hasBody":"_:g69850616688260","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70075065329300","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/cd83f3e6-791e-49b6-a44a-74a598fcfdd1","@type":"oa:Annotation","hasBody":"_:g70075065329300","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:31 GMT
+  recorded_at: Mon, 04 May 2015 17:52:34 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:59:31 GMT
+      - Mon, 04 May 2015 17:52:34 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:59:31 GMT
+      - Mon, 04 May 2015 23:52:34 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:31 GMT
+  recorded_at: Mon, 04 May 2015 17:52:34 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:59:31 GMT
+      - Mon, 04 May 2015 17:52:35 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,9 +135,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:59:31 GMT
+      - Mon, 04 May 2015 23:52:35 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -1251,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:31 GMT
+  recorded_at: Mon, 04 May 2015 17:52:35 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1271,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:59:31 GMT
+      - Mon, 04 May 2015 17:52:35 GMT
       Server:
       - Apache/2
       Location:
@@ -1279,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:59:31 GMT
+      - Mon, 04 May 2015 23:52:35 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1295,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:31 GMT
+  recorded_at: Mon, 04 May 2015 17:52:35 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1317,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:59:32 GMT
+      - Mon, 04 May 2015 17:52:35 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1331,9 +1333,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:59:32 GMT
+      - Mon, 04 May 2015 23:52:35 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -2447,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:32 GMT
+  recorded_at: Mon, 04 May 2015 17:52:35 GMT
 - request:
     method: get
-    uri: http://localhost:3000/annotations/983fa9f7-151c-471e-93f5-fb3d13f8308b
+    uri: http://localhost:3000/annotations/1831e9db-a74a-4308-961c-dc4f9494cb35
     body:
       encoding: US-ASCII
       string: ''
@@ -2477,23 +2481,23 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - e1b5a80d-efcd-4421-92b9-8036b11ae89c
+      - 3e66be43-68c1-48ba-8f09-a55d6788ed4a
       X-Runtime:
-      - '0.010448'
+      - '0.011258'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Tue, 28 Apr 2015 23:59:32 GMT
+      - Mon, 04 May 2015 17:52:35 GMT
       Content-Length:
       - '1486'
       Connection:
       - Keep-Alive
     body:
       encoding: UTF-8
-      string: "<h2>error getting 983fa9f7-151c-471e-93f5-fb3d13f8308b from LDP</h2><html>\n<head>\n<meta
+      string: "<h2>error getting 1831e9db-a74a-4308-961c-dc4f9494cb35 from LDP</h2><html>\n<head>\n<meta
         http-equiv=\"Content-Type\" content=\"text/html; charset=ISO-8859-1\"/>\n<title>Error
         404 Not Found</title>\n</head>\n<body><h2>HTTP ERROR 404</h2>\n<p>Problem
-        accessing /fedora/rest/anno/983fa9f7-151c-471e-93f5-fb3d13f8308b. Reason:\n<pre>
+        accessing /fedora/rest/anno/1831e9db-a74a-4308-961c-dc4f9494cb35. Reason:\n<pre>
         \   Not Found</pre></p><hr /><i><small>Powered by Jetty://</small></i><br/>
         \                                               \n<br/>                                                \n<br/>
         \                                               \n<br/>                                                \n<br/>
@@ -2506,10 +2510,10 @@ http_interactions:
         \                                               \n<br/>                                                \n<br/>
         \                                               \n<br/>                                                \n\n</body>\n</html>\n"
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:32 GMT
+  recorded_at: Mon, 04 May 2015 17:52:35 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/20ef3d0b-f83e-4ac9-878c-be8e00c22196
+    uri: http://localhost:3000/annotations/cd83f3e6-791e-49b6-a44a-74a598fcfdd1
     body:
       encoding: US-ASCII
       string: ''
@@ -2536,22 +2540,199 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - d3df272c-4a25-46d5-8b5b-78112c35978e
+      - 30dec732-6794-4e82-99da-61526165b937
       X-Runtime:
-      - '0.138258'
+      - '0.136612'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Tue, 28 Apr 2015 23:59:32 GMT
+      - Mon, 04 May 2015 17:52:36 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=MmtReVhOTWJmdnErdEZ1QnlJMnVEajRMZi9pZkJkblJyYW0wM0VEczZUaUxjY3RtZnhzMzR6SHNlekF1ZUNZci9jOUhSSXFjRFJtRURzZ1ppek8rOWhjeFcrT0p3c09Zb0pReUJjNXNSRXBkYm5OQXRXaDczOUNteXVPaWZTSUVCcFFqUjZNL0Y1dG1VNmVhSXA0K0g5Z3c4TWZlMnAzWGVCTlEwZ1dqcXJoRkVlU2JmU2pndUJGd29JaXhCeFc0LS1WeW5LM0ZhNkxjSzg4S3J0Rzd0M1ZRPT0%3D--68b72c81fc0acb04efa88b6c0e9519b0c99ff32d;
+      - _internal_session=QmpEa3BFbVgwK1lHWFRpRGxXOE9wQnYreHd2THJIL3VyWjNyZ1Nra0IyRkxEdkZXTlJjb2VjYWZwaGdtV3dIZkx0RU1KT29TaGJyMlo2enp5d3BYSzF2Z2YzN1Jwb0x1YjFuMDYzTlpiMFcxcFhtblFEZTRpSHBHbG9DRFJ4amx3TUtVbllwY1prVC9yOXRzQzRvVHlocThtSXBXcWtBcElualBFenhGcmJjbXNWWXgrcEhVVW92UWRnSjBKUDlELS1haE1nYWtHQnl3TS9mMnBKbzR3Tk53PT0%3D--91595508a0a1697b49d911d3562577e60f64db3a;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:32 GMT
+  recorded_at: Mon, 04 May 2015 17:52:36 GMT
+- request:
+    method: get
+    uri: http://localhost:3000/annotations/50175e7e-b313-4dee-bc96-6e1074197394
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/ld+json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: 'Not Found '
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - text/html; charset=utf-8
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - c0d2879b-51aa-4513-9e4c-e7aeb65c7e4d
+      X-Runtime:
+      - '0.013820'
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
+      Date:
+      - Mon, 04 May 2015 17:54:46 GMT
+      Content-Length:
+      - '1486'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: "<h2>error getting 50175e7e-b313-4dee-bc96-6e1074197394 from LDP</h2><html>\n<head>\n<meta
+        http-equiv=\"Content-Type\" content=\"text/html; charset=ISO-8859-1\"/>\n<title>Error
+        404 Not Found</title>\n</head>\n<body><h2>HTTP ERROR 404</h2>\n<p>Problem
+        accessing /fedora/rest/anno/50175e7e-b313-4dee-bc96-6e1074197394. Reason:\n<pre>
+        \   Not Found</pre></p><hr /><i><small>Powered by Jetty://</small></i><br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n\n</body>\n</html>\n"
+    http_version: 
+  recorded_at: Mon, 04 May 2015 17:54:46 GMT
+- request:
+    method: get
+    uri: http://localhost:3000/annotations/752ba17f-c124-4971-bdfd-72a0d47c5daf
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/ld+json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: 'Not Found '
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - text/html; charset=utf-8
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - f23ad642-beba-4e52-8d2a-26ff062fa584
+      X-Runtime:
+      - '0.015942'
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
+      Date:
+      - Mon, 04 May 2015 17:55:35 GMT
+      Content-Length:
+      - '1486'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: "<h2>error getting 752ba17f-c124-4971-bdfd-72a0d47c5daf from LDP</h2><html>\n<head>\n<meta
+        http-equiv=\"Content-Type\" content=\"text/html; charset=ISO-8859-1\"/>\n<title>Error
+        404 Not Found</title>\n</head>\n<body><h2>HTTP ERROR 404</h2>\n<p>Problem
+        accessing /fedora/rest/anno/752ba17f-c124-4971-bdfd-72a0d47c5daf. Reason:\n<pre>
+        \   Not Found</pre></p><hr /><i><small>Powered by Jetty://</small></i><br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n\n</body>\n</html>\n"
+    http_version: 
+  recorded_at: Mon, 04 May 2015 17:55:35 GMT
+- request:
+    method: get
+    uri: http://localhost:3000/annotations/d318c1a0-7f6a-45ad-97c0-ddf717340513
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/ld+json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: 'Not Found '
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - text/html; charset=utf-8
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 181dfcd7-b0ae-4823-8fd3-1d4062cb45cb
+      X-Runtime:
+      - '0.012217'
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
+      Date:
+      - Mon, 04 May 2015 17:57:23 GMT
+      Content-Length:
+      - '1486'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: "<h2>error getting d318c1a0-7f6a-45ad-97c0-ddf717340513 from LDP</h2><html>\n<head>\n<meta
+        http-equiv=\"Content-Type\" content=\"text/html; charset=ISO-8859-1\"/>\n<title>Error
+        404 Not Found</title>\n</head>\n<body><h2>HTTP ERROR 404</h2>\n<p>Problem
+        accessing /fedora/rest/anno/d318c1a0-7f6a-45ad-97c0-ddf717340513. Reason:\n<pre>
+        \   Not Found</pre></p><hr /><i><small>Powered by Jetty://</small></i><br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n\n</body>\n</html>\n"
+    http_version: 
+  recorded_at: Mon, 04 May 2015 17:57:23 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_no_content_type/returns_an_RDF_graph_with_a_valid_ID_for_an_annotation_on_the_server.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_no_content_type/returns_an_RDF_graph_with_a_valid_ID_for_an_annotation_on_the_server.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"bf91f579bc23125f00e700feef8f9e70"
+      - W/"96484d4f6fbdfc8c710f2a1123c6ac7f"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - d6bb394d-12eb-43a3-8567-ae089b24b980
+      - 1b107483-d135-4bc1-85ff-4e6fea418187
       X-Runtime:
-      - '1.408661'
+      - '1.392281'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Tue, 28 Apr 2015 23:59:26 GMT
+      - Mon, 04 May 2015 17:52:30 GMT
       Content-Length:
       - '431'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=U0xkR3VFaFpmRWpFcmpFM0RpSWNsZTlFQUdoTU1pSVFuaTYvcGpTZUl1Ty9pSlNHRDYvZFhJK2l2c25xWjhaUTJrOFg2bWJ1RW8vL21vckpHRWtSeU93bkc0TndpQnNPOG1NNkx2M2ppcUxpOVpUdzJTVzl2OHUzNkNsQ2lYN1VZMFFwV0xzTUVuZlpyanROY0lsVDNMaDJqN0N1Wk1kWkxDNGNXZjJhbzV1cEFMRlZaeE9zMU0wMEVmQTV2a1FZK1psMWdoZG1aN0RoRU9RRG01RXJEWVFObDZNaGJ1c2ZVeitnL3pwYlBmYz0tLTd6NHZDNHVaakVLQzlKamFYZmF5V0E9PQ%3D%3D--8693fb82a21f1c433150d8d4f75da5b9e65d7337;
+      - _internal_session=VnN2Z2ZIZ0NxLzJjb0JHS1h6MEFFZk9DTmtONHNaMk8rbkQxL1p5YjJ5aGRad3FBci9TMUdETmNPbDM1THE4MjVzSmUxZ284YTcwUUtOaG03K2FGdkw3aldUNXAyb2tWK1h6N3hKRUdQcXhjVDVCUlg5RWJGVnd5cTl1N3Qrc1FBOWc5TmZQckg3MlZjSDZMUHpkdXNWZitLbkxwbEpDZkkwRHFSdk1UcE83NUhzSUlmckdjR2tKaWVJbE5SblA0TjhhWGtmSnRFNjEzOWJ4OTB4MUFqQy9zRWs1aHhEWVh1bnJ5bU9kVDNMcz0tLUpYOHE5U2VEVlVxWHM1SkhXS2lZU1E9PQ%3D%3D--02d6661057dea7b08c1c329db767a3cf7fdf0a0f;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69850563567260","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/6914022b-7ecc-4567-950e-e741c6d167bb","@type":"oa:Annotation","hasBody":"_:g69850563567260","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70075064382240","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/4f151042-9863-4356-81ad-1b405d7a11d7","@type":"oa:Annotation","hasBody":"_:g70075064382240","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:26 GMT
+  recorded_at: Mon, 04 May 2015 17:52:30 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:59:26 GMT
+      - Mon, 04 May 2015 17:52:30 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:59:26 GMT
+      - Mon, 04 May 2015 23:52:30 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:26 GMT
+  recorded_at: Mon, 04 May 2015 17:52:30 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:59:26 GMT
+      - Mon, 04 May 2015 17:52:30 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,9 +135,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:59:26 GMT
+      - Mon, 04 May 2015 23:52:30 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -1251,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:27 GMT
+  recorded_at: Mon, 04 May 2015 17:52:30 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1271,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:59:27 GMT
+      - Mon, 04 May 2015 17:52:30 GMT
       Server:
       - Apache/2
       Location:
@@ -1279,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:59:27 GMT
+      - Mon, 04 May 2015 23:52:30 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1295,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:27 GMT
+  recorded_at: Mon, 04 May 2015 17:52:30 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1317,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:59:27 GMT
+      - Mon, 04 May 2015 17:52:31 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1331,9 +1333,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:59:27 GMT
+      - Mon, 04 May 2015 23:52:31 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -2447,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:27 GMT
+  recorded_at: Mon, 04 May 2015 17:52:31 GMT
 - request:
     method: get
-    uri: http://localhost:3000/annotations/6914022b-7ecc-4567-950e-e741c6d167bb
+    uri: http://localhost:3000/annotations/4f151042-9863-4356-81ad-1b405d7a11d7
     body:
       encoding: US-ASCII
       string: ''
@@ -2475,27 +2479,27 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"f2b56d01f90491b6c094cf09b7322d0c"
+      - W/"9cc3e47e1609b372fc9669b7ff17d3c2"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - e96c787d-4822-40e9-95e3-37d47dd303c9
+      - 747d51e5-b215-440c-999f-3b31ac9b942f
       X-Runtime:
-      - '0.690062'
+      - '0.672765'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Tue, 28 Apr 2015 23:59:28 GMT
+      - Mon, 04 May 2015 17:52:32 GMT
       Content-Length:
       - '431'
       Connection:
       - Keep-Alive
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69850774876480","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/6914022b-7ecc-4567-950e-e741c6d167bb","@type":"oa:Annotation","hasBody":"_:g69850774876480","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70075208581600","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/4f151042-9863-4356-81ad-1b405d7a11d7","@type":"oa:Annotation","hasBody":"_:g70075208581600","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:28 GMT
+  recorded_at: Mon, 04 May 2015 17:52:32 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -2515,7 +2519,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:59:28 GMT
+      - Mon, 04 May 2015 17:52:32 GMT
       Server:
       - Apache/2
       Location:
@@ -2523,7 +2527,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:59:28 GMT
+      - Mon, 04 May 2015 23:52:32 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -2539,7 +2543,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:28 GMT
+  recorded_at: Mon, 04 May 2015 17:52:32 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -2561,7 +2565,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:59:28 GMT
+      - Mon, 04 May 2015 17:52:32 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -2575,9 +2579,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:59:28 GMT
+      - Mon, 04 May 2015 23:52:32 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -3691,7 +3697,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:29 GMT
+  recorded_at: Mon, 04 May 2015 17:52:32 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -3711,7 +3717,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:59:29 GMT
+      - Mon, 04 May 2015 17:52:32 GMT
       Server:
       - Apache/2
       Location:
@@ -3719,7 +3725,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:59:29 GMT
+      - Mon, 04 May 2015 23:52:32 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -3735,7 +3741,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:29 GMT
+  recorded_at: Mon, 04 May 2015 17:52:32 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -3757,7 +3763,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:59:29 GMT
+      - Mon, 04 May 2015 17:52:32 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -3771,9 +3777,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:59:29 GMT
+      - Mon, 04 May 2015 23:52:32 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -4887,10 +4895,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:29 GMT
+  recorded_at: Mon, 04 May 2015 17:52:33 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/6914022b-7ecc-4567-950e-e741c6d167bb
+    uri: http://localhost:3000/annotations/4f151042-9863-4356-81ad-1b405d7a11d7
     body:
       encoding: US-ASCII
       string: ''
@@ -4917,22 +4925,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - b87fb1e6-d97e-4426-99f3-4e7302825390
+      - 9fa4914c-1940-4581-9747-e8f3eddf8f34
       X-Runtime:
-      - '0.191978'
+      - '0.157603'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Tue, 28 Apr 2015 23:59:29 GMT
+      - Mon, 04 May 2015 17:52:33 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=K0dKR1dUYzBYY01obWtDZmZZcHdWYk5SQnNmYTNCUHVKVVZWSU5TMEQ0ZFl5c1NCM3lkdXB3VmJGYS8rRytaWXRnbTBUM2I1TUcrdFdYZlVrYTFKYWUramYyRTJSOFdTTW1yQjhDYTdhU1RrRjVNMTMvb09SVDNVNWl5TDFCTjRrY01nMyszS3FkYUlRRFlmaEtNSWxLdHcvVjlQOGUvRmVocXQ3aEloM3dnS2lXUzloSWJreHRiTjFMWE5WKzlhLS05b3hWQzdScXAvR2FxaCtqOSt0Z1dBPT0%3D--65ba27b0d6cdf9bdf422edaac95eb677b6f5d0f5;
+      - _internal_session=a1lRL3pGdEJjd1JjeThyWm9seFh0SHMydDUxNmprNGYrejRlTUcrMWhxa04wL2g5WWlhT1JlQ3ltR0VxTFpOcHN5RkJJQUlSOFVZTHRUdCsxdHY2eW82UXFCU2N5VC80TzNFRUc5N0RqUDY5UW5YZXh5MzJ4T1NxWFcwaHVJdk9KUy83aGU1bHk3NHFlUUtLWC9sY2JVYU5VYmxaR2M5eUtpaGdHNGdLSGwwcldLUlAzbUE3aFZRek1zZlFvTDFILS1iZVFnT244SlhEOXJIWHZoVldoU2xRPT0%3D--489c13f724063cfef6acdf088d945678e53e3e74;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:29 GMT
+  recorded_at: Mon, 04 May 2015 17:52:33 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_iiif_annotation/requests_an_open_annotation_by_ID_using_a_IIIF_profile.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_iiif_annotation/requests_an_open_annotation_by_ID_using_a_IIIF_profile.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"c57d418fb7f5ad1ffd8b595c6420e643"
+      - W/"4ab0858ac4f9c8e523cdbc85b0b797c1"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 7684f701-71e5-4b41-9d8b-f76f008d7845
+      - a04d1acb-7f86-4b7a-b516-c17929ee5e9b
       X-Runtime:
-      - '6.384194'
+      - '1.369335'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Tue, 28 Apr 2015 23:59:49 GMT
+      - Mon, 04 May 2015 17:52:42 GMT
       Content-Length:
       - '431'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=UGI4NDVSNHpzM0lHNE1KbWJ1YTJIYmtzTnVkQ29xRE8yc1FDQkZIRWtzNEJ2b0F1dXVUcHJBcTBPM1dEVnNNVXZuZjVyUEcrYjlsU0dmbU5oR2dPVUVWbW42RjhUdmt5OUw2YVRZVWZDVWRqVUgva1BwWHV3TTVDQ0c0UVd0Y3BUNmdLb0lRM3owOXAvUktlRWtWUkV2NjkrTVR0WU53TTArUnhQTThORE9ZbWhVOVZVOHhUZWNWdUJjQjRWQnBVNmQ5SlVSNjl3U0NITFJrM2JQQlRmV0x3VU1iRmxtblNtNHhkcTBCVXRKOD0tLVdvajdQaHdEREJIYTV5THN1TDhISEE9PQ%3D%3D--360831990363141cf5ab6f37b1ce080434635c61;
+      - _internal_session=Z20rZjI3NHJETDZXYWtXdUhaTXBtWm1KdVdaVlF3S2VsQnBNa1NXcjgrdGFKNlpFeGRIWFVPd3dHa1Q5c28wbHVzQXZSSkRBaWJQVDUzNytTaGxxNEk0bUMxNmF2Z2NXTlFhbS9ldm1BdWtlUHhhSUcvZWV2aER4azVHNjdSOFZhUjA4ZDFod2p1UXlHeTJUb21xUmtnV2RNa0FhU2wrdGlIU1ZSMGxkQ2xBdjZ4Zmk4OGc2VGYweWVwMnB3eU1aRFdGM3NoSnNFZTZYOTZTaHU5N3RIUFdqdEJQNG9yWEw4ZFhkb1M4RDU0az0tLUpCdHR1aGNUZmVzV3k4QjNjR0tWWHc9PQ%3D%3D--c446a704d1af4917f26bc8d7a0a478c9e9c76cf7;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69850776604920","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/4611636c-29a1-474c-989a-47bccfb4b536","@type":"oa:Annotation","hasBody":"_:g69850776604920","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70075211666520","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/79bddc49-08fa-4317-ae36-3691f4d9a744","@type":"oa:Annotation","hasBody":"_:g70075211666520","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:49 GMT
+  recorded_at: Mon, 04 May 2015 17:52:42 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:59:54 GMT
+      - Mon, 04 May 2015 17:52:42 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:59:54 GMT
+      - Mon, 04 May 2015 23:52:42 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:54 GMT
+  recorded_at: Mon, 04 May 2015 17:52:43 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:59:54 GMT
+      - Mon, 04 May 2015 17:52:43 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,9 +135,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:59:54 GMT
+      - Mon, 04 May 2015 23:52:43 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -1251,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:55 GMT
+  recorded_at: Mon, 04 May 2015 17:52:43 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1271,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:59:55 GMT
+      - Mon, 04 May 2015 17:52:43 GMT
       Server:
       - Apache/2
       Location:
@@ -1279,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:59:55 GMT
+      - Mon, 04 May 2015 23:52:43 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1295,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:55 GMT
+  recorded_at: Mon, 04 May 2015 17:52:43 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1317,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:59:55 GMT
+      - Mon, 04 May 2015 17:52:43 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1331,9 +1333,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:59:55 GMT
+      - Mon, 04 May 2015 23:52:43 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -2447,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:55 GMT
+  recorded_at: Mon, 04 May 2015 17:52:43 GMT
 - request:
     method: get
-    uri: http://localhost:3000/annotations/4611636c-29a1-474c-989a-47bccfb4b536
+    uri: http://localhost:3000/annotations/79bddc49-08fa-4317-ae36-3691f4d9a744
     body:
       encoding: US-ASCII
       string: ''
@@ -2475,27 +2479,27 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"39cb121cfc3c21b58ca85f7c8ed43293"
+      - W/"cc0706ce13f32c7049064e71edc989b0"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 206b0543-3f43-4953-98c3-8ea4b93e47b7
+      - 7597189d-2c14-4c3d-9218-1732fb2bb19c
       X-Runtime:
-      - '0.127070'
+      - '0.134069'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Tue, 28 Apr 2015 23:59:55 GMT
+      - Mon, 04 May 2015 17:52:44 GMT
       Content-Length:
       - '425'
       Connection:
       - Keep-Alive
     body:
       encoding: UTF-8
-      string: '{"@context":"http://iiif.io/api/presentation/2/context.json","@graph":[{"@id":"_:g69850627002680","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/4611636c-29a1-474c-989a-47bccfb4b536","@type":"oa:Annotation","motivation":"oa:commenting","on":"http://purl.stanford.edu/kq131cs7229","resource":"_:g69850627002680"}]}'
+      string: '{"@context":"http://iiif.io/api/presentation/2/context.json","@graph":[{"@id":"_:g70075059768160","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/79bddc49-08fa-4317-ae36-3691f4d9a744","@type":"oa:Annotation","motivation":"oa:commenting","on":"http://purl.stanford.edu/kq131cs7229","resource":"_:g70075059768160"}]}'
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:55 GMT
+  recorded_at: Mon, 04 May 2015 17:52:44 GMT
 - request:
     method: get
     uri: http://iiif.io/api/presentation/2/context.json
@@ -2515,7 +2519,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:02:14 GMT
+      - Mon, 04 May 2015 17:55:11 GMT
       Server:
       - Apache/2.2.15 (Red Hat)
       Last-Modified:
@@ -2527,7 +2531,7 @@ http_interactions:
       Cache-Control:
       - max-age=86400
       Expires:
-      - Thu, 30 Apr 2015 00:02:14 GMT
+      - Tue, 05 May 2015 17:55:11 GMT
       Content-Type:
       - application/ld+json
       Access-Control-Allow-Origin:
@@ -2593,7 +2597,7 @@ http_interactions:
         \   \"language\":    {\"@id\": \"dc:language\"},\n\t\t    \"value\":       {\"@id\":
         \"rdf:value\"},\n\t\t    \"label\":       {\"@id\": \"rdfs:label\"}\n\t\t}\n\t]\n}"
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:55 GMT
+  recorded_at: Mon, 04 May 2015 17:52:44 GMT
 - request:
     method: get
     uri: http://iiif.io/api/presentation/2/context.json
@@ -2613,7 +2617,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:02:14 GMT
+      - Mon, 04 May 2015 17:55:11 GMT
       Server:
       - Apache/2.2.15 (Red Hat)
       Last-Modified:
@@ -2625,7 +2629,7 @@ http_interactions:
       Cache-Control:
       - max-age=86400
       Expires:
-      - Thu, 30 Apr 2015 00:02:14 GMT
+      - Tue, 05 May 2015 17:55:11 GMT
       Content-Type:
       - application/ld+json
       Access-Control-Allow-Origin:
@@ -2691,10 +2695,10 @@ http_interactions:
         \   \"language\":    {\"@id\": \"dc:language\"},\n\t\t    \"value\":       {\"@id\":
         \"rdf:value\"},\n\t\t    \"label\":       {\"@id\": \"rdfs:label\"}\n\t\t}\n\t]\n}"
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:56 GMT
+  recorded_at: Mon, 04 May 2015 17:52:44 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/4611636c-29a1-474c-989a-47bccfb4b536
+    uri: http://localhost:3000/annotations/79bddc49-08fa-4317-ae36-3691f4d9a744
     body:
       encoding: US-ASCII
       string: ''
@@ -2721,22 +2725,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 6a322130-3da1-4d47-a724-0f90572f2a65
+      - 9a3927a8-2301-4743-a038-6081a99460b2
       X-Runtime:
-      - '0.132072'
+      - '0.135164'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Tue, 28 Apr 2015 23:59:56 GMT
+      - Mon, 04 May 2015 17:52:44 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=bkU1a3MvKy9tK2tyNWdQWTZ1OXNyd2VERmVLdGE1Y0ZWUTJvWUpEaW9FQ0NuU1U1eVFKd0dZazNZWEVLd3gwRnF1UTJidFFWRjI3MGs3Q3orSUNTYWtEUUNIaGt3TW1DK1BTL1RlQkdZbXJnTnoways5ek8waHJGQXdKVGV4V0lSYmhSUzlvZGkyWVBFcGMvbjdqaWNPYSs4SXhqRkptSm5oUnlnQlNzc3hvang4cjFBNElQN3RnS3dkZldtb1dQLS0wajRNVWZ4cWJYS3JxRnVpaldKZzVBPT0%3D--c8ae6857d746aaae6457c4136811b17ca165308f;
+      - _internal_session=TGFwbndmUWZEdkNkUjduWmttREpjV2lyZTNXdlVoR04xK29ob1NGNkQ2QUpqbGI0NWhlQmUzSTU4RCtUcnUzQ1ZiYnpPakRVb2ZXcVJNbHZIZjlJQm1xTHVBZFQ5dUZiR3BsRWlVS2dldStCWUlsYXhjMCswVTFUV0k3K3h3Z3BRaENHaW45QXg5bkpDSW95Y0ZJS0Y5Y05IVVIzKytIQ2lwMzNoa1hVTnAyYTF2RE9sT25VQUFyU21qVThKbjFnLS10VThGdkE1NVM4SlRBZHNrYVZMM2FRPT0%3D--be523bf66757506e91f23acc95bb836d8c2ad4d7;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:56 GMT
+  recorded_at: Mon, 04 May 2015 17:52:44 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_oa_annotation/requests_an_open_annotation_by_ID_using_an_OA_profile.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_oa_annotation/requests_an_open_annotation_by_ID_using_an_OA_profile.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"2d543b27f945ac3824dc998011fc92de"
+      - W/"ac2842e4c3614f617a5b2db401ad9a9d"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 46155465-d87d-434c-a24c-e1ba0fcd9f6d
+      - b4b2caa8-b3ef-493a-9077-48a1b5a4353d
       X-Runtime:
-      - '1.376042'
+      - '1.378145'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Tue, 28 Apr 2015 23:59:57 GMT
+      - Mon, 04 May 2015 17:52:45 GMT
       Content-Length:
       - '431'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=NzN3ZDlXclF4NllVWUJXalFuMW1iRDRQMk5pRFdCMzhqZGx6U1R4YlNJK1h3ZkRhUUNrNm4yUWVZMHdNZmpvdjlXWitKQzdWK25PZVFqME03M2YyT2psaWVYQVJRa2p0YlpoT0lZNHYrUHRka292MkhORWo0TitScENjdG0yVitud3JlVWVmZ0szamFCS0dERUpVcWlMNXhkSndlRzZHbVdXay8vdUlIbVRrdGM4V3g4U3d5WW9EckRXMlVwYWlpbmxKZzc0Q3MvWXpxcU1Xa3hOREY5b3B6L3JDbU5MY1BWcHRlTGc5anphVT0tLS9DbHpNVTFCMU1DSUpyL0lJeHBmNUE9PQ%3D%3D--cdba2f45c1bf03b7b15b48b7a5b73ec3b805e3d3;
+      - _internal_session=RUp1cDVmTEpuRTJFdnBMeE1sK1c5TXJFSEh5NHdxSzVFdFIxeW5zRDdVRkMyRjN6S0JuZlJzdHNWUHVtVW9aRGJWSE8rRlZlQVNXVTZqY1hPd3N5WnZoa1MzRFltTE8xTFdNeXc0SFpkNHVZekFUTnBqWkRGNXM4eFppeVp6aVZXYmlpTjh5VjlrT2E5WWRLWTliTVFzcmd6RW1DL3ZRU2FZWGFXYU11WFhqMEJhZzhzbXEvQ3F4Z3dHK2JISktSNEFJUFpVL2p5eHMvTCtOeFBQYjAyUk9GZ3UrclBicW1hcGtSOEJ6ekZRTT0tLUFxZysyN25reUVUNmxONU9lSTBWOFE9PQ%3D%3D--4e2a37cf833e4fd02e4e520f1cbe1a0b59d270b5;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69850625153620","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/78426d26-2fac-47c8-b8dc-b3a929d3cce6","@type":"oa:Annotation","hasBody":"_:g69850625153620","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70075072387040","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/4bf087ee-e887-4b67-b558-82e7707418fb","@type":"oa:Annotation","hasBody":"_:g70075072387040","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:57 GMT
+  recorded_at: Mon, 04 May 2015 17:52:45 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:59:57 GMT
+      - Mon, 04 May 2015 17:52:45 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:59:57 GMT
+      - Mon, 04 May 2015 23:52:45 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:57 GMT
+  recorded_at: Mon, 04 May 2015 17:52:45 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:59:57 GMT
+      - Mon, 04 May 2015 17:52:46 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,9 +135,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:59:57 GMT
+      - Mon, 04 May 2015 23:52:46 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -1251,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:59:58 GMT
+  recorded_at: Mon, 04 May 2015 17:52:46 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1271,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:00:03 GMT
+      - Mon, 04 May 2015 17:52:46 GMT
       Server:
       - Apache/2
       Location:
@@ -1279,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:00:03 GMT
+      - Mon, 04 May 2015 23:52:46 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1295,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:00:03 GMT
+  recorded_at: Mon, 04 May 2015 17:52:46 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1317,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:00:03 GMT
+      - Mon, 04 May 2015 17:52:46 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1331,9 +1333,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:00:03 GMT
+      - Mon, 04 May 2015 23:52:46 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -2447,16 +2451,16 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:00:03 GMT
+  recorded_at: Mon, 04 May 2015 17:52:46 GMT
 - request:
     method: get
-    uri: http://localhost:3000/annotations/78426d26-2fac-47c8-b8dc-b3a929d3cce6
+    uri: http://localhost:3000/annotations/4bf087ee-e887-4b67-b558-82e7707418fb
     body:
       encoding: US-ASCII
       string: ''
     headers:
       Accept:
-      - application/ld+json; profile="http://iiif.io/api/presentation/2/context.json"
+      - application/ld+json; profile="http://www.w3.org/ns/oa-context-20130208.json"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
@@ -2475,30 +2479,30 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"b847306ffdca5abb7f08191dab594c2d"
+      - W/"e29fd3a194636c594b74a3f560d7f99d"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 264f23b7-9b07-4e36-87d7-f5370cd0d9e6
+      - 424d42c9-1e59-49d5-a545-965c6112bc6e
       X-Runtime:
-      - '0.111984'
+      - '0.681687'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Wed, 29 Apr 2015 00:00:03 GMT
+      - Mon, 04 May 2015 17:52:47 GMT
       Content-Length:
-      - '425'
+      - '431'
       Connection:
       - Keep-Alive
     body:
       encoding: UTF-8
-      string: '{"@context":"http://iiif.io/api/presentation/2/context.json","@graph":[{"@id":"_:g69850778594300","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/78426d26-2fac-47c8-b8dc-b3a929d3cce6","@type":"oa:Annotation","motivation":"oa:commenting","on":"http://purl.stanford.edu/kq131cs7229","resource":"_:g69850778594300"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70075064695300","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/4bf087ee-e887-4b67-b558-82e7707418fb","@type":"oa:Annotation","hasBody":"_:g70075064695300","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:00:03 GMT
+  recorded_at: Mon, 04 May 2015 17:52:47 GMT
 - request:
     method: get
-    uri: http://iiif.io/api/presentation/2/context.json
+    uri: http://www.w3.org/ns/oa-context-20130208.json
     body:
       encoding: US-ASCII
       string: ''
@@ -2511,92 +2515,1192 @@ http_interactions:
       - Ruby
   response:
     status:
+      code: 307
+      message: Temporary Redirect
+    headers:
+      Date:
+      - Mon, 04 May 2015 17:52:47 GMT
+      Server:
+      - Apache/2
+      Location:
+      - http://www.w3.org/ns/oa.jsonld
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Mon, 04 May 2015 23:52:47 GMT
+      Content-Length:
+      - '240'
+      Content-Type:
+      - text/html; charset=iso-8859-1
+    body:
+      encoding: UTF-8
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+        <html><head>
+        <title>307 Temporary Redirect</title>
+        </head><body>
+        <h1>Temporary Redirect</h1>
+        <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
+        </body></html>
+    http_version: 
+  recorded_at: Mon, 04 May 2015 17:52:47 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa.jsonld
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/ld+json, application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cookie:
+      - ''
+      User-Agent:
+      - Ruby
+  response:
+    status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:02:22 GMT
+      - Mon, 04 May 2015 17:52:47 GMT
       Server:
-      - Apache/2.2.15 (Red Hat)
+      - Apache/2
       Last-Modified:
-      - Tue, 28 Apr 2015 19:46:55 GMT
+      - Tue, 06 May 2014 11:14:49 GMT
+      Etag:
+      - '"b533-4f8b95b2a9c40"'
       Accept-Ranges:
       - bytes
       Content-Length:
-      - '4235'
+      - '46387'
       Cache-Control:
-      - max-age=86400
+      - max-age=21600
       Expires:
-      - Thu, 30 Apr 2015 00:02:22 GMT
-      Content-Type:
-      - application/ld+json
+      - Mon, 04 May 2015 23:52:47 GMT
+      P3p:
+      - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
       - "*"
+      Content-Type:
+      - application/ld+json
     body:
       encoding: UTF-8
-      string: "{\n\t\"@context\": [\n\t\t{\n\t\t\t\"sc\":      \"http://iiif.io/api/presentation/2#\",\n\t
-        \       \"iiif\":    \"http://iiif.io/api/image/2#\",\n\t        \"exif\":
-        \   \"http://www.w3.org/2003/12/exif/ns#\",\n\t        \"oa\":      \"http://www.w3.org/ns/oa#\",\n\t
-        \       \"cnt\":     \"http://www.w3.org/2011/content#\",\n\t        \"dc\":
-        \     \"http://purl.org/dc/elements/1.1/\",\n\t        \"dcterms\": \"http://purl.org/dc/terms/\",\n\t
-        \       \"dctypes\": \"http://purl.org/dc/dcmitype/\",\n\t        \"foaf\":
-        \   \"http://xmlns.com/foaf/0.1/\",\n\t        \"rdf\":     \"http://www.w3.org/1999/02/22-rdf-syntax-ns#\",\n\t
-        \       \"rdfs\":    \"http://www.w3.org/2000/01/rdf-schema#\",\n\t        \"xsd\":
-        \    \"http://www.w3.org/2001/XMLSchema#\",\n\t\t\t\"svcs\":    \"http://rdfs.org/sioc/services#\",\n\n\t
-        \       \"license\":     {\"@type\":\"@id\", \"@id\":\"dcterms:license\"},\n\t
-        \       \"service\":     {\"@type\":\"@id\", \"@id\":\"svcs:has_service\"},\n\t
-        \       \"seeAlso\":    {\"@type\":\"@id\", \"@id\":\"foaf:page\"},\n\t        \"within\":
-        \     {\"@type\":\"@id\", \"@id\":\"dcterms:isPartOf\"},\n\t        \"profile\":
-        \    {\"@type\":\"@id\", \"@id\":\"dcterms:conformsTo\"},\n\t        \"related\":
-        \    {\"@type\":\"@id\", \"@id\":\"dcterms:relation\"},\n\t        \"logo\":
-        \       {\"@type\":\"@id\", \"@id\":\"foaf:logo\"},\n\t        \"thumbnail\":
-        \  {\"@type\":\"@id\", \"@id\":\"foaf:thumbnail\"},\n\t        \"startCanvas\":
-        {\"@type\":\"@id\", \"@id\":\"sc:hasStartCanvas\"},\n\n\t        \"collections\":
-        {\"@type\":\"@id\", \"@id\":\"sc:hasCollections\", \"@container\":\"@list\"},\n\t
-        \       \"manifests\":   {\"@type\":\"@id\", \"@id\":\"sc:hasManifests\",
-        \"@container\":\"@list\"},\n\t        \"sequences\":   {\"@type\":\"@id\",
-        \"@id\":\"sc:hasSequences\", \"@container\":\"@list\"},\n\t        \"canvases\":
-        \   {\"@type\":\"@id\", \"@id\":\"sc:hasCanvases\", \"@container\":\"@list\"},\n\t
-        \       \"resources\":   {\"@type\":\"@id\", \"@id\":\"sc:hasAnnotations\",
-        \"@container\":\"@list\"},\n\t        \"images\":      {\"@type\":\"@id\",
-        \"@id\":\"sc:hasImageAnnotations\",\"@container\":\"@list\"},\n\t        \"otherContent\":
-        {\"@type\":\"@id\", \"@id\":\"sc:hasLists\", \"@container\":\"@list\"},\n\t
-        \       \"structures\":  {\"@type\":\"@id\", \"@id\":\"sc:hasRanges\", \"@container\":\"@list\"},\n\t
-        \       \"ranges\" :     {\"@type\": \"@id\", \"@id\": \"sc:hasRanges\", \"@container\":\"@list\"},\n\n\t
-        \       \"metadata\":    {\"@type\":\"@id\", \"@id\":\"sc:metadataLabels\",
-        \"@container\":\"@list\"},\n\n\t        \"description\": {\"@id\": \"dc:description\"},\n\t
-        \       \"height\":      {\"@type\":\"xsd:integer\", \"@id\":\"exif:height\"},\n\t
-        \       \"width\":       {\"@type\":\"xsd:integer\", \"@id\":\"exif:width\"},\n\n\t
-        \       \"attribution\": {\"@id\": \"sc:attributionLabel\"},\n\t        \"viewingDirection\":
-        {\"@id\": \"sc:viewingDirection\", \"@type\":\"@id\"},\n\t        \"viewingHint\":
-        {\"@id\": \"sc:viewingHint\", \"@type\":\"@id\"},\n\n\t        \"left-to-right\":
-        {\"@id\":\"sc:leftToRightDirection\", \"@type\":\"sc:ViewingDirection\"},\n\t
-        \       \"right-to-left\": {\"@id\":\"sc:rightToLeftDirection\", \"@type\":\"sc:ViewingDirection\"},\n\t
-        \       \"top-to-bottom\": {\"@id\":\"sc:topToBottomDirection\", \"@type\":\"sc:ViewingDirection\"},\t
-        \       \n\t        \"bottom-to-top\": {\"@id\":\"sc:bottomToTopDirection\",
-        \"@type\":\"sc:ViewingDirection\"},\n\n\t        \"paged\":         {\"@id\":\"sc:pagedHint\",
-        \"@type\":\"sc:ViewingHint\"},\n\t        \"non-paged\":     {\"@id\":\"sc:nonPagedHint\",
-        \"@type\":\"sc:ViewingHint\"},   \n\t        \"continuous\":    {\"@id\":\"sc:continuousHint\",
-        \"@type\":\"sc:ViewingHint\"},\n\t        \"individuals\":   {\"@id\":\"sc:individualsHint\",
-        \"@type\":\"sc:ViewingHint\"}, \n\t        \"top\":           {\"@id\":\"sc:topHint\",
-        \"@type\":\"sc:ViewingHint\"},\n\n\t        \"motivation\":  {\"@type\":\"@id\",
-        \"@id\":\"oa:motivatedBy\"},\n\t        \"resource\":    {\"@type\":\"@id\",
-        \"@id\":\"oa:hasBody\"},\n\t        \"on\":          {\"@type\":\"@id\", \"@id\":\"oa:hasTarget\"},\n\t
-        \       \"full\":        {\"@type\":\"@id\", \"@id\":\"oa:hasSource\"},\n\t
-        \       \"selector\":    {\"@type\":\"@id\", \"@id\":\"oa:hasSelector\"},\n\t
-        \       \"stylesheet\":  {\"@type\":\"@id\", \"@id\":\"oa:styledBy\"},\n\t
-        \       \"style\":       {\"@id\":\"oa:styleClass\"},\n\n\t\t    \"default\":
-        \    {\"@type\":\"@id\", \"@id\" : \"oa:default\"},\n\t\t    \"item\":        {\"@type\":\"@id\",
-        \"@id\" : \"oa:item\"},\n\t\t    \"chars\":       {\"@id\": \"cnt:chars\"},\n\t\t
-        \   \"encoding\":    {\"@id\": \"cnt:characterEncoding\"},\n\t\t    \"bytes\":
-        \      {\"@id\": \"cnt:bytes\"},\n\t\t    \"format\":      {\"@id\": \"dc:format\"},\n\t\t
-        \   \"language\":    {\"@id\": \"dc:language\"},\n\t\t    \"value\":       {\"@id\":
-        \"rdf:value\"},\n\t\t    \"label\":       {\"@id\": \"rdfs:label\"}\n\t\t}\n\t]\n}"
+      string: |+
+        {
+          "@context": {
+            "oa": "http://www.w3.org/ns/oa#",
+            "cnt": "http://www.w3.org/2011/content#",
+            "dc": "http://purl.org/dc/elements/1.1/",
+            "dcterms": "http://purl.org/dc/terms/",
+            "dctypes": "http://purl.org/dc/dcmitype/",
+            "foaf": "http://xmlns.com/foaf/0.1/",
+            "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+            "skos": "http://www.w3.org/2004/02/skos/core#",
+            "owl": "http://www.w3.org/2002/07/owl#",
+            "prov": "http://www.w3.org/ns/prov#",
+            "trig": "http://www.w3.org/2004/03/trix/rdfg-1/",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+
+            "hasBody" :         {"@type":"@id", "@id" : "oa:hasBody"},
+            "hasTarget" :       {"@type":"@id", "@id" : "oa:hasTarget"},
+            "hasSource" :       {"@type":"@id", "@id" : "oa:hasSource"},
+            "hasSelector" :     {"@type":"@id", "@id" : "oa:hasSelector"},
+            "hasState" :        {"@type":"@id", "@id" : "oa:hasState"},
+            "hasScope" :        {"@type":"@id", "@id" : "oa:hasScope"},
+            "annotatedBy" :  {"@type":"@id", "@id" : "oa:annotatedBy"},
+            "serializedBy" : {"@type":"@id", "@id" : "oa:serializedBy"},
+            "motivatedBy" :  {"@type":"@id", "@id" : "oa:motivatedBy"},
+            "equivalentTo" : {"@type":"@id", "@id" : "oa:equivalentTo"},
+            "styledBy" :     {"@type":"@id", "@id" : "oa:styledBy"},
+            "cachedSource" : {"@type":"@id", "@id" : "oa:cachedSource"},
+            "conformsTo" :   {"@type":"@id", "@id" : "dcterms:conformsTo"},
+            "default" :      {"@type":"@id", "@id" : "oa:default"},
+            "item" :         {"@type":"@id", "@id" : "oa:item"},
+            "first":         {"@type":"@id", "@id" : "rdf:first"},
+            "rest":          {"@type":"@id", "@id" : "rdf:rest", "@container" : "@list"},
+
+            "annotatedAt" :  { "@type": "xsd:dateTimeStamp", "@id": "oa:annotatedAt" },
+            "end" :          { "@type": "xsd:nonNegativeInteger", "@id": "oa:end" },
+            "exact" :        "oa:exact",
+            "prefix" :       "oa:prefix",
+            "serializedAt" : { "@type": "xsd:dateTimeStamp", "@id": "oa:serializedAt" },
+            "start" :        { "@type": "xsd:nonNegativeInteger", "@id": "oa:start" },
+            "styleClass" :   "oa:styleClass",
+            "suffix" :       "oa:suffix",
+            "when" :         { "@type": "xsd:dateTimeStamp", "@id": "oa:when" },
+
+            "chars" :        "cnt:chars",
+            "bytes" :        "cnt:bytes",
+            "format" :       "dc:format",
+            "language" :     "dc:language",
+            "value" :        "rdf:value",
+            "label" :        "rdfs:label",
+            "name" :         "foaf:name",
+            "mbox" :         "foaf:mbox"
+
+          },
+          "@graph": [
+            {
+              "@id": "oa:annotatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is a resource that identifies the agent responsible for creating the Annotation. This may be either a human or software agent. \n\nThere SHOULD be exactly 1 oa:annotatedBy relationship per Annotation, but MAY be 0 or more than 1, as the Annotation may be anonymous, or multiple agents may have worked together on it.\n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:commenting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a commentary about or review of the target resource(s). For example to provide a commentary about a particular PDF."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "commenting"
+              }
+            },
+            {
+              "@id": "oa:SvgSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which selects an area specified as an SVG shape.\n\nThe SVG document should either be retrievable by resolving the URI of this resource, or be included as an Embedded Resource using cnt:Content.\n\nIt is RECOMMENDED that the document contain only a single shape element and that element SHOULD be one of: path, rect, circle, ellipse, polyline, polygon or g. The g element SHOULD ONLY be used to construct a multi-element group, for example to define a donut shape requiring an outer circle and a clipped inner circle.\n\nThe dimensions of both the shape and the SVG canvas MUST be relative to the dimensions of the Source resource. For example, given an image which is 600 pixels by 400 pixels, and the desired section is a circle of 100 pixel radius at the center of the image, then the SVG element would be: <circle cx=\"300\" cy=\"200\" r=\"100\"/>\n\nIt is NOT RECOMMENDED to include style information within the SVG element, nor Javascript, animation, text or other non shape oriented information. Clients SHOULD ignore such information if present."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SvgSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:Selector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the segment of interest in a representation of a Source resource, indicated with oa:hasSelector from the Specific Resource. \n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe nature of the Selector will be dependent on the type of the representation for which the segment is conveyed. The specific type of selector should be indicated using a subclass of oa:Selector.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Selector"
+              }
+            },
+            {
+              "@id": "oa:Style",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the style in which the selection or resource should be rendered, indicated with oa:styledBy from an oa:Annotation.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe content of the resource provides the rendering hints about the Annotation's constituent resources. \n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Style"
+              }
+            },
+            {
+              "@id": "oa:exact",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A copy of the text which is being selected, after normalization.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "exact"
+              }
+            },
+            {
+              "@id": "oa:hasBody",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and body. The body is somehow \"about\" the oa:hasTarget of the annotation.\n\nThe Body may be of any media type, and contain any type of content. The Body SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded bodies SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Body\" as a body might be a target of a different annotation. However, there SHOULD be 1 or more content-based classes associated with the body resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasBody"
+              }
+            },
+            {
+              "@id": "oa:Choice",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that it should select one of the constituent resources to display to the user, and not render/use all of them. \n\noa:Choice can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 1 or more oa:item relationships for each oa:Choice.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Choice"
+              },
+              "rdfs:subClassOf": {
+                "@id": "rdf:Alt"
+              }
+            },
+            {
+              "@id": "oa:when",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The timestamp at which the Source resource should be interpreted for the Annotation, typically the time that the Annotation was created."
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "when"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:serializedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is the agent, likely software, responsible for generating the serialization of the Annotation's serialization. \n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage\n\nThere MAY be 0 or more oa:serializedBy relationships per Annotation."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:motivatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between an Annotation and a Motivation, indicating the reasons why the Annotation was created.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship, and MAY be more than 1."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivatedBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Motivation"
+              }
+            },
+            {
+              "@id": "oa:moderating",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an assignment of value or quality to the target resource(s). For example annotating an Annotation to moderate it up in a trust network or threaded discussion."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "moderating"
+              }
+            },
+            {
+              "@id": "oa:highlighting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a highlighted section of the target resource or segment. For example to draw attention to the selected text that the annotator disagrees with. A Highlight may or may not have a Body resource"
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "highlighting"
+              }
+            },
+            {
+              "@id": "oa:styledBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:Annotation and a oa:Style.\n\nThere MAY be 0 or 1 styledBy relationships for each Annotation.\n\nIf there are multiple Style resources that must be associated with the Annotation, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styledBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:FragmentSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes the segment of interest in a representation, through the use of the fragment identifier component of a URI.\n\nIt is RECOMMENDED to use oa:FragmentSelector as the selector on a Specific Resource rather than annotating the fragment URI directly, in order to improve discoverability of annotation on the Source.\n\nThe oa:FragmentSelector MUST have exactly 1 rdf:value property, containing the fragment identifier component of a URI that describes the segment of interest in the resource, excluding the initial \"#\".\n\nThe Fragment Selector SHOULD have a dcterms:conformsTo relationship with the object being the specification that defines the syntax of the fragment, for instance <http://tools.ietf.org/rfc/rfc3236> for HTML fragments. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "FragmentSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:SpecificResource",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource identifies part of another Source resource, a particular representation of a resource, a resource with styling hints for renders, or any combination of these. \n\nThe Specific Resource takes the role of oa:hasBody or oa:hasTarget in an oa:Annotation instead of the Source resource.\n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a Specific Resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each Specific Resource.\n\nIf the Specific Resource has an HTTP URI, then the exact segment of the Source resource that it identifies, and only the segment, MUST be returned when the URI is dereferenced. For example, if the segment of interest is a region of an image and the Specific Resource has an HTTP URI, then dereferencing it MUST return the selected region of the image as it was at the time when the annotation was created. Typically this would be a burden to support, and thus the Specific Resource SHOULD be identified by a globally unique URI, such as a UUID URN. If it is not considered important to allow other Annotations or systems to refer to the Specific Resource, then a blank node MAY be used instead."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SpecificResource"
+              }
+            },
+            {
+              "@id": "oa:annotatedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the Annotation was created. \n\nThere SHOULD be exactly 1 oa:annotatedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:editing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a request for a modification or edit to the target resource. For example, an Annotation that requests a typo to be corrected."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "editing"
+              }
+            },
+            {
+              "@id": "oa:Annotation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "Typically an Annotation has a single Body (oa:hasBody), which is the comment or other descriptive resource, and a single Target (oa:hasTarget) that the Body is somehow \"about\". The Body provides the information which is annotating the Target. \n\nThis \"aboutness\" may be further clarified or extended to notions such as classifying or identifying with oa:motivatedBy."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Annotation"
+              }
+            },
+            {
+              "@id": "oa:equivalentTo",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The subject and object resources of the oa:equivalentTo relationship represent the same resource, but potentially have different metadata such as oa:serializedBy, oa:serializedAt and serialization format.  oa:equivalentTo is a symmetrical and transitive relationship; if A oa:equivalentTo B, then it is also true that B oa:equivalent A; and that if B oa:equivalentTo C, then it is also true that A oa:equivalentTo C. \n\nThe Annotation MAY include 0 or more instances of the oa:equivalentTo relationship between copies of the Annotation or other resources, and SHOULD include as many as are available.\n\nIf a system publishes an embedded resource (a cnt:Content) at a new HTTP URI, then it SHOULD express the oa:equivalentTo relationship between the resource's URN and the new URI from which it is available."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "equivalentTo"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:alternateOf"
+              }
+            },
+            {
+              "@id": "oa:Motivation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Motivation for creating an Annotation, indicated with oa:motivatedBy, is a reason for its creation, and might include things like oa:replying to another annotation, oa:commenting on a resource, or oa:linking to a related resource.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship to an instance of oa:Motivation, which is a subClass of skos:Concept."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Motivation"
+              },
+              "rdfs:subClassOf": {
+                "@id": "skos:Concept"
+              }
+            },
+            {
+              "@id": "oa:tagging",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents adding a Tag on the target resource(s). One or more of the bodies of the annotation should be typed as a oa:Tag or oa:SemanticTag."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "tagging"
+              }
+            },
+            {
+              "@id": "oa:List",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted, and in a particular order. \n\noa:List can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:List, with their order defined using the rdf:List construct of rdf:first/rdf:rest/rdf:nil.\n\nAll the elements of the list should also be declared using oa:item, and each of the oa:items should appear at least once in the list."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "List"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Composite"
+              }
+            },
+            {
+              "@id": "oa:TextQuoteSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector that describes a textual segment by means of quoting it, plus passages before or after it.\n\nFor example, if the document were \"abcdefghijklmnopqrstuvwxyz\", one could select \"efg\" by a oa:prefix of \"abcd\", the quotation of oa:exact \"efg\" and a oa:suffix of \"hijk\".\n\nThe text MUST be normalized before recording.\n\nEach TextQuoteSelector MUST have exactly 1 oa:exact property.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:prefix property, and MUST NOT have more than 1.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:suffix property, and MUST NOT have more than 1."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextQuoteSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:cachedSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A link to a copy of the Source resource's representation appropriate for the Annotation, typically a copy of the original at the time that the Annotation was created"
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "cachedSource"
+              }
+            },
+            {
+              "@id": "oa:bookmarking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the creation of a bookmark to the target resources or recorded point or points within one or more resources. For example, an Annotation that bookmarks the point in a text where the reader finished reading. Bookmark Annotations may or may not have a Body resource."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "bookmarking"
+              }
+            },
+            {
+              "@id": "oa:SemanticTag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a semantic tagging resource; a URI that identifies a concept, rather than an embedded string, frequently a term from a controlled vocabulary.\n\nIt is NOT RECOMMENDED to use the URI of a document as a Semantic Tag, as it might also be used as a regular Body in other Annotations which would inherit the oa:SemanticTag class assignment. Instead it is more appropriate to create a new URI and link it to the document, using the foaf:page predicate."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SemanticTag"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Tag"
+              }
+            },
+            {
+              "@id": "oa:hasSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and the resource that it is a more specific representation of. \n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSource"
+              }
+            },
+            {
+              "@id": "oa:default",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The constituent resource of a oa:Choice to use as a default option, if there is no other means to determine which would be most appropriate.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Choice"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "default"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "oa:item"
+              }
+            },
+            {
+              "@id": "oa:hasSelector",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:Selector.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a \nSpecific Resource. \n\nIf multiple Selectors are required, either to express a choice between different optional, equivalent selectors, or a chain of selectors that should all be processed, it is necessary to use oa:Choice, oa:Composite or oa:List as a selector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSelector"
+              },
+              "rdfs:range": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:hasTarget",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and target. The target resource is what the oa:hasBody is somewhat \"about\".\n\nThe target may be of any media type, and contain any type of content. The target SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded targets SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Target\" as a target might be a body in a different annotation. However, there SHOULD be 1 or more content-based classes associated with the target resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasTarget"
+              }
+            },
+            {
+              "@id": "oa:TextPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "An oa:Selector which describes a range of text based on its start and end positions.\n\nThe text MUST be normalized before counting characters. For a Selector that works from the bitstream rather than the rendered characters, see oa:DataPositionSelector.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:start property.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:end property."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:serializedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the agent referenced by oa:serializedBy generated the first serialization of the Annotation, and any subsequent substantially different one. The annotation graph MUST have changed for this property to be updated, and as such represents the last modified datestamp for the Annotation. This might be used to determine if it should be re-imported into a triplestore when discovered. \n\nThere MAY be exactly 1 oa:serializedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:Composite",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted. \n\noa:Composite can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:Composite."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": "Composite",
+              "rdfs:subClassOf": {
+                "@id": "rdf:Bag"
+              }
+            },
+            {
+              "@id": "oa:classifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of a classification type, typically from a controlled vocabulary, to the target resource(s). For example to classify an Image resource as a Portrait."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "classifying"
+              }
+            },
+            {
+              "@id": "oa:identifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of an identity to the target resource(s). For example, annotating the name of a city in a string of text with the URI that identifies it."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "identifying"
+              }
+            },
+            {
+              "@id": "oa:HttpRequestState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource for the Annotation, based on the HTTP Request headers to send to the server.\n\nThere MUST be exactly 1 rdf:value property per HttpRequestState, containing HTTP request headers as a single, complete string, exactly as they would appear in an HTTP request. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "HttpRequestState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:DataPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes a range of data based on its start and end positions within the byte stream of the representation.\n\nEach DataPositionSelector MUST have exactly 1 oa:start property.\n\nEach TextPositionSelector MUST have exactly 1 oa:end property.\n\nSee oa:TextPositionSelector for selection at normalized character level rather than bytestream level."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "DataPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:linking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an untyped link to a resource related to the target."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "linking"
+              }
+            },
+            {
+              "@id": "oa:motivationScheme",
+              "@type": [
+                "skos:ConceptScheme",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The concept scheme for Open Annotation Motivations"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivationScheme"
+              }
+            },
+            {
+              "@id": "oa:replying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a reply to a previous statement, either an Annotation or another resource. For example providing the assistance requested in the above."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "replying"
+              }
+            },
+            {
+              "@id": "oa:start",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The starting position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:start is included within the selected segment. \n\nSee oa:DataPositionSelector and oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "start"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:end",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The end position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:end is NOT included within the selected segment. \n\nSee oa:DataPositionSelector and oa:oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "end"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:TimeState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve a representation of the Source resource that is temporally appropriate for the Annotation.\n\nThere MUST be at least one of oa:cachedSource or oa:when specified. If there is more than 1, each gives an alternative copy of the representation."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TimeState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:State",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource, indicated with oa:hasState from the Specific Resource.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "State"
+              }
+            },
+            {
+              "@id": "oa:CssStyle",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes styles for resources participating in the Annotation using CSS.\n\nSpecific Resources MAY be assigned a CSS style class using oa:styleClass.\n\nThe CSS resource MAY have its own dereferencable URI that provides the information. For example, \"Style1\" in the diagram below might actually have the URI \"http://www.example.com/styles/annotations.css\". It MAY be embedded within the Annotation using the inline constructions described in Embedding Resources."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "CssStyle"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:item",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a multiplicity construct node and its constituent resources.\n\nThere MUST be 1 or more item relationships for each multiplicity construct oa:Choice, oa:Composite and oa:List."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "item"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "rdfs:member"
+              }
+            },
+            {
+              "@id": "oa:hasScope",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a Specific Resource and the resource that provides the scope or context for it in this Annotation.\n\nThere MAY be 0 or more hasScope relationships for each Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasScope"
+              }
+            },
+            {
+              "@id": "oa:suffix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The snippet of text that occurs immediately after the text which is being selected. \n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "suffix"
+              }
+            },
+            {
+              "@id": "oa:hasState",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:State resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each SpecificResource.\n\nIf there are multiple State resources that must be associated with the specific resource, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasState"
+              },
+              "rdfs:range": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:",
+              "@type": "owl:Ontology",
+              "dc:contributor": {
+                "@language": "en",
+                "@value": "Stian Soiland-Reyes"
+              },
+              "dc:creator": [
+                {
+                  "@language": "en",
+                  "@value": "Robert Sanderson"
+                },
+                {
+                  "@language": "it",
+                  "@value": "Paolo Ciccarese"
+                },
+                {
+                  "@language": "vls",
+                  "@value": "Herbert Van de Sompel"
+                }
+              ],
+              "dc:description": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web. Open Annotations can easily be shared between platforms, with sufficient richness of expression to satisfy complex requirements while remaining simple enough to also allow for the most common use cases, such as attaching a piece of text to a single web resource.\n\nAn Annotation is considered to be a set of connected resources, typically including a body and target, where the body is somehow about the target. The full model supports additional functionality, enabling semantic annotations, embedding content, selecting segments of resources, choosing the appropriate representation of a resource and providing styling hints for consuming clients."
+              },
+              "dc:title": {
+                "@language": "en",
+                "@value": "Open Annotation Data Model"
+              },
+              "dcterms:modified": {
+                "@type": "xsd:dateTime",
+                "@value": "2013-02-22T21:40:51+01:00"
+              },
+              "owl:versionIRI": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/oa.owl"
+              },
+              "owl:versionInfo": "0.9.20130208",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web.\n\nThis ontology is a non-normative OWL formalization of the textual OA specification at http://www.openannotation.org/spec/core/20130208/index.html\n\nNote that OWL imports are disabled in the published version in order to reduce external implications, improve OWL 2 Profile conformity and increase interoperability. Some OWL tools might thus misleadingly show this ontology as (re)defining properties like skos:prefLabel."
+              },
+              "rdfs:seeAlso": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/index.html"
+              }
+            },
+            {
+              "@id": "oa:questioning",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents asking a question about the target resource(s). For example to ask for assistance with a particular section of text, or question its veracity."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "questioning"
+              }
+            },
+            {
+              "@id": "oa:describing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a description of the target resource(s), as opposed to a comment about them. For example describing the above PDF's contents, rather than commenting on their accuracy."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "describing"
+              }
+            },
+            {
+              "@id": "oa:styleClass",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The string name of the class used in the CSS description that should be applied to the Specific Resource.\n\nThere MAY be 0 or more styleClass properties on a Specific Resource.\n\nSee oa:CssStyle."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styleClass"
+              }
+            },
+            {
+              "@id": "oa:Tag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a tag, such as a embedded text string with cnt:chars.\n\nTags are typically keywords or labels, and used for organization, description or discovery of the resource being tagged. In the Semantic Web, URIs are used instead of strings to avoid the issue of polysemy where one word has multiple meanings, such usage MUST be indicated using the subclass oa:SemanticTag.\n\nAnnotations that tag resources, either with text or semantic tags, SHOULD also have the oa:tagging motivation to make the reason for the Annotation more clear to applications, and MAY have other motivations as well."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Tag"
+              }
+            },
+            {
+              "@id": "oa:prefix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A snippet of text that occurs immediately before the text which is being selected.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "prefix"
+              }
+            }
+          ]
+        }
+
+
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:00:03 GMT
+  recorded_at: Mon, 04 May 2015 17:52:48 GMT
 - request:
     method: get
-    uri: http://iiif.io/api/presentation/2/context.json
+    uri: http://www.w3.org/ns/oa-context-20130208.json
     body:
       encoding: US-ASCII
       string: ''
@@ -2609,92 +3713,1192 @@ http_interactions:
       - Ruby
   response:
     status:
+      code: 307
+      message: Temporary Redirect
+    headers:
+      Date:
+      - Mon, 04 May 2015 17:52:48 GMT
+      Server:
+      - Apache/2
+      Location:
+      - http://www.w3.org/ns/oa.jsonld
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Mon, 04 May 2015 23:52:48 GMT
+      Content-Length:
+      - '240'
+      Content-Type:
+      - text/html; charset=iso-8859-1
+    body:
+      encoding: UTF-8
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+        <html><head>
+        <title>307 Temporary Redirect</title>
+        </head><body>
+        <h1>Temporary Redirect</h1>
+        <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
+        </body></html>
+    http_version: 
+  recorded_at: Mon, 04 May 2015 17:52:48 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa.jsonld
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/ld+json, application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cookie:
+      - ''
+      User-Agent:
+      - Ruby
+  response:
+    status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:02:22 GMT
+      - Mon, 04 May 2015 17:52:48 GMT
       Server:
-      - Apache/2.2.15 (Red Hat)
+      - Apache/2
       Last-Modified:
-      - Tue, 28 Apr 2015 19:46:55 GMT
+      - Tue, 06 May 2014 11:14:49 GMT
+      Etag:
+      - '"b533-4f8b95b2a9c40"'
       Accept-Ranges:
       - bytes
       Content-Length:
-      - '4235'
+      - '46387'
       Cache-Control:
-      - max-age=86400
+      - max-age=21600
       Expires:
-      - Thu, 30 Apr 2015 00:02:22 GMT
-      Content-Type:
-      - application/ld+json
+      - Mon, 04 May 2015 23:52:48 GMT
+      P3p:
+      - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
       - "*"
+      Content-Type:
+      - application/ld+json
     body:
       encoding: UTF-8
-      string: "{\n\t\"@context\": [\n\t\t{\n\t\t\t\"sc\":      \"http://iiif.io/api/presentation/2#\",\n\t
-        \       \"iiif\":    \"http://iiif.io/api/image/2#\",\n\t        \"exif\":
-        \   \"http://www.w3.org/2003/12/exif/ns#\",\n\t        \"oa\":      \"http://www.w3.org/ns/oa#\",\n\t
-        \       \"cnt\":     \"http://www.w3.org/2011/content#\",\n\t        \"dc\":
-        \     \"http://purl.org/dc/elements/1.1/\",\n\t        \"dcterms\": \"http://purl.org/dc/terms/\",\n\t
-        \       \"dctypes\": \"http://purl.org/dc/dcmitype/\",\n\t        \"foaf\":
-        \   \"http://xmlns.com/foaf/0.1/\",\n\t        \"rdf\":     \"http://www.w3.org/1999/02/22-rdf-syntax-ns#\",\n\t
-        \       \"rdfs\":    \"http://www.w3.org/2000/01/rdf-schema#\",\n\t        \"xsd\":
-        \    \"http://www.w3.org/2001/XMLSchema#\",\n\t\t\t\"svcs\":    \"http://rdfs.org/sioc/services#\",\n\n\t
-        \       \"license\":     {\"@type\":\"@id\", \"@id\":\"dcterms:license\"},\n\t
-        \       \"service\":     {\"@type\":\"@id\", \"@id\":\"svcs:has_service\"},\n\t
-        \       \"seeAlso\":    {\"@type\":\"@id\", \"@id\":\"foaf:page\"},\n\t        \"within\":
-        \     {\"@type\":\"@id\", \"@id\":\"dcterms:isPartOf\"},\n\t        \"profile\":
-        \    {\"@type\":\"@id\", \"@id\":\"dcterms:conformsTo\"},\n\t        \"related\":
-        \    {\"@type\":\"@id\", \"@id\":\"dcterms:relation\"},\n\t        \"logo\":
-        \       {\"@type\":\"@id\", \"@id\":\"foaf:logo\"},\n\t        \"thumbnail\":
-        \  {\"@type\":\"@id\", \"@id\":\"foaf:thumbnail\"},\n\t        \"startCanvas\":
-        {\"@type\":\"@id\", \"@id\":\"sc:hasStartCanvas\"},\n\n\t        \"collections\":
-        {\"@type\":\"@id\", \"@id\":\"sc:hasCollections\", \"@container\":\"@list\"},\n\t
-        \       \"manifests\":   {\"@type\":\"@id\", \"@id\":\"sc:hasManifests\",
-        \"@container\":\"@list\"},\n\t        \"sequences\":   {\"@type\":\"@id\",
-        \"@id\":\"sc:hasSequences\", \"@container\":\"@list\"},\n\t        \"canvases\":
-        \   {\"@type\":\"@id\", \"@id\":\"sc:hasCanvases\", \"@container\":\"@list\"},\n\t
-        \       \"resources\":   {\"@type\":\"@id\", \"@id\":\"sc:hasAnnotations\",
-        \"@container\":\"@list\"},\n\t        \"images\":      {\"@type\":\"@id\",
-        \"@id\":\"sc:hasImageAnnotations\",\"@container\":\"@list\"},\n\t        \"otherContent\":
-        {\"@type\":\"@id\", \"@id\":\"sc:hasLists\", \"@container\":\"@list\"},\n\t
-        \       \"structures\":  {\"@type\":\"@id\", \"@id\":\"sc:hasRanges\", \"@container\":\"@list\"},\n\t
-        \       \"ranges\" :     {\"@type\": \"@id\", \"@id\": \"sc:hasRanges\", \"@container\":\"@list\"},\n\n\t
-        \       \"metadata\":    {\"@type\":\"@id\", \"@id\":\"sc:metadataLabels\",
-        \"@container\":\"@list\"},\n\n\t        \"description\": {\"@id\": \"dc:description\"},\n\t
-        \       \"height\":      {\"@type\":\"xsd:integer\", \"@id\":\"exif:height\"},\n\t
-        \       \"width\":       {\"@type\":\"xsd:integer\", \"@id\":\"exif:width\"},\n\n\t
-        \       \"attribution\": {\"@id\": \"sc:attributionLabel\"},\n\t        \"viewingDirection\":
-        {\"@id\": \"sc:viewingDirection\", \"@type\":\"@id\"},\n\t        \"viewingHint\":
-        {\"@id\": \"sc:viewingHint\", \"@type\":\"@id\"},\n\n\t        \"left-to-right\":
-        {\"@id\":\"sc:leftToRightDirection\", \"@type\":\"sc:ViewingDirection\"},\n\t
-        \       \"right-to-left\": {\"@id\":\"sc:rightToLeftDirection\", \"@type\":\"sc:ViewingDirection\"},\n\t
-        \       \"top-to-bottom\": {\"@id\":\"sc:topToBottomDirection\", \"@type\":\"sc:ViewingDirection\"},\t
-        \       \n\t        \"bottom-to-top\": {\"@id\":\"sc:bottomToTopDirection\",
-        \"@type\":\"sc:ViewingDirection\"},\n\n\t        \"paged\":         {\"@id\":\"sc:pagedHint\",
-        \"@type\":\"sc:ViewingHint\"},\n\t        \"non-paged\":     {\"@id\":\"sc:nonPagedHint\",
-        \"@type\":\"sc:ViewingHint\"},   \n\t        \"continuous\":    {\"@id\":\"sc:continuousHint\",
-        \"@type\":\"sc:ViewingHint\"},\n\t        \"individuals\":   {\"@id\":\"sc:individualsHint\",
-        \"@type\":\"sc:ViewingHint\"}, \n\t        \"top\":           {\"@id\":\"sc:topHint\",
-        \"@type\":\"sc:ViewingHint\"},\n\n\t        \"motivation\":  {\"@type\":\"@id\",
-        \"@id\":\"oa:motivatedBy\"},\n\t        \"resource\":    {\"@type\":\"@id\",
-        \"@id\":\"oa:hasBody\"},\n\t        \"on\":          {\"@type\":\"@id\", \"@id\":\"oa:hasTarget\"},\n\t
-        \       \"full\":        {\"@type\":\"@id\", \"@id\":\"oa:hasSource\"},\n\t
-        \       \"selector\":    {\"@type\":\"@id\", \"@id\":\"oa:hasSelector\"},\n\t
-        \       \"stylesheet\":  {\"@type\":\"@id\", \"@id\":\"oa:styledBy\"},\n\t
-        \       \"style\":       {\"@id\":\"oa:styleClass\"},\n\n\t\t    \"default\":
-        \    {\"@type\":\"@id\", \"@id\" : \"oa:default\"},\n\t\t    \"item\":        {\"@type\":\"@id\",
-        \"@id\" : \"oa:item\"},\n\t\t    \"chars\":       {\"@id\": \"cnt:chars\"},\n\t\t
-        \   \"encoding\":    {\"@id\": \"cnt:characterEncoding\"},\n\t\t    \"bytes\":
-        \      {\"@id\": \"cnt:bytes\"},\n\t\t    \"format\":      {\"@id\": \"dc:format\"},\n\t\t
-        \   \"language\":    {\"@id\": \"dc:language\"},\n\t\t    \"value\":       {\"@id\":
-        \"rdf:value\"},\n\t\t    \"label\":       {\"@id\": \"rdfs:label\"}\n\t\t}\n\t]\n}"
+      string: |+
+        {
+          "@context": {
+            "oa": "http://www.w3.org/ns/oa#",
+            "cnt": "http://www.w3.org/2011/content#",
+            "dc": "http://purl.org/dc/elements/1.1/",
+            "dcterms": "http://purl.org/dc/terms/",
+            "dctypes": "http://purl.org/dc/dcmitype/",
+            "foaf": "http://xmlns.com/foaf/0.1/",
+            "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+            "skos": "http://www.w3.org/2004/02/skos/core#",
+            "owl": "http://www.w3.org/2002/07/owl#",
+            "prov": "http://www.w3.org/ns/prov#",
+            "trig": "http://www.w3.org/2004/03/trix/rdfg-1/",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+
+            "hasBody" :         {"@type":"@id", "@id" : "oa:hasBody"},
+            "hasTarget" :       {"@type":"@id", "@id" : "oa:hasTarget"},
+            "hasSource" :       {"@type":"@id", "@id" : "oa:hasSource"},
+            "hasSelector" :     {"@type":"@id", "@id" : "oa:hasSelector"},
+            "hasState" :        {"@type":"@id", "@id" : "oa:hasState"},
+            "hasScope" :        {"@type":"@id", "@id" : "oa:hasScope"},
+            "annotatedBy" :  {"@type":"@id", "@id" : "oa:annotatedBy"},
+            "serializedBy" : {"@type":"@id", "@id" : "oa:serializedBy"},
+            "motivatedBy" :  {"@type":"@id", "@id" : "oa:motivatedBy"},
+            "equivalentTo" : {"@type":"@id", "@id" : "oa:equivalentTo"},
+            "styledBy" :     {"@type":"@id", "@id" : "oa:styledBy"},
+            "cachedSource" : {"@type":"@id", "@id" : "oa:cachedSource"},
+            "conformsTo" :   {"@type":"@id", "@id" : "dcterms:conformsTo"},
+            "default" :      {"@type":"@id", "@id" : "oa:default"},
+            "item" :         {"@type":"@id", "@id" : "oa:item"},
+            "first":         {"@type":"@id", "@id" : "rdf:first"},
+            "rest":          {"@type":"@id", "@id" : "rdf:rest", "@container" : "@list"},
+
+            "annotatedAt" :  { "@type": "xsd:dateTimeStamp", "@id": "oa:annotatedAt" },
+            "end" :          { "@type": "xsd:nonNegativeInteger", "@id": "oa:end" },
+            "exact" :        "oa:exact",
+            "prefix" :       "oa:prefix",
+            "serializedAt" : { "@type": "xsd:dateTimeStamp", "@id": "oa:serializedAt" },
+            "start" :        { "@type": "xsd:nonNegativeInteger", "@id": "oa:start" },
+            "styleClass" :   "oa:styleClass",
+            "suffix" :       "oa:suffix",
+            "when" :         { "@type": "xsd:dateTimeStamp", "@id": "oa:when" },
+
+            "chars" :        "cnt:chars",
+            "bytes" :        "cnt:bytes",
+            "format" :       "dc:format",
+            "language" :     "dc:language",
+            "value" :        "rdf:value",
+            "label" :        "rdfs:label",
+            "name" :         "foaf:name",
+            "mbox" :         "foaf:mbox"
+
+          },
+          "@graph": [
+            {
+              "@id": "oa:annotatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is a resource that identifies the agent responsible for creating the Annotation. This may be either a human or software agent. \n\nThere SHOULD be exactly 1 oa:annotatedBy relationship per Annotation, but MAY be 0 or more than 1, as the Annotation may be anonymous, or multiple agents may have worked together on it.\n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:commenting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a commentary about or review of the target resource(s). For example to provide a commentary about a particular PDF."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "commenting"
+              }
+            },
+            {
+              "@id": "oa:SvgSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which selects an area specified as an SVG shape.\n\nThe SVG document should either be retrievable by resolving the URI of this resource, or be included as an Embedded Resource using cnt:Content.\n\nIt is RECOMMENDED that the document contain only a single shape element and that element SHOULD be one of: path, rect, circle, ellipse, polyline, polygon or g. The g element SHOULD ONLY be used to construct a multi-element group, for example to define a donut shape requiring an outer circle and a clipped inner circle.\n\nThe dimensions of both the shape and the SVG canvas MUST be relative to the dimensions of the Source resource. For example, given an image which is 600 pixels by 400 pixels, and the desired section is a circle of 100 pixel radius at the center of the image, then the SVG element would be: <circle cx=\"300\" cy=\"200\" r=\"100\"/>\n\nIt is NOT RECOMMENDED to include style information within the SVG element, nor Javascript, animation, text or other non shape oriented information. Clients SHOULD ignore such information if present."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SvgSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:Selector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the segment of interest in a representation of a Source resource, indicated with oa:hasSelector from the Specific Resource. \n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe nature of the Selector will be dependent on the type of the representation for which the segment is conveyed. The specific type of selector should be indicated using a subclass of oa:Selector.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Selector"
+              }
+            },
+            {
+              "@id": "oa:Style",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the style in which the selection or resource should be rendered, indicated with oa:styledBy from an oa:Annotation.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe content of the resource provides the rendering hints about the Annotation's constituent resources. \n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Style"
+              }
+            },
+            {
+              "@id": "oa:exact",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A copy of the text which is being selected, after normalization.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "exact"
+              }
+            },
+            {
+              "@id": "oa:hasBody",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and body. The body is somehow \"about\" the oa:hasTarget of the annotation.\n\nThe Body may be of any media type, and contain any type of content. The Body SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded bodies SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Body\" as a body might be a target of a different annotation. However, there SHOULD be 1 or more content-based classes associated with the body resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasBody"
+              }
+            },
+            {
+              "@id": "oa:Choice",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that it should select one of the constituent resources to display to the user, and not render/use all of them. \n\noa:Choice can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 1 or more oa:item relationships for each oa:Choice.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Choice"
+              },
+              "rdfs:subClassOf": {
+                "@id": "rdf:Alt"
+              }
+            },
+            {
+              "@id": "oa:when",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The timestamp at which the Source resource should be interpreted for the Annotation, typically the time that the Annotation was created."
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "when"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:serializedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is the agent, likely software, responsible for generating the serialization of the Annotation's serialization. \n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage\n\nThere MAY be 0 or more oa:serializedBy relationships per Annotation."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:motivatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between an Annotation and a Motivation, indicating the reasons why the Annotation was created.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship, and MAY be more than 1."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivatedBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Motivation"
+              }
+            },
+            {
+              "@id": "oa:moderating",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an assignment of value or quality to the target resource(s). For example annotating an Annotation to moderate it up in a trust network or threaded discussion."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "moderating"
+              }
+            },
+            {
+              "@id": "oa:highlighting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a highlighted section of the target resource or segment. For example to draw attention to the selected text that the annotator disagrees with. A Highlight may or may not have a Body resource"
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "highlighting"
+              }
+            },
+            {
+              "@id": "oa:styledBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:Annotation and a oa:Style.\n\nThere MAY be 0 or 1 styledBy relationships for each Annotation.\n\nIf there are multiple Style resources that must be associated with the Annotation, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styledBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:FragmentSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes the segment of interest in a representation, through the use of the fragment identifier component of a URI.\n\nIt is RECOMMENDED to use oa:FragmentSelector as the selector on a Specific Resource rather than annotating the fragment URI directly, in order to improve discoverability of annotation on the Source.\n\nThe oa:FragmentSelector MUST have exactly 1 rdf:value property, containing the fragment identifier component of a URI that describes the segment of interest in the resource, excluding the initial \"#\".\n\nThe Fragment Selector SHOULD have a dcterms:conformsTo relationship with the object being the specification that defines the syntax of the fragment, for instance <http://tools.ietf.org/rfc/rfc3236> for HTML fragments. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "FragmentSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:SpecificResource",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource identifies part of another Source resource, a particular representation of a resource, a resource with styling hints for renders, or any combination of these. \n\nThe Specific Resource takes the role of oa:hasBody or oa:hasTarget in an oa:Annotation instead of the Source resource.\n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a Specific Resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each Specific Resource.\n\nIf the Specific Resource has an HTTP URI, then the exact segment of the Source resource that it identifies, and only the segment, MUST be returned when the URI is dereferenced. For example, if the segment of interest is a region of an image and the Specific Resource has an HTTP URI, then dereferencing it MUST return the selected region of the image as it was at the time when the annotation was created. Typically this would be a burden to support, and thus the Specific Resource SHOULD be identified by a globally unique URI, such as a UUID URN. If it is not considered important to allow other Annotations or systems to refer to the Specific Resource, then a blank node MAY be used instead."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SpecificResource"
+              }
+            },
+            {
+              "@id": "oa:annotatedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the Annotation was created. \n\nThere SHOULD be exactly 1 oa:annotatedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:editing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a request for a modification or edit to the target resource. For example, an Annotation that requests a typo to be corrected."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "editing"
+              }
+            },
+            {
+              "@id": "oa:Annotation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "Typically an Annotation has a single Body (oa:hasBody), which is the comment or other descriptive resource, and a single Target (oa:hasTarget) that the Body is somehow \"about\". The Body provides the information which is annotating the Target. \n\nThis \"aboutness\" may be further clarified or extended to notions such as classifying or identifying with oa:motivatedBy."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Annotation"
+              }
+            },
+            {
+              "@id": "oa:equivalentTo",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The subject and object resources of the oa:equivalentTo relationship represent the same resource, but potentially have different metadata such as oa:serializedBy, oa:serializedAt and serialization format.  oa:equivalentTo is a symmetrical and transitive relationship; if A oa:equivalentTo B, then it is also true that B oa:equivalent A; and that if B oa:equivalentTo C, then it is also true that A oa:equivalentTo C. \n\nThe Annotation MAY include 0 or more instances of the oa:equivalentTo relationship between copies of the Annotation or other resources, and SHOULD include as many as are available.\n\nIf a system publishes an embedded resource (a cnt:Content) at a new HTTP URI, then it SHOULD express the oa:equivalentTo relationship between the resource's URN and the new URI from which it is available."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "equivalentTo"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:alternateOf"
+              }
+            },
+            {
+              "@id": "oa:Motivation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Motivation for creating an Annotation, indicated with oa:motivatedBy, is a reason for its creation, and might include things like oa:replying to another annotation, oa:commenting on a resource, or oa:linking to a related resource.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship to an instance of oa:Motivation, which is a subClass of skos:Concept."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Motivation"
+              },
+              "rdfs:subClassOf": {
+                "@id": "skos:Concept"
+              }
+            },
+            {
+              "@id": "oa:tagging",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents adding a Tag on the target resource(s). One or more of the bodies of the annotation should be typed as a oa:Tag or oa:SemanticTag."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "tagging"
+              }
+            },
+            {
+              "@id": "oa:List",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted, and in a particular order. \n\noa:List can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:List, with their order defined using the rdf:List construct of rdf:first/rdf:rest/rdf:nil.\n\nAll the elements of the list should also be declared using oa:item, and each of the oa:items should appear at least once in the list."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "List"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Composite"
+              }
+            },
+            {
+              "@id": "oa:TextQuoteSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector that describes a textual segment by means of quoting it, plus passages before or after it.\n\nFor example, if the document were \"abcdefghijklmnopqrstuvwxyz\", one could select \"efg\" by a oa:prefix of \"abcd\", the quotation of oa:exact \"efg\" and a oa:suffix of \"hijk\".\n\nThe text MUST be normalized before recording.\n\nEach TextQuoteSelector MUST have exactly 1 oa:exact property.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:prefix property, and MUST NOT have more than 1.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:suffix property, and MUST NOT have more than 1."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextQuoteSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:cachedSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A link to a copy of the Source resource's representation appropriate for the Annotation, typically a copy of the original at the time that the Annotation was created"
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "cachedSource"
+              }
+            },
+            {
+              "@id": "oa:bookmarking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the creation of a bookmark to the target resources or recorded point or points within one or more resources. For example, an Annotation that bookmarks the point in a text where the reader finished reading. Bookmark Annotations may or may not have a Body resource."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "bookmarking"
+              }
+            },
+            {
+              "@id": "oa:SemanticTag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a semantic tagging resource; a URI that identifies a concept, rather than an embedded string, frequently a term from a controlled vocabulary.\n\nIt is NOT RECOMMENDED to use the URI of a document as a Semantic Tag, as it might also be used as a regular Body in other Annotations which would inherit the oa:SemanticTag class assignment. Instead it is more appropriate to create a new URI and link it to the document, using the foaf:page predicate."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SemanticTag"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Tag"
+              }
+            },
+            {
+              "@id": "oa:hasSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and the resource that it is a more specific representation of. \n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSource"
+              }
+            },
+            {
+              "@id": "oa:default",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The constituent resource of a oa:Choice to use as a default option, if there is no other means to determine which would be most appropriate.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Choice"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "default"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "oa:item"
+              }
+            },
+            {
+              "@id": "oa:hasSelector",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:Selector.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a \nSpecific Resource. \n\nIf multiple Selectors are required, either to express a choice between different optional, equivalent selectors, or a chain of selectors that should all be processed, it is necessary to use oa:Choice, oa:Composite or oa:List as a selector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSelector"
+              },
+              "rdfs:range": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:hasTarget",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and target. The target resource is what the oa:hasBody is somewhat \"about\".\n\nThe target may be of any media type, and contain any type of content. The target SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded targets SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Target\" as a target might be a body in a different annotation. However, there SHOULD be 1 or more content-based classes associated with the target resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasTarget"
+              }
+            },
+            {
+              "@id": "oa:TextPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "An oa:Selector which describes a range of text based on its start and end positions.\n\nThe text MUST be normalized before counting characters. For a Selector that works from the bitstream rather than the rendered characters, see oa:DataPositionSelector.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:start property.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:end property."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:serializedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the agent referenced by oa:serializedBy generated the first serialization of the Annotation, and any subsequent substantially different one. The annotation graph MUST have changed for this property to be updated, and as such represents the last modified datestamp for the Annotation. This might be used to determine if it should be re-imported into a triplestore when discovered. \n\nThere MAY be exactly 1 oa:serializedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:Composite",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted. \n\noa:Composite can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:Composite."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": "Composite",
+              "rdfs:subClassOf": {
+                "@id": "rdf:Bag"
+              }
+            },
+            {
+              "@id": "oa:classifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of a classification type, typically from a controlled vocabulary, to the target resource(s). For example to classify an Image resource as a Portrait."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "classifying"
+              }
+            },
+            {
+              "@id": "oa:identifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of an identity to the target resource(s). For example, annotating the name of a city in a string of text with the URI that identifies it."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "identifying"
+              }
+            },
+            {
+              "@id": "oa:HttpRequestState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource for the Annotation, based on the HTTP Request headers to send to the server.\n\nThere MUST be exactly 1 rdf:value property per HttpRequestState, containing HTTP request headers as a single, complete string, exactly as they would appear in an HTTP request. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "HttpRequestState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:DataPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes a range of data based on its start and end positions within the byte stream of the representation.\n\nEach DataPositionSelector MUST have exactly 1 oa:start property.\n\nEach TextPositionSelector MUST have exactly 1 oa:end property.\n\nSee oa:TextPositionSelector for selection at normalized character level rather than bytestream level."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "DataPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:linking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an untyped link to a resource related to the target."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "linking"
+              }
+            },
+            {
+              "@id": "oa:motivationScheme",
+              "@type": [
+                "skos:ConceptScheme",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The concept scheme for Open Annotation Motivations"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivationScheme"
+              }
+            },
+            {
+              "@id": "oa:replying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a reply to a previous statement, either an Annotation or another resource. For example providing the assistance requested in the above."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "replying"
+              }
+            },
+            {
+              "@id": "oa:start",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The starting position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:start is included within the selected segment. \n\nSee oa:DataPositionSelector and oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "start"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:end",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The end position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:end is NOT included within the selected segment. \n\nSee oa:DataPositionSelector and oa:oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "end"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:TimeState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve a representation of the Source resource that is temporally appropriate for the Annotation.\n\nThere MUST be at least one of oa:cachedSource or oa:when specified. If there is more than 1, each gives an alternative copy of the representation."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TimeState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:State",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource, indicated with oa:hasState from the Specific Resource.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "State"
+              }
+            },
+            {
+              "@id": "oa:CssStyle",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes styles for resources participating in the Annotation using CSS.\n\nSpecific Resources MAY be assigned a CSS style class using oa:styleClass.\n\nThe CSS resource MAY have its own dereferencable URI that provides the information. For example, \"Style1\" in the diagram below might actually have the URI \"http://www.example.com/styles/annotations.css\". It MAY be embedded within the Annotation using the inline constructions described in Embedding Resources."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "CssStyle"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:item",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a multiplicity construct node and its constituent resources.\n\nThere MUST be 1 or more item relationships for each multiplicity construct oa:Choice, oa:Composite and oa:List."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "item"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "rdfs:member"
+              }
+            },
+            {
+              "@id": "oa:hasScope",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a Specific Resource and the resource that provides the scope or context for it in this Annotation.\n\nThere MAY be 0 or more hasScope relationships for each Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasScope"
+              }
+            },
+            {
+              "@id": "oa:suffix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The snippet of text that occurs immediately after the text which is being selected. \n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "suffix"
+              }
+            },
+            {
+              "@id": "oa:hasState",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:State resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each SpecificResource.\n\nIf there are multiple State resources that must be associated with the specific resource, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasState"
+              },
+              "rdfs:range": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:",
+              "@type": "owl:Ontology",
+              "dc:contributor": {
+                "@language": "en",
+                "@value": "Stian Soiland-Reyes"
+              },
+              "dc:creator": [
+                {
+                  "@language": "en",
+                  "@value": "Robert Sanderson"
+                },
+                {
+                  "@language": "it",
+                  "@value": "Paolo Ciccarese"
+                },
+                {
+                  "@language": "vls",
+                  "@value": "Herbert Van de Sompel"
+                }
+              ],
+              "dc:description": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web. Open Annotations can easily be shared between platforms, with sufficient richness of expression to satisfy complex requirements while remaining simple enough to also allow for the most common use cases, such as attaching a piece of text to a single web resource.\n\nAn Annotation is considered to be a set of connected resources, typically including a body and target, where the body is somehow about the target. The full model supports additional functionality, enabling semantic annotations, embedding content, selecting segments of resources, choosing the appropriate representation of a resource and providing styling hints for consuming clients."
+              },
+              "dc:title": {
+                "@language": "en",
+                "@value": "Open Annotation Data Model"
+              },
+              "dcterms:modified": {
+                "@type": "xsd:dateTime",
+                "@value": "2013-02-22T21:40:51+01:00"
+              },
+              "owl:versionIRI": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/oa.owl"
+              },
+              "owl:versionInfo": "0.9.20130208",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web.\n\nThis ontology is a non-normative OWL formalization of the textual OA specification at http://www.openannotation.org/spec/core/20130208/index.html\n\nNote that OWL imports are disabled in the published version in order to reduce external implications, improve OWL 2 Profile conformity and increase interoperability. Some OWL tools might thus misleadingly show this ontology as (re)defining properties like skos:prefLabel."
+              },
+              "rdfs:seeAlso": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/index.html"
+              }
+            },
+            {
+              "@id": "oa:questioning",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents asking a question about the target resource(s). For example to ask for assistance with a particular section of text, or question its veracity."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "questioning"
+              }
+            },
+            {
+              "@id": "oa:describing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a description of the target resource(s), as opposed to a comment about them. For example describing the above PDF's contents, rather than commenting on their accuracy."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "describing"
+              }
+            },
+            {
+              "@id": "oa:styleClass",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The string name of the class used in the CSS description that should be applied to the Specific Resource.\n\nThere MAY be 0 or more styleClass properties on a Specific Resource.\n\nSee oa:CssStyle."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styleClass"
+              }
+            },
+            {
+              "@id": "oa:Tag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a tag, such as a embedded text string with cnt:chars.\n\nTags are typically keywords or labels, and used for organization, description or discovery of the resource being tagged. In the Semantic Web, URIs are used instead of strings to avoid the issue of polysemy where one word has multiple meanings, such usage MUST be indicated using the subclass oa:SemanticTag.\n\nAnnotations that tag resources, either with text or semantic tags, SHOULD also have the oa:tagging motivation to make the reason for the Annotation more clear to applications, and MAY have other motivations as well."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Tag"
+              }
+            },
+            {
+              "@id": "oa:prefix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A snippet of text that occurs immediately before the text which is being selected.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "prefix"
+              }
+            }
+          ]
+        }
+
+
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:00:03 GMT
+  recorded_at: Mon, 04 May 2015 17:52:48 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/78426d26-2fac-47c8-b8dc-b3a929d3cce6
+    uri: http://localhost:3000/annotations/4bf087ee-e887-4b67-b558-82e7707418fb
     body:
       encoding: US-ASCII
       string: ''
@@ -2721,22 +4925,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - e433ac31-ba10-4770-8f67-740b52d3ded6
+      - f0b2678f-5ad6-4041-9ba8-e2bc58158958
       X-Runtime:
-      - '0.159408'
+      - '0.150550'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Wed, 29 Apr 2015 00:00:04 GMT
+      - Mon, 04 May 2015 17:52:48 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=QlZVMElPS1RocnNzMjN3b2dpZC9kY1I3bHlhSVpMOFBObzFPQ0t1bThtdUtjSjNCeVg2TG9WaVpDalVaTXpaS0E5bHVQL25rSkhpSllmTzZNUUVNWEpKbzVicGFQYTBFQkpWYnpBS2JUZklybC83NHd2eVl5T0xjVUJ0Z0hOczhPVkRHY0dhTmtqT211SUdEa0MrNVJPSnM0bUp5a1NJYm9xM0VrdUNaVGRLY2tqQ1pSazRZd2NmK0JLNHB5Rm1PLS1jY3ZmZzZ5MkJaR3dVRzJWWGQrZktnPT0%3D--f87a45f9c852304bcebd2290a54eace4bba37906;
+      - _internal_session=MCsxTGw1d3FtWkRoMSt6WWloNFNCZ1NRQmd6b2p2b3BnSmZNb2RkeUt6MUJrNnpHa2lGdUNZZ09nMFJDRjVmS1QrMEVRaHdFN09oMENLMThud2xQdFI5RjRJbWtFdjNRZUtoS1p4OUY5dUpvUXlwTHRqeHBCN3J6U3NTN29GazlRcER0WEVoalRQTkdaSFRCVEpQRkxoemlLV3pxS2ZPU1N5NFdJNWdFQW14T3JOZUd0RDIxNTRreHBNa2IxaWx4LS1JbTYwc2t1K0tiT01sTHgzR25PM29nPT0%3D--0c90062e735096a310437d8e3d87080929cd567b;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:00:04 GMT
+  recorded_at: Mon, 04 May 2015 17:52:48 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/_delete_annotation/deletes_an_open_annotation_that_exists.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/_delete_annotation/deletes_an_open_annotation_that_exists.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"833f3a8c6f9a931fb8ed0712235d0b49"
+      - W/"3d96293c7bdc48c73d38745abb21a104"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 7e17fac8-410a-40cc-8e0d-46ddd14f61da
+      - 26b43f3d-2ccd-4fc6-b7ba-07e7e63bcc69
       X-Runtime:
-      - '8.356013'
+      - '2.926212'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Tue, 28 Apr 2015 23:58:43 GMT
+      - Mon, 04 May 2015 17:52:10 GMT
       Content-Length:
       - '431'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=TVNtUlJNdDR2eEl6VDR3Q2dlR3U1YWh5dXRVVFRtZklpaTlnUVRwTytWWUFZVnBqUjRWbnU1OHo1NDJEWjFUOEZkY3NRdmVwQzIvME9DZ3RhRjg1bWZyTnpxd1EweExZdkozcGZsZ3d3bSs5akh2QWd5emZpb2F5bWd4TGw2RkhhbjNaWEdmZlkrSlRoMjJ0L2FQUHE5aDF6Vm04UGJkSUtZSFdFMXduZFBuS3BqN2M1TG0vSm5ZVGFIYnFlV2F1OXdNWUZiWjVER0RBcEpvUCtmeVFaYzBlanEzYmtiQWNia0Y0Y3VURWxKTT0tLWtlaUJLMEsyVnJubzlXeThzWEx2V2c9PQ%3D%3D--0050ab8ac3543c89c5c42764145b1f274574b9d0;
+      - _internal_session=NTRacDMwWEhPeEVTK3R3a3RERW9WNVpsUFdwWm15azY2aUh2b0EzMEVxcThXYTFqbFBRMEJhbk56VXZKb3Bwa2dEUWdwRTg0WlBtc1BpcXF2YnhIMUMxZThWMitZOGcxNjdKdnZEUTVjeFFjTFZmT3l3WVNCOUdMWDRSWTA5OHovNGFhV3IwQmc0ZkIrZUhLTnlxRDZsdnlFRlYxRkovUUVLN1BJUmZHR0txTEI0djZaT3M5N0Y0RmRLcTMrODVSNTFWeDliWnY5alg2WXFCbWJPTk5sbFphUHl6cWViaHZFVExBZmtwajdiVT0tLXJqcHduVkFnbmcrQUdrSEx3MmRaa2c9PQ%3D%3D--621629b8ed0b82b776bd8e5a6c7bb4a111f0de63;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69850621064800","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/38b8a558-9a43-4f18-8995-f0dcdf837563","@type":"oa:Annotation","hasBody":"_:g69850621064800","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70075066584580","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/cca887fe-ce83-4b1b-a45b-bd4e613a5878","@type":"oa:Annotation","hasBody":"_:g70075066584580","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:58:43 GMT
+  recorded_at: Mon, 04 May 2015 17:52:10 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:58:43 GMT
+      - Mon, 04 May 2015 17:52:10 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:58:43 GMT
+      - Mon, 04 May 2015 23:52:10 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:58:43 GMT
+  recorded_at: Mon, 04 May 2015 17:52:10 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:58:43 GMT
+      - Mon, 04 May 2015 17:52:10 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,9 +135,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:58:43 GMT
+      - Mon, 04 May 2015 23:52:10 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -1251,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:58:43 GMT
+  recorded_at: Mon, 04 May 2015 17:52:10 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1271,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:58:43 GMT
+      - Mon, 04 May 2015 17:52:10 GMT
       Server:
       - Apache/2
       Location:
@@ -1279,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:58:43 GMT
+      - Mon, 04 May 2015 23:52:10 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1295,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:58:43 GMT
+  recorded_at: Mon, 04 May 2015 17:52:10 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1317,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:58:44 GMT
+      - Mon, 04 May 2015 17:52:11 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1331,9 +1333,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:58:44 GMT
+      - Mon, 04 May 2015 23:52:11 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -2447,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:58:44 GMT
+  recorded_at: Mon, 04 May 2015 17:52:11 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/38b8a558-9a43-4f18-8995-f0dcdf837563
+    uri: http://localhost:3000/annotations/cca887fe-ce83-4b1b-a45b-bd4e613a5878
     body:
       encoding: US-ASCII
       string: ''
@@ -2477,27 +2481,27 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 8bbd199b-6847-4601-ba1d-886f11cdf384
+      - 2164a942-83f0-475f-8a1e-cabaa497cd85
       X-Runtime:
-      - '0.230995'
+      - '0.232093'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Tue, 28 Apr 2015 23:58:44 GMT
+      - Mon, 04 May 2015 17:52:11 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=dEdOT2cxb0NtdEpyTEVhMzhCS284U3l6bTdKMG95ajRtNzE0YkVxa2NmUVZURjdSS05lK1JvRElxa0VibWN6ZmtvZFE5RENqQVc5SFdsaGc3R1I0OUZIRWRnSTByOUphVUpBeTVZaHpkY2FWN1didGpPMklIOStJR25CVDB6Zm80bDRkNW84ME9NaVlhVUliTjhRR1lTYjVmcWx1TFo5cmlNNVJCM3BpaXpraG81K1RzdE00dHNoUHBJb0hrR1lvLS1hZUs0cGgyVmw0TXplcGE5OHZtZC93PT0%3D--167a6b653d977b635c5132719aa1d1c2f011477b;
+      - _internal_session=OHBCY1phYzBSUTNSbzNzd1JVYXh3ZzdYeWdRMHVUUXZoVm1NR0VIcnk0R0VVK0JjaDFvUW83SjRMSTVIOFB0TzlsajlqS0FTUHU3OGVtaFlzYUpHK2NOQ245YVNQMHQ2Vk9XeUdkbCthZnFKZDcxZVpBS1Buakx3RjQ4ZmZWNko2bmpsVjhka1FsNUZWeGJldWtwQTRNRjdsTkI0T1pxZ0JJRXNIOVF1NUxWcWJHeFV6dXJzbyt4c1VWTmlFVE9ZLS02VWcrS1R3a1Y3RXdzcjZzaFRkZDZBPT0%3D--b5af2ab4bb3a616bec8954a47bfc007232fac15c;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:58:44 GMT
+  recorded_at: Mon, 04 May 2015 17:52:11 GMT
 - request:
     method: get
-    uri: http://localhost:3000/annotations/38b8a558-9a43-4f18-8995-f0dcdf837563
+    uri: http://localhost:3000/annotations/cca887fe-ce83-4b1b-a45b-bd4e613a5878
     body:
       encoding: US-ASCII
       string: ''
@@ -2524,21 +2528,21 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - f854d345-4503-4f7c-bbe6-9c77f5a0ccd1
+      - f1d56ad7-bf84-4ec0-80f0-dc12f4dbfe75
       X-Runtime:
-      - '0.014960'
+      - '0.014609'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Tue, 28 Apr 2015 23:58:44 GMT
+      - Mon, 04 May 2015 17:52:11 GMT
       Content-Length:
       - '146'
       Connection:
       - Keep-Alive
     body:
       encoding: UTF-8
-      string: "<h2>error getting 38b8a558-9a43-4f18-8995-f0dcdf837563 from LDP</h2>Discovered
-        tombstone resource at org.fcrepo.kernel.impl.TombstoneImpl@631298f5"
+      string: "<h2>error getting cca887fe-ce83-4b1b-a45b-bd4e613a5878 from LDP</h2>Discovered
+        tombstone resource at org.fcrepo.kernel.impl.TombstoneImpl@4788737d"
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:58:44 GMT
+  recorded_at: Mon, 04 May 2015 17:52:11 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/_delete_annotation/fails_to_delete_an_open_annotation_that_does_NOT_exist.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/_delete_annotation/fails_to_delete_an_open_annotation_that_does_NOT_exist.yml
@@ -29,13 +29,13 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - c5f45480-771d-4d6d-865b-c0e8b31fdcd4
+      - 1f92de84-879d-4eae-a591-6f7f7a8c57ba
       X-Runtime:
-      - '0.012721'
+      - '0.013469'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Tue, 28 Apr 2015 23:58:44 GMT
+      - Mon, 04 May 2015 17:52:11 GMT
       Content-Length:
       - '1452'
       Connection:
@@ -58,7 +58,7 @@ http_interactions:
         \                                               \n<br/>                                                \n<br/>
         \                                               \n\n</body>\n</html>\n"
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:58:44 GMT
+  recorded_at: Mon, 04 May 2015 17:52:11 GMT
 - request:
     method: delete
     uri: http://localhost:3000/annotations/anno_does_not_exist
@@ -88,13 +88,13 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 4db7cb2b-c3e9-4790-8c07-d6705165a6d9
+      - 8e605d20-19b6-45e8-b573-35d6818ebf3f
       X-Runtime:
-      - '0.013973'
+      - '0.013532'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Tue, 28 Apr 2015 23:58:44 GMT
+      - Mon, 04 May 2015 17:52:11 GMT
       Content-Length:
       - '1452'
       Connection:
@@ -119,5 +119,5 @@ http_interactions:
         \                                               \n<br/>                                                \n<br/>
         \                                               \n\n</body>\n</html>\n"
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:58:44 GMT
+  recorded_at: Mon, 04 May 2015 17:52:11 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/_delete_annotation/returns_false_for_a_500_response_to_a_DELETE_request.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/_delete_annotation/returns_false_for_a_500_response_to_a_DELETE_request.yml
@@ -29,13 +29,13 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 9a7c47ac-ed4a-4db6-bdd8-e39ada403c83
+      - 44a30438-8fb9-4747-8502-ee1167269abc
       X-Runtime:
-      - '0.451693'
+      - '0.480381'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Tue, 28 Apr 2015 23:58:34 GMT
+      - Mon, 04 May 2015 17:52:07 GMT
       Content-Length:
       - '1452'
       Connection:
@@ -60,5 +60,5 @@ http_interactions:
         \                                               \n<br/>                                                \n<br/>
         \                                               \n\n</body>\n</html>\n"
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:58:34 GMT
+  recorded_at: Mon, 04 May 2015 17:52:07 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/_delete_annotation/returns_true_for_a_200_response_to_a_DELETE_request.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/_delete_annotation/returns_true_for_a_200_response_to_a_DELETE_request.yml
@@ -29,13 +29,13 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 54a03ddd-2b1f-43a5-b4d8-c72183737022
+      - 0b9eea78-11ec-4cc0-8ba3-121b40f3b25d
       X-Runtime:
-      - '0.019223'
+      - '0.017352'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Tue, 28 Apr 2015 23:58:34 GMT
+      - Mon, 04 May 2015 17:52:07 GMT
       Content-Length:
       - '1452'
       Connection:
@@ -60,5 +60,5 @@ http_interactions:
         \                                               \n<br/>                                                \n<br/>
         \                                               \n\n</body>\n</html>\n"
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:58:34 GMT
+  recorded_at: Mon, 04 May 2015 17:52:07 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/_delete_annotation/returns_true_for_a_202_response_to_a_DELETE_request.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/_delete_annotation/returns_true_for_a_202_response_to_a_DELETE_request.yml
@@ -29,13 +29,13 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 6cd5362c-24e4-4a53-993c-b8da5dd566e9
+      - 11f2fbec-da74-47f4-ab83-40f5edd9ce20
       X-Runtime:
-      - '0.017034'
+      - '0.014571'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Tue, 28 Apr 2015 23:58:34 GMT
+      - Mon, 04 May 2015 17:52:07 GMT
       Content-Length:
       - '1452'
       Connection:
@@ -60,5 +60,5 @@ http_interactions:
         \                                               \n<br/>                                                \n<br/>
         \                                               \n\n</body>\n</html>\n"
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:58:34 GMT
+  recorded_at: Mon, 04 May 2015 17:52:07 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/_delete_annotation/returns_true_for_a_204_response_to_a_DELETE_request.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/_delete_annotation/returns_true_for_a_204_response_to_a_DELETE_request.yml
@@ -29,13 +29,13 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 94af5e52-d24b-49b8-b04f-ac3fc651226d
+      - f29ea6aa-f38f-4832-b440-f9ffdec13224
       X-Runtime:
-      - '0.016089'
+      - '0.016009'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Tue, 28 Apr 2015 23:58:34 GMT
+      - Mon, 04 May 2015 17:52:07 GMT
       Content-Length:
       - '1452'
       Connection:
@@ -60,5 +60,5 @@ http_interactions:
         \                                               \n<br/>                                                \n<br/>
         \                                               \n\n</body>\n</html>\n"
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:58:34 GMT
+  recorded_at: Mon, 04 May 2015 17:52:07 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/_delete_annotation/validates_the_annotation_ID.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/_delete_annotation/validates_the_annotation_ID.yml
@@ -29,13 +29,13 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 168b3109-bbca-4ff8-a32f-957923339925
+      - 61e91ea9-65d9-4bb0-8fcb-4f443375543d
       X-Runtime:
-      - '0.019183'
+      - '0.023928'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Tue, 28 Apr 2015 23:58:34 GMT
+      - Mon, 04 May 2015 17:52:07 GMT
       Content-Length:
       - '1452'
       Connection:
@@ -60,5 +60,5 @@ http_interactions:
         \                                               \n<br/>                                                \n<br/>
         \                                               \n\n</body>\n</html>\n"
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:58:34 GMT
+  recorded_at: Mon, 04 May 2015 17:52:07 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/_get_annotations/returns_an_RDF_Graph.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/_get_annotations/returns_an_RDF_Graph.yml
@@ -31,13 +31,13 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 2d7afed2-fcb8-46d3-8598-73ef581c9642
+      - 32eb4779-4ad1-4add-a872-b49f6ab48c54
       X-Runtime:
-      - '0.003327'
+      - '0.004080'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Tue, 28 Apr 2015 23:58:44 GMT
+      - Mon, 04 May 2015 17:52:11 GMT
       Content-Length:
       - '94'
       Connection:
@@ -46,7 +46,7 @@ http_interactions:
       encoding: UTF-8
       string: <html><body>You are being <a href="http://localhost:3000/search">redirected</a>.</body></html>
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:58:44 GMT
+  recorded_at: Mon, 04 May 2015 17:52:11 GMT
 - request:
     method: get
     uri: http://localhost:3000/search
@@ -80,13 +80,13 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 29d24642-5c8d-4c46-b7f0-3d32f99971c4
+      - c6e82963-b299-4c4d-877f-81d43f27614b
       X-Runtime:
-      - '0.011154'
+      - '0.013985'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Tue, 28 Apr 2015 23:58:44 GMT
+      - Mon, 04 May 2015 17:52:11 GMT
       Content-Length:
       - '181'
       Connection:
@@ -95,7 +95,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"@context":"http://iiif.io/api/presentation/2/context.json","@type":"sc:AnnotationList","within":{"@type":"sc:Layer","total":0},"resources":[],"@id":"http://localhost:3000/search"}'
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:58:44 GMT
+  recorded_at: Mon, 04 May 2015 17:52:11 GMT
 - request:
     method: get
     uri: http://iiif.io/api/presentation/2/context.json
@@ -115,7 +115,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:01:02 GMT
+      - Mon, 04 May 2015 17:54:38 GMT
       Server:
       - Apache/2.2.15 (Red Hat)
       Last-Modified:
@@ -127,7 +127,7 @@ http_interactions:
       Cache-Control:
       - max-age=86400
       Expires:
-      - Thu, 30 Apr 2015 00:01:02 GMT
+      - Tue, 05 May 2015 17:54:38 GMT
       Content-Type:
       - application/ld+json
       Access-Control-Allow-Origin:
@@ -193,7 +193,7 @@ http_interactions:
         \   \"language\":    {\"@id\": \"dc:language\"},\n\t\t    \"value\":       {\"@id\":
         \"rdf:value\"},\n\t\t    \"label\":       {\"@id\": \"rdfs:label\"}\n\t\t}\n\t]\n}"
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:58:44 GMT
+  recorded_at: Mon, 04 May 2015 17:52:11 GMT
 - request:
     method: get
     uri: http://iiif.io/api/presentation/2/context.json
@@ -213,7 +213,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:01:03 GMT
+      - Mon, 04 May 2015 17:54:38 GMT
       Server:
       - Apache/2.2.15 (Red Hat)
       Last-Modified:
@@ -225,7 +225,7 @@ http_interactions:
       Cache-Control:
       - max-age=86400
       Expires:
-      - Thu, 30 Apr 2015 00:01:03 GMT
+      - Tue, 05 May 2015 17:54:38 GMT
       Content-Type:
       - application/ld+json
       Access-Control-Allow-Origin:
@@ -291,5 +291,5 @@ http_interactions:
         \   \"language\":    {\"@id\": \"dc:language\"},\n\t\t    \"value\":       {\"@id\":
         \"rdf:value\"},\n\t\t    \"label\":       {\"@id\": \"rdfs:label\"}\n\t\t}\n\t]\n}"
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:58:44 GMT
+  recorded_at: Mon, 04 May 2015 17:52:11 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/_get_annotations/returns_an_RDF_Graph_that_contains_an_AnnotationList.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/_get_annotations/returns_an_RDF_Graph_that_contains_an_AnnotationList.yml
@@ -31,13 +31,13 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - d45cb1cb-67e9-4d2e-8bfd-b6b325213ff5
+      - 0519f25b-e937-4489-b200-a85e5de8415c
       X-Runtime:
-      - '0.002635'
+      - '0.002476'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Tue, 28 Apr 2015 23:58:44 GMT
+      - Mon, 04 May 2015 17:52:11 GMT
       Content-Length:
       - '94'
       Connection:
@@ -46,7 +46,7 @@ http_interactions:
       encoding: UTF-8
       string: <html><body>You are being <a href="http://localhost:3000/search">redirected</a>.</body></html>
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:58:44 GMT
+  recorded_at: Mon, 04 May 2015 17:52:11 GMT
 - request:
     method: get
     uri: http://localhost:3000/search
@@ -80,13 +80,13 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 5612f5c1-dc39-4e3a-8b45-ec45a9eb43a6
+      - 2ff91c14-ebb0-4d2a-bea7-8c58e4e1885d
       X-Runtime:
-      - '0.007921'
+      - '0.007865'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Tue, 28 Apr 2015 23:58:44 GMT
+      - Mon, 04 May 2015 17:52:11 GMT
       Content-Length:
       - '181'
       Connection:
@@ -95,7 +95,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"@context":"http://iiif.io/api/presentation/2/context.json","@type":"sc:AnnotationList","within":{"@type":"sc:Layer","total":0},"resources":[],"@id":"http://localhost:3000/search"}'
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:58:44 GMT
+  recorded_at: Mon, 04 May 2015 17:52:11 GMT
 - request:
     method: get
     uri: http://iiif.io/api/presentation/2/context.json
@@ -115,7 +115,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:01:03 GMT
+      - Mon, 04 May 2015 17:54:39 GMT
       Server:
       - Apache/2.2.15 (Red Hat)
       Last-Modified:
@@ -127,7 +127,7 @@ http_interactions:
       Cache-Control:
       - max-age=86400
       Expires:
-      - Thu, 30 Apr 2015 00:01:03 GMT
+      - Tue, 05 May 2015 17:54:39 GMT
       Content-Type:
       - application/ld+json
       Access-Control-Allow-Origin:
@@ -193,7 +193,7 @@ http_interactions:
         \   \"language\":    {\"@id\": \"dc:language\"},\n\t\t    \"value\":       {\"@id\":
         \"rdf:value\"},\n\t\t    \"label\":       {\"@id\": \"rdfs:label\"}\n\t\t}\n\t]\n}"
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:58:44 GMT
+  recorded_at: Mon, 04 May 2015 17:52:11 GMT
 - request:
     method: get
     uri: http://iiif.io/api/presentation/2/context.json
@@ -213,7 +213,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:01:03 GMT
+      - Mon, 04 May 2015 17:54:39 GMT
       Server:
       - Apache/2.2.15 (Red Hat)
       Last-Modified:
@@ -225,7 +225,7 @@ http_interactions:
       Cache-Control:
       - max-age=86400
       Expires:
-      - Thu, 30 Apr 2015 00:01:03 GMT
+      - Tue, 05 May 2015 17:54:39 GMT
       Content-Type:
       - application/ld+json
       Access-Control-Allow-Origin:
@@ -291,5 +291,5 @@ http_interactions:
         \   \"language\":    {\"@id\": \"dc:language\"},\n\t\t    \"value\":       {\"@id\":
         \"rdf:value\"},\n\t\t    \"label\":       {\"@id\": \"rdfs:label\"}\n\t\t}\n\t]\n}"
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:58:44 GMT
+  recorded_at: Mon, 04 May 2015 17:52:11 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/_get_annotations/returns_an_annotation_list_with_an_annotation_created_by_a_prior_POST.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/_get_annotations/returns_an_annotation_list_with_an_annotation_created_by_a_prior_POST.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"b288268e7d5d702c97f10853f0282bd7"
+      - W/"f1b746b91a599611f0ff1c1ab94d5f1f"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - d353b458-34c4-4f3b-be1d-4e37e1aea631
+      - 796addd0-100b-413f-97cd-9b4934ec1d3b
       X-Runtime:
-      - '1.504890'
+      - '1.538348'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Tue, 28 Apr 2015 23:58:46 GMT
+      - Mon, 04 May 2015 17:52:13 GMT
       Content-Length:
       - '431'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=SkdiL2c5OTFLeG1NdUtNRWg0U0JFaDBpWXpLZmJwVWIxS1p5bW5DaUpjbEVvQmZlWUZLb2padjM4RFhvTDU2M3FXcFlIOVprR0hpVS9PSTh1Z1RWU1JBNEdIeVZ1bE9YUDR1YWhzRWpiM1hyU2p3S1ZDaktZR3hrNGhCMXJPZXJYVHl3MGJYd3ZXZWlpbldIQUpDOE9DTnZnYVRUcEI3MEkwUzVtd1BDU1paSS9qbGYva0lTbURHcWtxSURYdUhXV1B6b05tNk4vM21oQWRzaWJjcGl5dUtlWmJWTWtWT2N5TzRHalF4d3d4OD0tLXorbGJlZzRIV1N0ZFZQT3ZiUG1tR1E9PQ%3D%3D--a6c79620fb55c6c9d315afda99d2ea94279c6028;
+      - _internal_session=aW96WDRhWCtSbitMRGx4cUFhOVM4S1ZtTndkRGIrSy8vTURTenBYdFcyS3lrc1o2UjFpdXVuYUVKdHJNcmdpbFNsbnpzcHhaT2RPMkZXdEtzcldqZzZpZlU1cWgxZ0IwOThMa1lxQmE0WElzK2ZtRHpWanVjNGlPMnZGUUxLd01uMzJXM2JOV2RKREZWT2taMVNzZXV1QWxvTHBVbytEbU1IUy9pT1hPM0hUd3R1UGg1WlY0Q0ttcmJYdXY5dUJXZDNjcUs3VUdINGp1cEF2bXJQTU9LNkVFMnEwVk1CTkhBVzZYY3dsU2tMUT0tLThwUkFnaGZnOU9WZFlGVnZmVWpqWGc9PQ%3D%3D--a4f96ac35a81071389676ff2fcc40c789652ea3b;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69850626199440","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/b880defd-616f-4138-a849-de4cc1103e5a","@type":"oa:Annotation","hasBody":"_:g69850626199440","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70075071578940","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/387658e8-f4fb-4beb-8b7a-cdffe66a39e8","@type":"oa:Annotation","hasBody":"_:g70075071578940","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:58:46 GMT
+  recorded_at: Mon, 04 May 2015 17:52:13 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:58:46 GMT
+      - Mon, 04 May 2015 17:52:13 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:58:46 GMT
+      - Mon, 04 May 2015 23:52:13 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:58:46 GMT
+  recorded_at: Mon, 04 May 2015 17:52:13 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:58:46 GMT
+      - Mon, 04 May 2015 17:52:13 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,9 +135,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:58:46 GMT
+      - Mon, 04 May 2015 23:52:13 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -1251,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:58:47 GMT
+  recorded_at: Mon, 04 May 2015 17:52:14 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1271,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:58:47 GMT
+      - Mon, 04 May 2015 17:52:14 GMT
       Server:
       - Apache/2
       Location:
@@ -1279,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:58:47 GMT
+      - Mon, 04 May 2015 23:52:14 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1295,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:58:47 GMT
+  recorded_at: Mon, 04 May 2015 17:52:14 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1317,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 28 Apr 2015 23:58:47 GMT
+      - Mon, 04 May 2015 17:52:14 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1331,9 +1333,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 05:58:47 GMT
+      - Mon, 04 May 2015 23:52:14 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -2447,7 +2451,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:58:47 GMT
+  recorded_at: Mon, 04 May 2015 17:52:14 GMT
 - request:
     method: get
     uri: http://localhost:3000/annotations
@@ -2479,13 +2483,13 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 1cf01595-f295-4dc5-975b-357c8e645052
+      - d035a280-dcd5-40d8-9f9a-1aa01f69dc4a
       X-Runtime:
-      - '0.004491'
+      - '0.002586'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Tue, 28 Apr 2015 23:58:47 GMT
+      - Mon, 04 May 2015 17:52:14 GMT
       Content-Length:
       - '94'
       Connection:
@@ -2494,7 +2498,7 @@ http_interactions:
       encoding: UTF-8
       string: <html><body>You are being <a href="http://localhost:3000/search">redirected</a>.</body></html>
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:58:47 GMT
+  recorded_at: Mon, 04 May 2015 17:52:14 GMT
 - request:
     method: get
     uri: http://localhost:3000/search
@@ -2524,27 +2528,27 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"f9fccee8a786846e10cbebca30242ff6"
+      - W/"b9c0f7a192754f0c98bc0ea4fe7b4120"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - f23e301d-1aeb-4c18-8663-25b24560a4e9
+      - a793b8a7-8936-4b5a-88b6-88e3fd2be415
       X-Runtime:
-      - '1.157550'
+      - '1.160217'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Tue, 28 Apr 2015 23:58:48 GMT
+      - Mon, 04 May 2015 17:52:15 GMT
       Content-Length:
       - '500'
       Connection:
       - Keep-Alive
     body:
       encoding: UTF-8
-      string: '{"@context":"http://iiif.io/api/presentation/2/context.json","@type":"sc:AnnotationList","within":{"@type":"sc:Layer","total":1},"resources":[{"@id":"http://your.triannon-server.com/annotations/b880defd-616f-4138-a849-de4cc1103e5a","@type":"oa:Annotation","motivation":"oa:commenting","on":"http://purl.stanford.edu/kq131cs7229","resource":{"@id":"_:b0","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+      string: '{"@context":"http://iiif.io/api/presentation/2/context.json","@type":"sc:AnnotationList","within":{"@type":"sc:Layer","total":1},"resources":[{"@id":"http://your.triannon-server.com/annotations/387658e8-f4fb-4beb-8b7a-cdffe66a39e8","@type":"oa:Annotation","motivation":"oa:commenting","on":"http://purl.stanford.edu/kq131cs7229","resource":{"@id":"_:b0","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
         love this!","format":"text/plain","language":"en"}}],"@id":"http://localhost:3000/search"}'
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:58:48 GMT
+  recorded_at: Mon, 04 May 2015 17:52:15 GMT
 - request:
     method: get
     uri: http://iiif.io/api/presentation/2/context.json
@@ -2564,7 +2568,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:01:07 GMT
+      - Mon, 04 May 2015 17:54:43 GMT
       Server:
       - Apache/2.2.15 (Red Hat)
       Last-Modified:
@@ -2576,7 +2580,7 @@ http_interactions:
       Cache-Control:
       - max-age=86400
       Expires:
-      - Thu, 30 Apr 2015 00:01:07 GMT
+      - Tue, 05 May 2015 17:54:43 GMT
       Content-Type:
       - application/ld+json
       Access-Control-Allow-Origin:
@@ -2642,7 +2646,7 @@ http_interactions:
         \   \"language\":    {\"@id\": \"dc:language\"},\n\t\t    \"value\":       {\"@id\":
         \"rdf:value\"},\n\t\t    \"label\":       {\"@id\": \"rdfs:label\"}\n\t\t}\n\t]\n}"
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:58:48 GMT
+  recorded_at: Mon, 04 May 2015 17:52:15 GMT
 - request:
     method: get
     uri: http://iiif.io/api/presentation/2/context.json
@@ -2662,7 +2666,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:01:07 GMT
+      - Mon, 04 May 2015 17:54:43 GMT
       Server:
       - Apache/2.2.15 (Red Hat)
       Last-Modified:
@@ -2674,7 +2678,7 @@ http_interactions:
       Cache-Control:
       - max-age=86400
       Expires:
-      - Thu, 30 Apr 2015 00:01:07 GMT
+      - Tue, 05 May 2015 17:54:43 GMT
       Content-Type:
       - application/ld+json
       Access-Control-Allow-Origin:
@@ -2740,10 +2744,10 @@ http_interactions:
         \   \"language\":    {\"@id\": \"dc:language\"},\n\t\t    \"value\":       {\"@id\":
         \"rdf:value\"},\n\t\t    \"label\":       {\"@id\": \"rdfs:label\"}\n\t\t}\n\t]\n}"
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:58:48 GMT
+  recorded_at: Mon, 04 May 2015 17:52:15 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/b880defd-616f-4138-a849-de4cc1103e5a
+    uri: http://localhost:3000/annotations/387658e8-f4fb-4beb-8b7a-cdffe66a39e8
     body:
       encoding: US-ASCII
       string: ''
@@ -2770,22 +2774,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 48b8ce07-327d-4048-87c4-9942b1af756e
+      - 8ade639a-e3cd-4aaf-8d76-8108aaae8af6
       X-Runtime:
-      - '0.215686'
+      - '0.215826'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Tue, 28 Apr 2015 23:58:49 GMT
+      - Mon, 04 May 2015 17:52:16 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=Ti9Vc2VYMzUrbXBoMVFraDdQY2ZiUEdyM21uclpBazJtbFlFZmZsbXJWVkYwek9NK05UUlJkcC9CWEpaN1NrRDdKNi90WFl5K2wvTHdqYUtyZEFRaEJ3OXpZTGVJc1EzM3piaXhpRkZ0R3MrQ3YvOGNVVDV5K1hlcHNVcTA0KzQyTm55Qkp0bUwwWGg3VzhwK0h5UUhHd3lvdlI0WXI1c2JCUldLeTl4c3drOXRHeFNVZFJvaW5vc1NMQmw3TzY2LS1peFU0MDM5d0hJL3NjVi9OTGtyL3RBPT0%3D--a18055ed296a9c904f7d53aca966e53ed561e305;
+      - _internal_session=S1Y2MkEybVFUQUY3eXJpMUZTakgvSi9kOVBtUzltVE9vNjM1M3ZKaTBLSmhUNit4cDRKWktBU2l1NFlBL1NKK2RDMEpDTThlbGg4WTV4cTQrWGRvbnFlbFVqb2F0MkVMOXk1TW1lSGNtaE00azZ5OWlMOUdtVVFwTVlHYUZIdzB1VDkyZ2lzUnU5THdqOENnRThyakYyNlFIZzByODRqb0ZyR1VWa2VlcHc1Y3JscUlEM24vcDhSR0Q2MXlZWEc5LS1QSkhVd3Bod25HOXNZbUxjQ1FSQzh3PT0%3D--bb17dd9d71d684692805ba2baf74155df9484725;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 28 Apr 2015 23:58:49 GMT
+  recorded_at: Mon, 04 May 2015 17:52:16 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/_post_annotation/does_not_raise_an_error_when_submitting_a_valid_open_annotation.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/_post_annotation/does_not_raise_an_error_when_submitting_a_valid_open_annotation.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"b03a0aaace6673efa63cc695182bd299"
+      - W/"94770b7b7959d972e3db1b7579861339"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - fa41d947-d48e-4fa6-9e14-10ff22d89897
+      - 50e8e735-1b6b-4fd2-a6b5-5ce7c20f55d0
       X-Runtime:
-      - '6.487963'
+      - '1.405835'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Wed, 29 Apr 2015 00:00:10 GMT
+      - Mon, 04 May 2015 17:52:50 GMT
       Content-Length:
       - '431'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=ckc4SzZ2SUN5blFsUExNNGl5a1B4ZmgwY0VzS2JuYlFEOEk5azd6Uk9hK0tFcUN1NW1ob052VW9nL085ZkVDZlZhUUhuZlVGcWdTbFVlM0pvVHFwYko4RVM2UUdJUCtFQ3Bkc2lEd1BtdzNYN2lBb0xWNmRxM3RrWk1UdEUwQkxtbzNHa3p1TU5LL1pkQlN3cDR2YnFrK2ZQaGNQUUY4akFhNDZvUzZXSVVqUXd0VXBxQnl4VXF2RmllaFdQRFJTVHdTUGhneXNJNVFDbEc4cjZ5TG1GVjNYeDNOQTE4cndDZHdPUXBlTnFiST0tLTdSbHN2M2NZMGhNa1RVZEpxVnVQeWc9PQ%3D%3D--af9bc7d59a6e39b3bbb5a95903ec786658c8f563;
+      - _internal_session=ZXNIRXlicUJyNTBvd1NsNU1UVW9SOHZjbzMwVFhDeDZHVmdwM2ZpR2Vyd1lIRTJCTlpnblRxa3F2ZUZjN0NITm5wcDduZDVDS0NPV3FoNjNXcjhjQVF5ZElCS0h2NHNUYzVJVFZRbThwbzlSQVErQ3hXZVVZN01Md3NXNVdTZzlYeTVmQysrdHU1bi92K2d6dEx2VENrSDNZTkJHNk1NaXJFZ2MwdWhYOTZoYjFPczJGVitDbUpYLzRlM2MwMWVTdVBaaU40RjBzTVliWDAwRWg0VTZUM2g5czA0Z01GRVBsZzBtbDhteU5SUT0tLW5iblJKV2N1ZHFVSU5zUXZiczV6eHc9PQ%3D%3D--d0d3b6787ce0e7cd3fa9d8f69c75dbe188cc6453;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69850615581060","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/c737a7e2-10f1-4820-8616-3ed1bd053a93","@type":"oa:Annotation","hasBody":"_:g69850615581060","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70075071189060","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/73527cd3-c1ce-44c1-85ee-46e0773639aa","@type":"oa:Annotation","hasBody":"_:g70075071189060","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:00:10 GMT
+  recorded_at: Mon, 04 May 2015 17:52:50 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:00:10 GMT
+      - Mon, 04 May 2015 17:52:50 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:00:10 GMT
+      - Mon, 04 May 2015 23:52:50 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:00:10 GMT
+  recorded_at: Mon, 04 May 2015 17:52:50 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:00:15 GMT
+      - Mon, 04 May 2015 17:52:50 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,9 +135,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:00:15 GMT
+      - Mon, 04 May 2015 23:52:50 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -1251,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:00:16 GMT
+  recorded_at: Mon, 04 May 2015 17:52:50 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1271,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:00:16 GMT
+      - Mon, 04 May 2015 17:52:51 GMT
       Server:
       - Apache/2
       Location:
@@ -1279,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:00:16 GMT
+      - Mon, 04 May 2015 23:52:51 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1295,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:00:16 GMT
+  recorded_at: Mon, 04 May 2015 17:52:51 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1317,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:00:17 GMT
+      - Mon, 04 May 2015 17:52:51 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1331,9 +1333,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:00:17 GMT
+      - Mon, 04 May 2015 23:52:51 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -2447,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:00:17 GMT
+  recorded_at: Mon, 04 May 2015 17:52:51 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/c737a7e2-10f1-4820-8616-3ed1bd053a93
+    uri: http://localhost:3000/annotations/73527cd3-c1ce-44c1-85ee-46e0773639aa
     body:
       encoding: US-ASCII
       string: ''
@@ -2477,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 221edf82-1240-4818-b1a8-6262fbd62998
+      - 8e4ae5b0-3a8d-412a-ba71-14d7b493984a
       X-Runtime:
-      - '0.141075'
+      - '0.132547'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Wed, 29 Apr 2015 00:00:17 GMT
+      - Mon, 04 May 2015 17:52:51 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=RGJwTVE5T1U2RGtGQ2d6VG5LQTFuRFR5bmNvUW4wMG51UFRiU0d2ZG1DN1FqSk9FN29aOTNDNXVPajVVSnFDb2M0VHZ0UTRTa2hwak9ybjZpU0ZTVVRwV01PYzlPSk92TEtCd3d5VGxtVi9HT0RGVzdST01tZGRWQnRVc1d2aVhPdTIwWkJNdXQxa3Y0OUpWWXU2M1JRa1BqQkpyT29oRkNVOTlUT214cmlzZkRKNEJieEF2OU5tREJvQ3dBL2EvLS1JTEc0U2E3MDUvUWVET0JiVWtlL0NnPT0%3D--5fbe1af987655b6a25b1de07cdce1791e9e41e66;
+      - _internal_session=SVllQUUyVEoyWjNtbnkwZ1g0d1RLUnFIenNJKzJ3RW9GWlpDdTQ4c3JpcXZCMTVRdHRCZU85TTdMVWNUUnB2U2NOc3lRWXVVQmttSE1CVlpFeGw3MWs5UzZFeEVENEtnUGpBZXZUU1QwY3RweElFYXFYZUF5bTd6QXNqYS9VbE1semJiemgxbDNXWDZLcmpnT3FqODA2NEQzc3VQUGdRU3VaczAreHFJY1RVaGRyRVNtKzFua1g2bWhHQzFRS1pjLS1kY25jenMyei9WY3JxM3B6VDNoK2xBPT0%3D--a0e2701ce4f25db4590c47fd63a78cfd0c2131ef;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:00:17 GMT
+  recorded_at: Mon, 04 May 2015 17:52:51 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/_post_annotation/returns_a_RestClient_Response_object.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/_post_annotation/returns_a_RestClient_Response_object.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"2eb3b96e7176b8bcad58fe6f4a87f4d6"
+      - W/"6aef7e454b385e5f7666d734e64ffcb0"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - a7552140-2058-4fbe-901c-8b9b05480e2e
+      - ae05a11f-6b0a-4400-ab2d-669e6c3a27ab
       X-Runtime:
-      - '1.354255'
+      - '1.383346'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Wed, 29 Apr 2015 00:00:19 GMT
+      - Mon, 04 May 2015 17:52:52 GMT
       Content-Length:
       - '431'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=bjdGNk9BMURZQlJaU1RrWmdFN3FLQlFmNStsSjZFSERnZDRVSGRNUFRiY1Nlb0R4ZmFoSUlhN0xBbWlRcjVhS1MxV2xyMy90SmxMWm5yRmsxVm1qVkx0TzhUdTV5UExtTlczbC82VyszTjZveXpZRXJlbmM2U3laQzgra3dPay9ZdGNodVlwQmE4d1Uvd1ZSSW1rQkh1QTUvR0d4K2ZTbkZpWExHOGVUSHg2Q2RRYlREeU5rOVkvQVlNaitNdnBQcjJMZHE2cVc1cHV2MGV3QXpyL3hjK2x2Yml5S1p6cjRPVDNkd2oxVTVnST0tLTZCeStOaGpRbzMyWDJ5VUpxazllc2c9PQ%3D%3D--7bc9d5da0989102c1c08efc466c019f7634568ba;
+      - _internal_session=YWMzL0NHN2o0T3NnNzRBZWpxMmZYZGd1KysyeW1ZcUF2OHFBSTUzaWlrOG1XakJLQXdyWlk2RkhZQmZYQXBwK0VJOVE3MHJuMVJaYUxuaUtXbmRsdmlQR1I2ZUJQMlAySThBL1NpUy9RRzNISDZZTGVmejNNQ1JmVDRVcFlEUEJKS004b09lNnBRcUhxSUc3RHE0TStFOUhvYVVmbVdpQjRRYnZZRk0xNFI1YWtsNkpVU0QrbVlObmlJK1crZDRnRTJ5WnpZb1dFVzNFU01FVEJJUFNVMy9FWGRGYzVnK2pJMmlFNmhHemo2Yz0tLXRreDJ5Rlh1cS9wMXYyMnc4aXh6akE9PQ%3D%3D--f14f405a81a52c3ea889fc28e0c28afcf01cab39;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69850620942600","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/2219ce3b-a3f5-44f9-ae47-f96772c322ac","@type":"oa:Annotation","hasBody":"_:g69850620942600","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70075009568160","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/53a7e711-594b-46f9-8346-499a226277a9","@type":"oa:Annotation","hasBody":"_:g70075009568160","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:00:19 GMT
+  recorded_at: Mon, 04 May 2015 17:52:52 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:00:24 GMT
+      - Mon, 04 May 2015 17:52:53 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:00:24 GMT
+      - Mon, 04 May 2015 23:52:53 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:00:24 GMT
+  recorded_at: Mon, 04 May 2015 17:52:53 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:00:24 GMT
+      - Mon, 04 May 2015 17:52:53 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,9 +135,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:00:24 GMT
+      - Mon, 04 May 2015 23:52:53 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -1251,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:00:24 GMT
+  recorded_at: Mon, 04 May 2015 17:52:53 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1271,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:00:24 GMT
+      - Mon, 04 May 2015 17:52:53 GMT
       Server:
       - Apache/2
       Location:
@@ -1279,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:00:24 GMT
+      - Mon, 04 May 2015 23:52:53 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1295,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:00:25 GMT
+  recorded_at: Mon, 04 May 2015 17:52:53 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1317,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:00:25 GMT
+      - Mon, 04 May 2015 17:52:53 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1331,9 +1333,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:00:25 GMT
+      - Mon, 04 May 2015 23:52:53 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -2447,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:00:25 GMT
+  recorded_at: Mon, 04 May 2015 17:52:54 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/2219ce3b-a3f5-44f9-ae47-f96772c322ac
+    uri: http://localhost:3000/annotations/53a7e711-594b-46f9-8346-499a226277a9
     body:
       encoding: US-ASCII
       string: ''
@@ -2477,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 18b5455c-7fce-43d0-9436-19fa13ca6ceb
+      - 6580b916-95d5-466f-9d6c-c068304325de
       X-Runtime:
-      - '0.132412'
+      - '0.135367'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Wed, 29 Apr 2015 00:00:25 GMT
+      - Mon, 04 May 2015 17:52:54 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=OEZoNE5DZUtqTG5GRmJyZlR6NFN0M0hTTDZiRkxQSExidVFsKytwMWJZV1VZQmg1NG9vOFdzWmFSeU8yQy9TNlliMFRZSXptYmtGcFVBOVArelp6U0I0Z2RseXVjU0xYcEgycmp0eHVha2FRM1lDVTFHMndEajAxZVBMZGhnREFoUElPVFZzZXUvSDFpRk9ybytPUW5qOFhvMXRkWDU4dzZEMmNQVHpPZVRUeGVqOGJqNE04Ty9NaC9tYmpxUDF5LS1NcjhlQkdEMTd2SDlVQlJmZE1VL0pnPT0%3D--e335afe6492259e03dc1c0a65af724a167b98488;
+      - _internal_session=R2tzY2s2OURyeEEyVkZ5Y1piTWV4a2d1WnNmVnd3U2pJTmZoK3oxNDBaQUhnYWR1T1pqREc1UGF1eDF6YnN5T01KNTE0NGxPU1g0cm5JNEtqMEFUYW0xMElicGF3SWNkaDE0RHZhQTJRWHNIQjVDWUN6YjBBRndSTndkcmJvOUNCdlpJb3IwYUJHUEFiOElJMXBHUkl0QUl4Y08vNGJranlBNjNHNnA5YTNaTU9YZXlnVDl4V0NuUnR0Zi9nWmhYLS1hdFBVYnpRK2ZNN3hhMWl4OGRueSt3PT0%3D--a7fd0da6b41661d86afbfcbfc68665401b56b293;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:00:25 GMT
+  recorded_at: Mon, 04 May 2015 17:52:54 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/response_processing_utilities/_annotation_id/returns_a_String_ID_from_the_RDF_URI_of_an_annotation.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/response_processing_utilities/_annotation_id/returns_a_String_ID_from_the_RDF_URI_of_an_annotation.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"4294253367a7baffc708b4dc143b37e2"
+      - W/"3be7a0aad496fe7588081f8372d0a1a8"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - a93e8616-3fc8-4704-86b7-6f385aacab77
+      - b7923e5a-430d-427f-b579-0396c6317123
       X-Runtime:
-      - '1.359844'
+      - '1.413728'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Wed, 29 Apr 2015 00:01:29 GMT
+      - Mon, 04 May 2015 17:53:13 GMT
       Content-Length:
       - '431'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=Rk1ZcFhlQ3NRanJQOHhrNTFJVUIxbFNnWklRcUgrdUhyVFZqWXpjalFZMHJSWWRobFpxRDkrcjQ5UVVtUFVnajZ2TTUvaWFISjJORUE2U1VLeldOaUJsSktDeDhpYnVJRzBiYk0wUTlYTDdFSjFZUWpoekhjSm5yc2cxcTVSZUxEYTYyZmFIOWhaSGpHdkpaL3pxdXVSejU4MVNNYnR1Z0xGdnlsZGpzSTRXdU41N29iU1lXWG45K0ZuSUd0c0Q0Z1lVL3pSbUpJdDVqNmQvdmJ0T2Frc09kUVJiWTlOeVRWODZEUXRDSDF4MD0tLVZvSmwwUWRrOG81dXgwOGpBNnhCTWc9PQ%3D%3D--6f1de064ff8a5380b88b3c3f265d7842d8d16aa2;
+      - _internal_session=OXZYcGhMUkg0TnZWdldoTDYrY2RjUkhWWGdpVm1zWmh4aUp5aWZhTzR6Wm5jMktRNHpHdVNxeVBUb05ES1RsbG5NMHVUVEtpL0RFemgvK2NFWXFtVmlrbnBKakdodlhHUXRFZkJrWE9kdHFHK2pDR2M3aUUyTmZjYjU5NmZtbmxxUUhlWno4L0tjUEVDM3YxVzh0ZHJNait0TnlhQUkxYlRiTVE3eXhTVnpIalRHeGlRczkrZ3NRV0dRaWZ2YUFBY3g3M0F1WEF2OWNqaW1qSHoxYWJZUWNxRmZiWlFmWU9ubXdHRTVUY0RWbz0tLTNBYWJUd1VEMFBoU3VlaEVaa1BpSFE9PQ%3D%3D--6d89cff817ca6511651c77da9cdfaaada055bb02;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69850566411600","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/eaeedf9d-c1e8-4ba8-b94d-db3dc7b34af5","@type":"oa:Annotation","hasBody":"_:g69850566411600","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70075068894240","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/d0117729-d1ad-45d2-996e-f12327a96dae","@type":"oa:Annotation","hasBody":"_:g70075068894240","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:01:29 GMT
+  recorded_at: Mon, 04 May 2015 17:53:13 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:01:29 GMT
+      - Mon, 04 May 2015 17:53:13 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:01:29 GMT
+      - Mon, 04 May 2015 23:53:13 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:01:29 GMT
+  recorded_at: Mon, 04 May 2015 17:53:13 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:01:29 GMT
+      - Mon, 04 May 2015 17:53:14 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,9 +135,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:01:29 GMT
+      - Mon, 04 May 2015 23:53:14 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -1251,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:01:30 GMT
+  recorded_at: Mon, 04 May 2015 17:53:14 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1271,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:01:30 GMT
+      - Mon, 04 May 2015 17:53:14 GMT
       Server:
       - Apache/2
       Location:
@@ -1279,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:01:30 GMT
+      - Mon, 04 May 2015 23:53:14 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1295,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:01:30 GMT
+  recorded_at: Mon, 04 May 2015 17:53:14 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1317,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:01:30 GMT
+      - Mon, 04 May 2015 17:53:14 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1331,9 +1333,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:01:30 GMT
+      - Mon, 04 May 2015 23:53:14 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -2447,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:01:30 GMT
+  recorded_at: Mon, 04 May 2015 17:53:14 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/eaeedf9d-c1e8-4ba8-b94d-db3dc7b34af5
+    uri: http://localhost:3000/annotations/d0117729-d1ad-45d2-996e-f12327a96dae
     body:
       encoding: US-ASCII
       string: ''
@@ -2477,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - a9a4d6e8-caa1-4477-b10f-dc2c485e022c
+      - 68a23a7f-da52-4b2f-8ff1-41e44a855eb3
       X-Runtime:
-      - '0.136995'
+      - '0.133964'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Wed, 29 Apr 2015 00:01:30 GMT
+      - Mon, 04 May 2015 17:53:15 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=VXFCaFEvWi9YempiVnV4QU1qUTcwMTJ5WC9KNHdmakF2RmJreFFod2JaT2tNMHVHSlpTVS9iZjljQTlSLzhsM2VrWDY4UlpScWYzeEJyMHcvM1Y4bEc1NUNrcXNSbG8rK3V4R0xJSnpzR2U1T0UxQ0JLaWJpbUR6alRLSzhpdDBIaEtZVW9obERaMk01clZXNDM3cnRUS3V2SFhmSDdsd0xRdlhvdmIrMVJPV2FUMEozNk53UUxLSEV5aUpJUFZLLS02WStvajhOenJtZ3RjU2xkR2NmS0l3PT0%3D--defcabe69c407c7fc8fd3a6a4c5a0135b45bbb3d;
+      - _internal_session=amRKZi9BRVU1cHFlSFhvNnFOSnJiamU1K0tpNFJkV25rZEt3WlloWDFEbStsdyt5S250Rk0yTXp2NmlzQm1IMTZvRGNPVDJmZ2NoUXJtUnVvT0JWTG5wSm1GU2l5YTR2V1NraTJ6c0cvTFBDb2RuYmtxVU4xWFFTUDZjT3NFeFQ3eVhkUGp2enk0OXVFUVFaWHlyTzRYV09DSVU5MkNLOU5zaWlSZnVHYUw4WWpMa0NwaXRqYnpwdGhuTllaT1IwLS0vcmY4dXB3Q2Rna3p6L0NqYkdOeHh3PT0%3D--f6f6cb5cbfe3d9561aa3a09a3c1d4375c0cb7dd8;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:01:30 GMT
+  recorded_at: Mon, 04 May 2015 17:53:15 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/response_processing_utilities/_annotation_id/returns_a_String_ID_that_is_not_empty.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/response_processing_utilities/_annotation_id/returns_a_String_ID_that_is_not_empty.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"c9b2d30f00f3cefacb930cf2aec07447"
+      - W/"71349a29210f596e369afc20afb28d48"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 5d733afe-0e34-4802-8c6c-14c2cf639552
+      - 575f3783-e7f9-4d7e-8cc2-1dc1b12193d9
       X-Runtime:
-      - '1.388506'
+      - '1.383847'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Wed, 29 Apr 2015 00:01:32 GMT
+      - Mon, 04 May 2015 17:53:16 GMT
       Content-Length:
       - '431'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=TlMvYkFqT29PUnBnQmY4d1BrYWJ6N1pLUTdGSGkrUzVYRTNyRVNuY3kvdmc5QjF0elRDNTdRYmVwK0dVSTdTbXV0RWRsOWpSQUVSUTArY3VJNjFYb1NFdHErZUhqSWRMK1RKeEV1WmxuM3g2SUg2VzdPbzR6UVhhL2NreDFoQjFOcThJTmVwN3VIYTRmWHMxTUNJTEpSZ084ZmVkV1NzRWdEQmE5VDZZQ2hVQ1JIdzB2WVB6amNEZHdPeGVLamppN0dqTFNHYzI1S01Ob3VDYUh2VEEvYUMrWkgzV1FZL3FscXRiTVlOWXBmST0tLVJzZjQzOTJLTmFyV2U4eU0zbSs1MFE9PQ%3D%3D--3f3c33cfa06302aac78eec17b91e5a7d3026ebc2;
+      - _internal_session=K1BUMHE3NGlHN3RQNlU4cEFyczJlK1hBaW9iTkV0eWxhK0RKU0Z4N0xRZmRFTDZSRmRpMW53czRreTFISXhMOWpPaVFkaFU4VXp5OXMxbzJmRWZRT1lad2gxaTR6SjNkVHYrWWVzeTZMcFBDSUVJRFpSWHpUZ0p1dWg2L1lFVlQwRi9ZVnE3OXI0eUNYcnc0TVcvTlg0ZTh6aDI5eHhXM242MGNNQnljN2REL01XTXFDM3hvS0N3SGhyeWJQSVB4eFo4aE5ackVmenRhZWlXYnhNc2MxK3lTRFAwdEtPcnJ3UUlIRWhLKy9hUT0tLW1LYStJbFQ2ZEJxT2F6KzJLT296Q0E9PQ%3D%3D--d38adac8544b888a32b1c2999fedf225ba927163;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69850778063180","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/52b1d866-e1f6-4734-aa4f-b9d1fd1ac188","@type":"oa:Annotation","hasBody":"_:g69850778063180","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70075073584500","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/bc266767-fa4c-4890-ace5-9f18ef113ed0","@type":"oa:Annotation","hasBody":"_:g70075073584500","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:01:32 GMT
+  recorded_at: Mon, 04 May 2015 17:53:16 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:01:37 GMT
+      - Mon, 04 May 2015 17:53:16 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:01:37 GMT
+      - Mon, 04 May 2015 23:53:16 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:01:37 GMT
+  recorded_at: Mon, 04 May 2015 17:53:16 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:01:37 GMT
+      - Mon, 04 May 2015 17:53:16 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,9 +135,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:01:37 GMT
+      - Mon, 04 May 2015 23:53:16 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -1251,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:01:37 GMT
+  recorded_at: Mon, 04 May 2015 17:53:16 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1271,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:01:37 GMT
+      - Mon, 04 May 2015 17:53:17 GMT
       Server:
       - Apache/2
       Location:
@@ -1279,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:01:37 GMT
+      - Mon, 04 May 2015 23:53:17 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1295,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:01:37 GMT
+  recorded_at: Mon, 04 May 2015 17:53:17 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1317,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:01:38 GMT
+      - Mon, 04 May 2015 17:53:17 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1331,9 +1333,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:01:38 GMT
+      - Mon, 04 May 2015 23:53:17 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -2447,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:01:38 GMT
+  recorded_at: Mon, 04 May 2015 17:53:17 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/52b1d866-e1f6-4734-aa4f-b9d1fd1ac188
+    uri: http://localhost:3000/annotations/bc266767-fa4c-4890-ace5-9f18ef113ed0
     body:
       encoding: US-ASCII
       string: ''
@@ -2477,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - e6e57e10-205c-498b-a603-3937daf1aada
+      - 64c54f5a-0bdf-4b43-a793-3ca608fa7417
       X-Runtime:
-      - '0.165245'
+      - '0.130666'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Wed, 29 Apr 2015 00:01:38 GMT
+      - Mon, 04 May 2015 17:53:17 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=TGp5QVBXY0VMSzNzUFVIUG9DUDAwaWNNbFFKbFQyWGpYM1NzOFRTTXpNU01WRDVGdXNiaElSQWJ6Ynp2SjY0eXlQTG1zOGt0ZGwvcmxSZzJQM3E4V05JeitiRTVrdERkT2tVZ2wwbVNTSkM1ZmtDa1BZQWRVSmt6UFEwM040RTdxNDAyM3BMYUdzaVl3bmJwS2ZNNnhBRkR4ajdZU1VmK0wvL0NCRkU3ODFaNWVjaTRTY2thUkJLa3cweFJORG1ILS1lTUw2OTdDWEVlSjh6SlZuRm8rRmRnPT0%3D--353b52053843949ab7caa61eb3372deda361b884;
+      - _internal_session=QWpNZGpacHFtSjF1YTh0MHUxS3VBUng1cHZiVXhtbkJSSmNTTUtmQSt4a2RQN2tDSW9DcUZnakhaU1NUK3RSZlpjTTdWYkwxc1QwTnd4K09tZGlsamJIeGpsbDdibkVXQWE0V0NBM1UrbmJHQkpMa3J4WW5tdlUyQWYxaDlYcStPQ0UybklzTThaMUFZbXJSYUxsK2ZzY0dpSlFiM2hkdVplRHNMUy9aSHVHTStSb25Vd25BUzdDcG5pYUp6Tm9DLS1CUjMveWpJbVRmRjRHbWlJaU0zT0xRPT0%3D--2f98bd8d3fb9b256e684cc28dc78aa64897f5045;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:01:38 GMT
+  recorded_at: Mon, 04 May 2015 17:53:17 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/response_processing_utilities/_annotation_uri/returns_an_RDF_URI_from_an_RDF_Graph_of_an_annotation.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/response_processing_utilities/_annotation_uri/returns_an_RDF_URI_from_an_RDF_Graph_of_an_annotation.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"b895ed2a4a7120997f9d080ffea2d17d"
+      - W/"934547942e4df935c877c5fc6c5cf1e4"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 0cd9b379-0cbf-4671-8006-de3b3fd9e5da
+      - 9115bb27-33b8-4ecb-a33e-7de86ca42381
       X-Runtime:
-      - '6.399008'
+      - '1.369645'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Wed, 29 Apr 2015 00:01:18 GMT
+      - Mon, 04 May 2015 17:53:08 GMT
       Content-Length:
       - '431'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=bUpRTU5zMU1OWVRianBmd1R4NmtMcUVnMEptd2ZKNGlCMEloR1EvUjlZSGo1QXVhbmVUMTRuWG14OXI1ckdIQ3Rwc2RybXluTmRNcnd1NVBEV2JwWGRqclNYNEN0UkphajIxRi9sL2JzVFdYZkFzYkVSRlF3d3VMbm9wNU4yTFpTaWhDNUF3VnA0Y25UZXNTdU5zZ3JvZG9la2xsTmEyLzBJNlZzZzhVUHlwM3ZxUGlPMXFvQUV6Sk1YdzBrVWNlVHlmbU1IaWdXdVAvS01QcTZsb3ZiTWJkM1NPeG1xdHk1R3VFVm0xNGIwQT0tLWJIZlVrVlhyKys1NElHTVZELzFTZWc9PQ%3D%3D--603c5885bad4f706302e5476956dd08c3277f3eb;
+      - _internal_session=ZzJpVm9leDVzTkZJWW5BcFJYUWNCYTRRSGhjS0JsOFVCUnNKanFyVkc3N004b2l1akkxQ2l3QnRNOW0vZjVMMDdmek9oa2ZXc2pVYWtZclV6cEdwMVdWWHRoVGhZK3Job1lRTE1PVW81YWFmTWtkdGhPb3lyeWU5bks2R2NlS0FhVzRFOWhTaXNzUkRCQVNqcnQ5ZE1PLy9tSENoa2p3a0lYaSsyVnF5WEk0QWd4OHdmb3lwSnhQbVZxR0ttOUdSZzdHZ2NzZjBMbk5QMUwxdkNNdFNYc1Nxa2haZEFQZzBtaU5oT2ZMaStjOD0tLW1paU43SS8rcC9rS3BWZE9oeDE1K3c9PQ%3D%3D--208b38cdaeb1f277759963be013c84dbd8fd9d1b;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69850619213000","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/aad7d43a-1426-4bda-b0d3-30c338d48b9f","@type":"oa:Annotation","hasBody":"_:g69850619213000","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70075070962920","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/9523f958-9452-4214-8245-aa0715d8a09d","@type":"oa:Annotation","hasBody":"_:g70075070962920","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:01:18 GMT
+  recorded_at: Mon, 04 May 2015 17:53:08 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:01:19 GMT
+      - Mon, 04 May 2015 17:53:08 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:01:19 GMT
+      - Mon, 04 May 2015 23:53:08 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:01:19 GMT
+  recorded_at: Mon, 04 May 2015 17:53:08 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:01:19 GMT
+      - Mon, 04 May 2015 17:53:08 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,9 +135,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:01:19 GMT
+      - Mon, 04 May 2015 23:53:08 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -1251,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:01:19 GMT
+  recorded_at: Mon, 04 May 2015 17:53:08 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1271,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:01:19 GMT
+      - Mon, 04 May 2015 17:53:09 GMT
       Server:
       - Apache/2
       Location:
@@ -1279,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:01:19 GMT
+      - Mon, 04 May 2015 23:53:09 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1295,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:01:19 GMT
+  recorded_at: Mon, 04 May 2015 17:53:09 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1317,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:01:19 GMT
+      - Mon, 04 May 2015 17:53:09 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1331,9 +1333,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:01:19 GMT
+      - Mon, 04 May 2015 23:53:09 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -2447,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:01:20 GMT
+  recorded_at: Mon, 04 May 2015 17:53:09 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/aad7d43a-1426-4bda-b0d3-30c338d48b9f
+    uri: http://localhost:3000/annotations/9523f958-9452-4214-8245-aa0715d8a09d
     body:
       encoding: US-ASCII
       string: ''
@@ -2477,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - d7c94928-8cf9-47be-bf06-b55f5ad4075f
+      - c9dc1977-680b-4156-8b35-04c80d6a6700
       X-Runtime:
-      - '0.154282'
+      - '0.147403'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Wed, 29 Apr 2015 00:01:20 GMT
+      - Mon, 04 May 2015 17:53:09 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=dWxNWGcxNUpxL0xXQ2tTUnh5emFrS2hFQTdLUCtmTktvTjNZRnNRUzJxWnVZVEIySi9qMUZkWGw5dUVzSllOV0dNSDNqSUdMZGFSQTU0VmNSRUxTWVdpSUY4L3VnWTl5NTVrSWtadVgvWjI5RFF0NkRGRWZoK3ZnQlVuVHFNZEJrSjFtMnFHakVtaVBQY01vMVFIRWJXRkozQU1CREdyR3p3VW1pbHBxcVp2UmJQUDAvSmU4V3gramtIZmZDbllWLS1tUy9WNGM2c3M2cnlOVVkveTBoa013PT0%3D--7ff06c294ec7c6f86234905caab508109cf827cf;
+      - _internal_session=aSs5cnNwMzZ5TGZOV1FYR0Q5Tm1teWpkUEFPMDQweWpwdzVUKzIvVnBJZjZKZ3dnV0JxYyt0M2J3cGN6OU1EOGFHQjdLbHRPNzcwQ0tkWDlxREloeFJnTk5INzMvaWNuZHczVC9la0hQQnZBK3dtYncrRWZNclphd2JHdnlweVBQU0lYTS83Wm1yYkFvMlpoQ0NlWnJBeXlYU3pVQmpnNGNXRzVPZUxYUXJSRVpFcG8vRXpocW8xRGIrSTV5bjVaLS1rM3M4WCtBdFpXZkk4eXdIbjlSNmRBPT0%3D--196aa345ae982d0250d6e5bf6af3243bf109019d;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:01:20 GMT
+  recorded_at: Mon, 04 May 2015 17:53:09 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/response_processing_utilities/_annotation_uri/returns_an_RDF_URI_that_is_a_valid_URI.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/response_processing_utilities/_annotation_uri/returns_an_RDF_URI_that_is_a_valid_URI.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"13356f76d94e6ea9c7750c8a1563ff58"
+      - W/"73fbf43229f21a0e60bdf6c43f7061ab"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 0169fd6b-776b-4a1d-ab13-581819b1faf6
+      - 33a4527a-d87f-4b6f-bab0-37bf8bd58107
       X-Runtime:
-      - '1.440347'
+      - '1.406326'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Wed, 29 Apr 2015 00:01:21 GMT
+      - Mon, 04 May 2015 17:53:11 GMT
       Content-Length:
       - '431'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=Q044SDB6VkZJQlBRSXRabTcwTFNIQmdxZnBqZDBHY3pQVjNoZFB3aXpPckpia0sxVjBGREJTTFN5Sm1pNDMwWWp4d0dQQitaT0NNNTBValA2KzYzbUVkNHN2ZU16NWxMTW91eTJVajVOWkVlS3BOWVVJdUhiTVk2ZDJsUjY3c1pJUFV3Q3lUMjJDY1FMWVcwYXBJVkUwVDZDOW0zVGxqa3ZPS3FIOUhGbVVBdVhORWpaanU2NFRlNUNEMWY2ZFNiM3RuUGNRb3p2QzljeDJWWld2UjkwSWVib0xIMlVEUmIxVGdFRnRJQ2hWOD0tLSt3cy9OaFlqODBsS1l6NWdhQ1RNYkE9PQ%3D%3D--8b3693a50a19882dbbe97ff6dc461425367f7ceb;
+      - _internal_session=d0RGN24rZ2lBWk52Tk9PLzhGaWdBd3piTkVtWUJTTjBKTzI3UkpmMU9tem9MZk1pREFxVEhOZ0xtZjRmL0hzamRDTld5R2cyd3huK3hOeGZzaGVraVI5THhQZ3QrUkdWVVJNUUkxdjJZZmp4NGhPeWNVYTVPbTNWamhpZEF4Y0RYMm9xYkY2MDJQNittUjhHQm9kL09SeDdSbE5KdlBRK25xUnBrMXFYQ3ZmeFJvTHF6c2lTdHVScWVhTGNjWUVzdk5KMEF5c3pNSFZXb3EvZWNVeGUvblNXa3ZTaVgwNW5xWWxQcHU2NndJTT0tLVQyMnBZK3hMYm8rOHpQd1h6djJGYkE9PQ%3D%3D--78041c59b8214c3026039dd064b8ec8dd9bea385;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69850780370500","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/8ebc4de8-25c3-4ecc-a44c-6b0d69cc5b86","@type":"oa:Annotation","hasBody":"_:g69850780370500","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70075075256140","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/4944b78d-65db-4b8d-a3d1-43e5150eb87f","@type":"oa:Annotation","hasBody":"_:g70075075256140","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:01:21 GMT
+  recorded_at: Mon, 04 May 2015 17:53:11 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:01:21 GMT
+      - Mon, 04 May 2015 17:53:11 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:01:21 GMT
+      - Mon, 04 May 2015 23:53:11 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:01:21 GMT
+  recorded_at: Mon, 04 May 2015 17:53:11 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:01:22 GMT
+      - Mon, 04 May 2015 17:53:11 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,9 +135,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:01:22 GMT
+      - Mon, 04 May 2015 23:53:11 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -1251,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:01:22 GMT
+  recorded_at: Mon, 04 May 2015 17:53:11 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1271,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:01:22 GMT
+      - Mon, 04 May 2015 17:53:11 GMT
       Server:
       - Apache/2
       Location:
@@ -1279,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:01:22 GMT
+      - Mon, 04 May 2015 23:53:11 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1295,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:01:22 GMT
+  recorded_at: Mon, 04 May 2015 17:53:11 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1317,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:01:27 GMT
+      - Mon, 04 May 2015 17:53:11 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1331,9 +1333,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:01:27 GMT
+      - Mon, 04 May 2015 23:53:11 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -2447,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:01:27 GMT
+  recorded_at: Mon, 04 May 2015 17:53:12 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/8ebc4de8-25c3-4ecc-a44c-6b0d69cc5b86
+    uri: http://localhost:3000/annotations/4944b78d-65db-4b8d-a3d1-43e5150eb87f
     body:
       encoding: US-ASCII
       string: ''
@@ -2477,27 +2481,27 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 426f4539-b2b5-4c92-9e43-6db3e868e071
+      - 7cc4bc3b-5dbc-4e7a-be8a-83dd217dd83c
       X-Runtime:
-      - '0.158014'
+      - '0.133060'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Wed, 29 Apr 2015 00:01:28 GMT
+      - Mon, 04 May 2015 17:53:12 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=NU5VaGE2WDlkOGhSWlNheVhvT2pXZllRZDFMSkdYbi9QeDBZaWhZT2lUVVI2czJDU0kvbnBmclEwUkk2enl0N0NsRU91ZEZRTDNMOGRWQ3FyWDhIR2N2Y3ZZZCtEYVprNHF4ZTBZeTNkbXViUGMrRFVHM283VWF1b1ZDMnBBS2ROMWFDQXdLbGs5R0dwM3ZPbm14cHN4NXR4cExxeER1MFZtN1ZPS1l5eHRHeFJnRGU5Ny9sRG90T0YrbGtuc1pNLS1BUStNakxnOTJ0ZXU1TWFqRUxPSENRPT0%3D--6b80e14158968a6f50874ac8c81d1aa1749074ce;
+      - _internal_session=V1hDRVd4UzZtbTRZMHoya05XTURtVlkwTHNxK2tidVFnSmhjSXBqSi9qTzZBZndmOVBWbWlvZUJTMkFBTEJEVGlMOXdRZDdYS0J5ZFV3eVZBYlY5QUJhVk1OVTNKbFFnUkxHNUJ5ekV3RDNPeVNyVHlCajliY3hwcS9tVjU0Y3lmcHlTSzg1eS90UXVqTTlLeC9Za0R1QU5vZHdncGlnK0NzTlVoNWF0RTc3TFk0ZTdBZ1YwRkx6QWVGOXNwWWpZLS1zYXgrKzVvSDRBOXdtKzlMUnRyaWRBPT0%3D--4c2703bd8bbc3fed35b8bfbee40f7e9e48ec75c5;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:01:28 GMT
+  recorded_at: Mon, 04 May 2015 17:53:12 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/8ebc4de8-25c3-4ecc-a44c-6b0d69cc5b86
+    uri: http://localhost:3000/annotations/4944b78d-65db-4b8d-a3d1-43e5150eb87f
     body:
       encoding: US-ASCII
       string: ''
@@ -2524,13 +2528,13 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - a06726da-e82c-4568-9216-df57b5156482
+      - 73a351c6-e832-4ad6-ba58-7e4878d26130
       X-Runtime:
-      - '0.010926'
+      - '0.009878'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Wed, 29 Apr 2015 00:01:28 GMT
+      - Mon, 04 May 2015 17:53:12 GMT
       Content-Length:
       - '146'
       Connection:
@@ -2539,8 +2543,8 @@ http_interactions:
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
-      string: "<h2>error getting 8ebc4de8-25c3-4ecc-a44c-6b0d69cc5b86 from LDP</h2>Discovered
-        tombstone resource at org.fcrepo.kernel.impl.TombstoneImpl@6ef30e28"
+      string: "<h2>error getting 4944b78d-65db-4b8d-a3d1-43e5150eb87f from LDP</h2>Discovered
+        tombstone resource at org.fcrepo.kernel.impl.TombstoneImpl@2d7c23c1"
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:01:28 GMT
+  recorded_at: Mon, 04 May 2015 17:53:12 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/response_processing_utilities/_response2graph/accepts_a_RestClient_Response_instance.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/response_processing_utilities/_response2graph/accepts_a_RestClient_Response_instance.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"f2fa21e4e6bea5fb6ef66a3742493aef"
+      - W/"1328b4a6db9a3cbd4e37fe4da2da5e13"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 3320e03f-cddc-4ee2-b14e-618bfe751704
+      - ae728f17-bd10-4f69-8a90-40887b69fe9a
       X-Runtime:
-      - '6.542542'
+      - '1.376851'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Wed, 29 Apr 2015 00:00:32 GMT
+      - Mon, 04 May 2015 17:52:55 GMT
       Content-Length:
       - '431'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=Q0w5NE5ORm9PSG83RjBNT0dhVGxLc0NCZi9PTjdhTlZKeDBMMDR2SXBPdFRJbVhDMVRvSmJZSnJmRmNZNkhRajRPNnZBK1J1bFM2MnBNV2kzakdTaWRNczR4eEtnZTRuc2xlZG5lb2t3YWZsQk9NRi9RSG95LzBuZDA0em1tQSsxak54WGdWL1JNckhVVjZ5SU1Ya2lNaU1Ic3V5b1I2YnNZYnZFd2x2aGplVTRqb291cndERzVTdHZrSlFSTnN3U1RjYS8wNzREczlWSUFkMkxpbzFJTnQ3d0VFMGhWNHpwUEtSbmx0WGZERT0tLXdSajBKL1llRU0zRVY1dWpaUjFuQ3c9PQ%3D%3D--8f1e2f43691f1f721b80fd4607719ede03228b45;
+      - _internal_session=Y0R3UmVyTFl3ZFpZZnFWaDRYWXgvSDFMbnVqOHJaMDg5TDd5WnJtdmMxc0ZFUHoveWVlakhGMFpCcmJuSktvcUtzMEgvNXhvMG9oZTYreTkvY3V4MnVrcnpqNkNtVHA2RktSODBUV09iVVBRM2ZiOE5mR1FBL013WFZlUmpQb01VenNWN2tuKzkwU3VNV0Z4Q0JHZmFkOWNFSTRNTUxmbVNCSFB6aXAwbE9XNGdCNmU3UmNJU2tMTnVRaHVRREJwbGdRMWFZV0Z5bHQ1cWc2VEdJb24rS0hqNlNvL3Z1blRkOU9VYnZDOW9udz0tLTBQU2l0YzR3TlR0WUlqYlBjYktEd0E9PQ%3D%3D--eef63c87430af6c547cdce08bcee561363e2b7e0;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69850619455860","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/41efdb33-b3f5-45fe-9954-9cc5c3d687e9","@type":"oa:Annotation","hasBody":"_:g69850619455860","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70075071274240","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/d31fc96f-e741-4985-814c-e0bf131a5e81","@type":"oa:Annotation","hasBody":"_:g70075071274240","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:00:32 GMT
+  recorded_at: Mon, 04 May 2015 17:52:55 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:00:32 GMT
+      - Mon, 04 May 2015 17:52:55 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:00:32 GMT
+      - Mon, 04 May 2015 23:52:55 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:00:32 GMT
+  recorded_at: Mon, 04 May 2015 17:52:55 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:00:32 GMT
+      - Mon, 04 May 2015 17:52:56 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,9 +135,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:00:32 GMT
+      - Mon, 04 May 2015 23:52:56 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -1251,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:00:32 GMT
+  recorded_at: Mon, 04 May 2015 17:52:57 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1271,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:00:32 GMT
+      - Mon, 04 May 2015 17:52:57 GMT
       Server:
       - Apache/2
       Location:
@@ -1279,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:00:32 GMT
+      - Mon, 04 May 2015 23:52:57 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1295,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:00:32 GMT
+  recorded_at: Mon, 04 May 2015 17:52:57 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1317,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:00:32 GMT
+      - Mon, 04 May 2015 17:52:57 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1331,9 +1333,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:00:32 GMT
+      - Mon, 04 May 2015 23:52:57 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -2447,7 +2451,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:00:33 GMT
+  recorded_at: Mon, 04 May 2015 17:52:57 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -2467,7 +2471,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:00:33 GMT
+      - Mon, 04 May 2015 17:52:57 GMT
       Server:
       - Apache/2
       Location:
@@ -2475,7 +2479,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:00:33 GMT
+      - Mon, 04 May 2015 23:52:57 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -2491,7 +2495,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:00:33 GMT
+  recorded_at: Mon, 04 May 2015 17:52:57 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -2513,7 +2517,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:00:33 GMT
+      - Mon, 04 May 2015 17:52:57 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -2527,9 +2531,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:00:33 GMT
+      - Mon, 04 May 2015 23:52:57 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -3643,7 +3649,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:00:33 GMT
+  recorded_at: Mon, 04 May 2015 17:52:58 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -3663,7 +3669,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:00:33 GMT
+      - Mon, 04 May 2015 17:52:58 GMT
       Server:
       - Apache/2
       Location:
@@ -3671,7 +3677,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:00:33 GMT
+      - Mon, 04 May 2015 23:52:58 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -3687,7 +3693,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:00:33 GMT
+  recorded_at: Mon, 04 May 2015 17:52:58 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -3709,7 +3715,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:00:34 GMT
+      - Mon, 04 May 2015 17:52:58 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -3723,9 +3729,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:00:34 GMT
+      - Mon, 04 May 2015 23:52:58 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -4839,10 +4847,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:00:34 GMT
+  recorded_at: Mon, 04 May 2015 17:52:58 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/41efdb33-b3f5-45fe-9954-9cc5c3d687e9
+    uri: http://localhost:3000/annotations/d31fc96f-e741-4985-814c-e0bf131a5e81
     body:
       encoding: US-ASCII
       string: ''
@@ -4869,22 +4877,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - cfc55f7e-ac0d-4eea-83d0-ceaa7e9236b4
+      - 049334a2-7b4d-4dd5-be9b-10ddf80c1e46
       X-Runtime:
-      - '0.141423'
+      - '0.150621'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Wed, 29 Apr 2015 00:00:34 GMT
+      - Mon, 04 May 2015 17:52:58 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=VmxhdFg3K1l4Vnl4V29kbk9DbmEwMFhPSDRDVzV2SXRqcHZvS1dzdi9YU1BCcGRDc1pDZS9hTjlQODc4ZHZlblNGN3hyd1VSbzd1V1VtOEpGaW45Z3NiNGhKR1ZSTkFBY0VNUitXS0x4cTcwRzJrMitzZ2xCLzg1OUQvZDdHT3doWHRSalczWWVkSmxUSktEbjM0eU9DbTNKQ2xRbGNPVm9rZEp3bnNXSmx2VkxyZTNkQUVGelFtcW5SN0lzWllILS1zYi9iTmZNS295UXdyWjNBa296MFFRPT0%3D--523a6f2995562d2d4ce1d572733bf532f4d7a767;
+      - _internal_session=MGJlNzFMSDJHdFg0SGlDTlk3aHRnaWxodlV6OW5WcDFPTlJNVE1QbHVUZzB1ZVNJSGNDNnRyVkxzak53UUZ4WWVacStLUHZwTjJJcWZYdWhUczhESFNiNHJLZ0pRTVpCNkRRaVBpQXI1eW5aQ1hlYVRub1BrUlNGSlZYdHYwdmNGeWo2NGYzQjBkNnd2NE9oK0NhbGVZRzJXbnViaTZWMlBoTkc1a1c3b1BiTmJHMlI1bGIwbmxPMnhtOFBJWlFNLS1HQXRxTEhwS0ZZM2tKTzZUYjNkMEdBPT0%3D--ab2e8bc55fbe31876d29be4e4c72560f45853a15;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:00:34 GMT
+  recorded_at: Mon, 04 May 2015 17:52:58 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/response_processing_utilities/_response2graph/raises_ArgumentError_when_given_an_empty_String.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/response_processing_utilities/_response2graph/raises_ArgumentError_when_given_an_empty_String.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"07dd6598ea76e592afaaba7a283e5016"
+      - W/"3314d6c8df50d51e02b8999af7237205"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 9f205fd7-74c3-4137-b09c-d8beb6bd3107
+      - fd10fe06-e1fa-4993-93cc-c61ad09161cf
       X-Runtime:
-      - '6.396686'
+      - '1.386327'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Wed, 29 Apr 2015 00:00:53 GMT
+      - Mon, 04 May 2015 17:53:03 GMT
       Content-Length:
       - '431'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=OHM2aXJlL2UwcXUvalM3RGJnaldEanluQVlROSs5SzBGaDZBNHBOZ1lxRmZ6cnl4SmRyeGtBYmdaNVFPMU5peXMwQnYxRWg3YS8xU2I0WTd0OUVZZThYbVFpUEF6cHFnQTIrR2JhSG5GYmE3V3pnV3lIMWc2RXFSMHpPYk40UlpobkZybnp6UzE5YVQvMFhjbmRDb09GVUl0ZDRYMk0xOUJGQmFxOFJrQmxjY0crblh2RjZ2R1R0UXpXV3hvalRYQ1hNRTJoMHNoMnB5L212bW1IMG1FV1ZzSis0ZFBmTlZvSEJjeEFNZEdMST0tLU9aSm5oU1dSSHM0bVE0NlRrS3pEQmc9PQ%3D%3D--61b6072740aff8dd3f6028b58920ac7683934130;
+      - _internal_session=aVh1NmdLOG9rSWdDdzVzZUNQb2Qrby8zQUs3dUtXRmI0UmVuQmlWb21POFVqdFkzSEs0clJOOS9ET25nanI1NUVDU1M1QVA1QXM0dXBDZkdqT3hveFhQR3E3T1J2UXhiOStRbHBQN3JENG92ajc0ZFp5SmhxN0lqbFV3dVVvemV2bGhhYmJEQmtDT1hJcURWbVhGdDVRcFE3TGx6NEt4N29EVGNldE1Ma0Uvd2JORUlnM21mT0U4bE81bjJmc0M0a1c2bzUvM1RGVmJqMC9wU3J3QlFOUXpBaVZISnJsTDE2b1FBM2E1bFQ3az0tLUZraTc4MDFveDBybkc3YU5oa1NHOWc9PQ%3D%3D--7b14ef8fdd5f0e4189c53699029a5a879344e5d9;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69850563181060","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/3e3a83ea-d0b5-4fd2-a39a-5b0adc30edba","@type":"oa:Annotation","hasBody":"_:g69850563181060","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70075071083340","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/89f3e403-f5bc-4386-bf6c-412cd41e3c3b","@type":"oa:Annotation","hasBody":"_:g70075071083340","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:00:53 GMT
+  recorded_at: Mon, 04 May 2015 17:53:03 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:00:53 GMT
+      - Mon, 04 May 2015 17:53:03 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:00:53 GMT
+      - Mon, 04 May 2015 23:53:03 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:00:53 GMT
+  recorded_at: Mon, 04 May 2015 17:53:03 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:00:53 GMT
+      - Mon, 04 May 2015 17:53:03 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,9 +135,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:00:53 GMT
+      - Mon, 04 May 2015 23:53:03 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -1251,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:00:54 GMT
+  recorded_at: Mon, 04 May 2015 17:53:03 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1271,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:00:54 GMT
+      - Mon, 04 May 2015 17:53:03 GMT
       Server:
       - Apache/2
       Location:
@@ -1279,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:00:54 GMT
+      - Mon, 04 May 2015 23:53:03 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1295,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:00:54 GMT
+  recorded_at: Mon, 04 May 2015 17:53:03 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1317,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:00:54 GMT
+      - Mon, 04 May 2015 17:53:03 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1331,9 +1333,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:00:54 GMT
+      - Mon, 04 May 2015 23:53:03 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -2447,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:00:54 GMT
+  recorded_at: Mon, 04 May 2015 17:53:04 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/3e3a83ea-d0b5-4fd2-a39a-5b0adc30edba
+    uri: http://localhost:3000/annotations/89f3e403-f5bc-4386-bf6c-412cd41e3c3b
     body:
       encoding: US-ASCII
       string: ''
@@ -2477,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - ceedcde0-d586-45bc-8da8-df111a33961f
+      - ba7f1313-a3fd-4501-87d1-b4f6ed9b990c
       X-Runtime:
-      - '0.134193'
+      - '0.133458'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Wed, 29 Apr 2015 00:00:54 GMT
+      - Mon, 04 May 2015 17:53:04 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=a1QxQmRkRTlBaVJaUmZLV3VrWGFURTZYdFlKd2ZNZm5QbUpSU0RSY3RaOGJiMFk4TVBRb1pDMytpVm5IYmMzelBYUEZGVG14aFhJSE4zQSt0Q2t1V2VzcFJzbmJ3Y0I1WWVkV2hrTDFJQ1lQdlJKaDUxZkZiK2ZGdkJzTGQrZGQwYUdyby9ONFpIaHZlbzlkWTEyZmhxOXViYUdmRjFmMS96MHAwQTI1NmJRUXZ0bUVmWnRCc1FpUS9vYnZlRTJLLS1GN29Qd1h2UWtwWm04N0pUUTl0TDhBPT0%3D--4f0e0c2e1de84b94a0d7401a915e2dd516beb11d;
+      - _internal_session=QURpS0JLTDlDdkhTMTRlS3RWakpWVnRLZkN4Q09YaEM5TkFEN2kvTGQ5S0gvL05tandYb1dsMWR2Q2RrZ1BGN2xvcFo2c002SXFrTnZTUVFuSEtMVk1uVll1a2pDK0tkb2YvWkZScmE1dWZjbCt0ODN5NTNuRDQ0QjRwU3dsa2tuK0NNVzNIQ2lQZ2lOWFltbmQ5QXQzTU12NENiaUhXSW9neEdTckhMMnZhVytaYmdjanNhSWsvNFgxb0U0UE5yLS00OElGWXhkbHphZDh3WUFPWUVxY0hRPT0%3D--c7b53260d8a5d41de715688f97987bfc3112ed95;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:00:54 GMT
+  recorded_at: Mon, 04 May 2015 17:53:04 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/response_processing_utilities/_response2graph/raises_ArgumentError_when_given_nil.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/response_processing_utilities/_response2graph/raises_ArgumentError_when_given_nil.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"1eefa62bb167fd0e77c61831cda5cb98"
+      - W/"300315d150b1e5a75d391da65b9a1a1c"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 6294e067-6cef-47e6-a6fd-e8c5ce0ee736
+      - 3a4b16da-6ef7-4dd8-811f-7b5be566270f
       X-Runtime:
-      - '6.389608'
+      - '1.422314'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Wed, 29 Apr 2015 00:00:40 GMT
+      - Mon, 04 May 2015 17:53:00 GMT
       Content-Length:
       - '431'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=VDNGSHZ5TXBBOEhBUFhwcE43YmR6czVvNk5PQS82V1NubXFtUXh4UkExZWJmY3J0VytQSmJXT2x5TGc4THp6Z2VmbVVObHRVWTRkU0k5Q0dZeU52Y2JOaEhBMW1oZE55bGU2OEtDOHJHdEdFdVNsWUVEOVc4Rlp3clBRN1g2aEFRVklzYkF6OTVDOFJkSnBHTWViTHBlQ3lBMU1McDA0V2hlUGhxdUx4Wk1WeVZHaC9yTTNia1poVzJ3cDlacTJDaXNxVi9lSzE5NnNBS1BFY3VDTUowNDdiQjVqREx1dEQ3SXRwZzBteXVXbz0tLUVSS2QzdmoxdUhmTjBERlFmQXdlcnc9PQ%3D%3D--92d971ca4d10b66537d4606354a9ddf12f7f25e2;
+      - _internal_session=QXZNazFaOXUxaWszdmxjTVJMZ1YrNFNZZXFNc2FyV25hYmVidW02d3FYTG1ObFkxMHo3VEJmU0dhWFVGY3NCbW9OVzZ5ZytFRHFDb0paZ1pETnQxcktKMFVQNHZkWnhMdzlsWVV5QzJpN0xEbmthQk9VeVNxenprc0t5U0VLTE9wSXBpUzlGZVB5alBWUXV1Z3hnMktmMk5YSnpIcFNHdEVramNFcUxPNnV6aHR1d0toR2xWNmhzQjN2RlNOUmdrRm0xK3ZYL0RLNUsreThRc2t2ZHBHRkR1UnhzVndzN2dUYWpMci8yYlpWMD0tLU1rVWM0OUgxdUw5Vmc1LzErL0Zybnc9PQ%3D%3D--a86d8a0e5e12efe53db20384636b8f900ff6692c;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69850788495860","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/8020234c-0e86-4def-a1fa-73040bda03e6","@type":"oa:Annotation","hasBody":"_:g69850788495860","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70075009463480","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/8d207dfd-c836-4197-8b2f-5de24721a9ea","@type":"oa:Annotation","hasBody":"_:g70075009463480","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:00:40 GMT
+  recorded_at: Mon, 04 May 2015 17:53:00 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:00:41 GMT
+      - Mon, 04 May 2015 17:53:00 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:00:41 GMT
+      - Mon, 04 May 2015 23:53:00 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:00:41 GMT
+  recorded_at: Mon, 04 May 2015 17:53:00 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:00:46 GMT
+      - Mon, 04 May 2015 17:53:00 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,9 +135,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:00:46 GMT
+      - Mon, 04 May 2015 23:53:00 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -1251,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:00:46 GMT
+  recorded_at: Mon, 04 May 2015 17:53:00 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1271,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:00:46 GMT
+      - Mon, 04 May 2015 17:53:01 GMT
       Server:
       - Apache/2
       Location:
@@ -1279,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:00:46 GMT
+      - Mon, 04 May 2015 23:53:01 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1295,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:00:46 GMT
+  recorded_at: Mon, 04 May 2015 17:53:01 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1317,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:00:46 GMT
+      - Mon, 04 May 2015 17:53:01 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1331,9 +1333,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:00:46 GMT
+      - Mon, 04 May 2015 23:53:01 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -2447,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:00:47 GMT
+  recorded_at: Mon, 04 May 2015 17:53:01 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/8020234c-0e86-4def-a1fa-73040bda03e6
+    uri: http://localhost:3000/annotations/8d207dfd-c836-4197-8b2f-5de24721a9ea
     body:
       encoding: US-ASCII
       string: ''
@@ -2477,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - a37c14c3-6d3c-414b-930c-04c89218710c
+      - 335fff6c-4919-480e-b0db-26bd995e3458
       X-Runtime:
-      - '0.140715'
+      - '0.133400'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Wed, 29 Apr 2015 00:00:47 GMT
+      - Mon, 04 May 2015 17:53:01 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=Z0REOUNkZlhCNWVyNGRkSktDNEU4QjZpVm16eXFtK3pSQ2hac2JmOGx3bWUxMjcwQ2tidHdpZUlNVjd2U3FxL1BWNDM4ZmtXNk1Edjg2cjVDbU10L2dzUUlOd1piNmxRSE1HME82MDIvbFZVblZmalZDKytSbGovSzRsUDJEYUFwRS9ZbjA4RVljcm93VVcvL0ZWajl4R0xjdnQ5U2xsQ2RwQUZxdzFrV1gzTGtwdHRGTWlTOFQxdjZYT0c2RkFsLS13cTBLY0RQaWNQcit0TytuNW10UUdBPT0%3D--4fed7032922ff1a3aa50cc125cfe28a1a301ee3e;
+      - _internal_session=SURDaGJ3QStyOTRiWEZOU3M2aS9hUm9iWkpKZ2V1bkFsWGJHbndpWkZkOHNTeGtkZzVYRGZudGJSR3FKM0tkT2tJNUdTdDIvMGJWVFpabnNuWWp6UGNCOFNpOW5OS2x6MlhMLzY3akRtdnlpM3ZlcTduRmsxLzk5ek9vRERYK3BlcERGbkdRaDczWndiWU1oTXI0RmJyY3h5c2xZNlFpUDdGSE5FaDFRaDNhcFFtV1dDMzJMU2k3SjZTMWt0dFpjLS13V2JFU2tIQVlUMTJRSCs1Y0hBdXh3PT0%3D--308b10745b3bf05c340cb11594a50c45d6bd8afa;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:00:47 GMT
+  recorded_at: Mon, 04 May 2015 17:53:01 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/response_processing_utilities/_response2graph/returns_an_RDF_Graph.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/response_processing_utilities/_response2graph/returns_an_RDF_Graph.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"e2943ccd8b50c62669add004b9bcb586"
+      - W/"99b401d54835971c8325df5b37ff1136"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - b5c58f02-89f8-4ad9-b716-901422e9f92b
+      - 8b629ef6-728a-42e3-b8f7-ded30205d268
       X-Runtime:
-      - '11.390580'
+      - '1.350961'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Wed, 29 Apr 2015 00:01:06 GMT
+      - Mon, 04 May 2015 17:53:05 GMT
       Content-Length:
       - '431'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=dEUyYUMzTjVsbGJIV0dSTng5Q2N4dFp0aGNEOGc1SE5GVkxNOHFiRVVvRDRVL2ZKQW5mcHNHZkZLeU9aNDd5cGd6L05DTzFUMytsQnc2WUFuSG5hRTJkUGk4SURvTTFhWUI2d3J0bk0zNHFVcEZTVFIwRUFiSTdKdk5oOXdSZXBmc0hhTFFWNzNqSDhqdUpVS1A0U2lubEpOaG1HQUJiVVVPbXNCYzhlL3d1UlR4aEx1UVk1SjIvcTRjK0JsZ0RtOWlEaVk4dy81bnhONC9kWk9qQ1I1ZjFDUE5aM0pCbmN4RDRmeXlnbG94dz0tLWo5eVVOMGF0ZUtXOFR3aUR1dUhOTFE9PQ%3D%3D--4a0e6376b6bac28a922fc582ee5b73a72a3009af;
+      - _internal_session=V2ZGMTJLUE95YTlKMThBdUVKbUx3ay9sMENuSWYzL3BCMWEzL3R3NkRTaUd1MmlEYnRocnNFTFdTY3plQlcvbXlGT1dpdkYwVTdvTWljY0Y1dHRaTmx3VUllM1QvME5TQjdYZ256c3REc211eVAwSmIzSmQraWRJeE5RaUdWK2w5NlhqbU03NkRJVXFZNDBQZG5DV2JGbFFxSVZiNzE0em1wamZ2WGhZOEIzVTJkKzRJNVM2eW5RbGJwQllEN3JxL3pNZkphUjRpc2J4akllNHgxKzF6VW1vb0QxUzV4UTBaTitvSlNabXRKST0tLWJsczVVYzc1S0pZaTM4aWYrbGdhakE9PQ%3D%3D--da9ff05f7231e094a7f0a6c9a642221da4181683;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69850784089540","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/1b3b0976-622c-4663-803f-057ca32f8518","@type":"oa:Annotation","hasBody":"_:g69850784089540","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70075075674480","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/a4c833b6-fd31-4be2-a58a-f9a753cce976","@type":"oa:Annotation","hasBody":"_:g70075075674480","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:01:06 GMT
+  recorded_at: Mon, 04 May 2015 17:53:05 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:01:06 GMT
+      - Mon, 04 May 2015 17:53:05 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:01:06 GMT
+      - Mon, 04 May 2015 23:53:05 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:01:06 GMT
+  recorded_at: Mon, 04 May 2015 17:53:05 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:01:11 GMT
+      - Mon, 04 May 2015 17:53:05 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,9 +135,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:01:11 GMT
+      - Mon, 04 May 2015 23:53:05 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -1251,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:01:11 GMT
+  recorded_at: Mon, 04 May 2015 17:53:06 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1271,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:01:11 GMT
+      - Mon, 04 May 2015 17:53:06 GMT
       Server:
       - Apache/2
       Location:
@@ -1279,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:01:11 GMT
+      - Mon, 04 May 2015 23:53:06 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1295,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:01:12 GMT
+  recorded_at: Mon, 04 May 2015 17:53:06 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1317,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 29 Apr 2015 00:01:12 GMT
+      - Mon, 04 May 2015 17:53:06 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1331,9 +1333,11 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 29 Apr 2015 06:01:12 GMT
+      - Mon, 04 May 2015 23:53:06 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
       Content-Type:
       - application/ld+json
     body:
@@ -2447,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:01:12 GMT
+  recorded_at: Mon, 04 May 2015 17:53:06 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/1b3b0976-622c-4663-803f-057ca32f8518
+    uri: http://localhost:3000/annotations/a4c833b6-fd31-4be2-a58a-f9a753cce976
     body:
       encoding: US-ASCII
       string: ''
@@ -2477,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 32516e34-ba06-407c-a5f9-17eaba6e86a9
+      - 916fbaf9-fd1c-408e-be76-b26d11675517
       X-Runtime:
-      - '0.137298'
+      - '0.128988'
       Server:
       - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
       Date:
-      - Wed, 29 Apr 2015 00:01:12 GMT
+      - Mon, 04 May 2015 17:53:06 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=cmNxWFpTdUFJMDJOYUZFbCtQRkV2VDhiRjNRSzNFN1pWS2M4T0hVVWlvQkFwMWFXL2RvQkNnZkYvVjBoUkhzMXpCdG1JcEZnQ2R1UHEzK2lXYnFHcjFMOFU3STFxQXlmVWRJZ0dNMjZDT2ZtanN2UWl2L0t3aU5EdU1JRlVQQll5VDh6V0NJdlpwSVcrWXF6MnRCTVZNVGJkY1o2RGRZeVJpUXBNZW9MRnNzUE9RM2MvZjNqekg0Z3MyZnpwbCtBLS1iVDA3Zy9aN05vQVdLZnkxNHFuTWR3PT0%3D--3614c6ea2a31dd045dd25d592f9f275925f149e8;
+      - _internal_session=QXROWlFRdlR2ZTF5bXZDQ1BQTE9hWTAralo4RzRyUkE1RjBoTjBjcnE1bHYvRUtzQmJsNWpEd1VnMHJ2MlFiZUwrMmszWmJOTHhZWkFUUmdpaEc4VEZ3bzlxZTErTGUwMkRCUUNMb2pNZWFmSlc5QVVpd08wS3VpTUVtQm9rdlh2eDM1bmFlOWM1ZTlTbDdpKzNQeGJPVmFCNkZzSDl6Qk9lRDQ3cWIvR21XN1BQZ3gxVWVtV21XTkFTc1JSOG9ELS0vcDJGdnRGd0Vmam1sbWNOV05KVENnPT0%3D--0c404047a72f73b59876fed6fdf0dc9316c9475f;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 29 Apr 2015 00:01:12 GMT
+  recorded_at: Mon, 04 May 2015 17:53:06 GMT
 recorded_with: VCR 2.9.3


### PR DESCRIPTION
Allow a `let` to define the client instance `tc`.  Do not use `let` to define any of the annotation creation, processing or deletion because the `let` abstractions make it too difficult to cleanup.  The tests are only slightly less efficient, but the accuracy is worth the cost.
