### PR TITLE
Feature/oauth client

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -12,7 +12,8 @@ export TRIANNON_LOG_FILE='log/triannon_client.log'
 
 # Configure the triannon service
 export TRIANNON_HOST='http://localhost:3000'
-export TRIANNON_USER=''
-export TRIANNON_PASS=''
+export TRIANNON_USER=''   #Basic Auth Username
+export TRIANNON_PASS=''   #Basic Auth Password
+export TRIANNON_SECRET='' #OAuth Client Secret Key
 export TRIANNON_CONTAINER='/annotations/'
 

--- a/.env_example
+++ b/.env_example
@@ -14,6 +14,7 @@ export TRIANNON_LOG_FILE='log/triannon_client.log'
 export TRIANNON_HOST='http://localhost:3000'
 export TRIANNON_USER=''   #Basic Auth Username
 export TRIANNON_PASS=''   #Basic Auth Password
-export TRIANNON_SECRET='' #OAuth Client Secret Key
+export TRIANNON_OAUTH_ID=''     #OAuth Client ID
+export TRIANNON_OAUTH_SECRET='' #OAuth Client Secret
 export TRIANNON_CONTAINER='/annotations/'
 

--- a/bin/console
+++ b/bin/console
@@ -1,4 +1,7 @@
 #!/usr/bin/env ruby
+require 'rubygems'
+require 'bundler/setup'
+
 require 'triannon-client'
 CONFIG = TriannonClient.configuration
 

--- a/lib/triannon-client.rb
+++ b/lib/triannon-client.rb
@@ -10,6 +10,7 @@ require 'rest-client'
 # (The ruby stdlib http client will use a proxy automatically.)
 RestClient.proxy = ENV['http_proxy'] unless ENV['http_proxy'].nil?
 RestClient.proxy = ENV['HTTP_PROXY'] unless ENV['HTTP_PROXY'].nil?
+require 'oauth'
 require 'linkeddata'
 require_relative 'triannon-client/configuration'
 require_relative 'triannon-client/triannon_client'

--- a/lib/triannon-client/configuration.rb
+++ b/lib/triannon-client/configuration.rb
@@ -9,6 +9,7 @@ module TriannonClient
     attr_accessor :host
     attr_accessor :user
     attr_accessor :pass
+    attr_accessor :oauth_secret
     attr_accessor :container
 
     def initialize
@@ -17,6 +18,7 @@ module TriannonClient
       @host = ENV['TRIANNON_HOST'] || 'http://localhost:3000'
       @user = ENV['TRIANNON_USER'] || ''
       @pass = ENV['TRIANNON_PASS'] || ''
+      @oauth_secret = ENV['TRIANNON_SECRET'] || ''
       @container = ENV['TRIANNON_CONTAINER'] || ''
       @container += '/' unless(@container.empty? || @container.end_with?('/'))
 

--- a/lib/triannon-client/configuration.rb
+++ b/lib/triannon-client/configuration.rb
@@ -9,6 +9,7 @@ module TriannonClient
     attr_accessor :host
     attr_accessor :user
     attr_accessor :pass
+    attr_accessor :oauth_client
     attr_accessor :oauth_secret
     attr_accessor :container
 
@@ -18,7 +19,8 @@ module TriannonClient
       @host = ENV['TRIANNON_HOST'] || 'http://localhost:3000'
       @user = ENV['TRIANNON_USER'] || ''
       @pass = ENV['TRIANNON_PASS'] || ''
-      @oauth_secret = ENV['TRIANNON_SECRET'] || ''
+      @oauth_client = ENV['TRIANNON_OAUTH_ID'] || ''
+      @oauth_secret = ENV['TRIANNON_OAUTH_SECRET'] || ''
       @container = ENV['TRIANNON_CONTAINER'] || ''
       @container += '/' unless(@container.empty? || @container.end_with?('/'))
 

--- a/lib/triannon-client/triannon_client.rb
+++ b/lib/triannon-client/triannon_client.rb
@@ -20,26 +20,28 @@ module TriannonClient
     # All params are optional, the defaults are set in
     # the ::TriannonClient.configuration
     # @param host [String] HTTP URI for triannon server
+    # @param container [String] The container path on the triannon server
     # @param user [String] Authorized username for triannon server
     # @param pass [String] Authorized password for triannon server
-    # @param secret [String] Authorized OAuth secret key for triannon server
-    # @param container [String] The container path on the triannon server
-    def initialize(host=nil, user=nil, pass=nil, secret=nil, container=nil)
+    # @param client [String] Registered OAuth client ID for triannon server
+    # @param secret [String] Authorized OAuth secret for triannon server
+    def initialize(host=nil, container=nil, user=nil, pass=nil, client=nil, secret=nil)
       # Configure triannon-app service
       @config = ::TriannonClient.configuration
       host ||= @config.host
       host.chomp!('/') if host.end_with?('/')
       # Use OAuth, if it's configured.
+      client ||= @config.oauth_client
       secret ||= @config.oauth_secret
-      unless secret.nil? || secret.empty?
-        # Try to use OAuth
-        consumer = OAuth::Consumer.new("key", secret, {:site => host})
+      unless client.nil? || client.empty? || secret.nil? || secret.empty?
+        # Try to use OAuth (don't handle exceptions, let it crash)
+        consumer = OAuth::Consumer.new(client, secret, {:site => host})
         request_token = consumer.get_request_token
+        raise 'Failed to get OAuth request token' unless request_token
         access_token = request_token.get_access_token
-        if access_token
-          RestClient.add_before_execution_proc do |req, params|
-            access_token.sign! req
-          end
+        raise 'Failed to get OAuth access token' unless access_token
+        RestClient.add_before_execution_proc do |req, params|
+          access_token.sign! req
         end
         @site = RestClient::Resource.new(
           host,

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/cannot_get_an_open_annotation_by_ID_with_content_type_application/n-quads_.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/cannot_get_an_open_annotation_by_ID_with_content_type_application/n-quads_.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"3693f746f7f82271c0e1eaa0a6cb8586"
+      - W/"b62d024d909d81a33c35825a273374bf"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 17a87e35-68f1-4977-8f0a-15c5b0c0f4e4
+      - 065cea4d-9c77-422b-bdfd-f4ccb790e1ad
       X-Runtime:
-      - '1.625174'
+      - '2.332286'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:07:54 GMT
+      - Thu, 28 May 2015 01:28:06 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=ZXo1UnFac0VKUmFYRjdZTXBnaEU4ZXpFWEoyZ3g0VE9MalFYK0d3NU1kYjlvWms0Q09Fa1htcWVRcno0YStxOENzdTZidVRQak12YUZjR01DbVV2Q1NYWlB0Y0k5OTdJeUtTUGZnS0ducmR5WGRwWjdDV1JiM1Yxd21welZ6NGJicDNWZTlFMmxscll4VkljcFppWXEwMWwzR0pTdS92MTg0YU9obGlTNEQ3cU5FczRXZ3VYY1kvZVJmYitVWTdRS2ZtdmVmLzgrRXU2dDBRUVdMMS9hbEVoRlBISE96Q1FiWjk2c0NEUHE5WGxWS2VTRUJrVER6OEp0ZUtYUVJqZi0taDZHWjI3aXEvTkU1Z0pwb3FZTjdBQT09--b347e6e63fc11833326c5fcf868da9499992df3e;
+      - _internal_session=NFFid2NwWWhhWExIdmxSd1Z2ZzcvaERTaWtJRjlIOVl0TUJhRzc2SlBLRFVUQkdORHYvYlJQbDRwMjl4QWVlV3JHbEFZMDB2bW96MXdHdmhmWkZwQkNLUUF6R0p2QkVNSEd5bGo1OHB6QlZvOHR2NW4yMUlXS2JQeHl4bUZyK3Q1cGNBY045MkJGa3hRa2tLblpUcjBqNjFMM0Q3bUtsVGlXc3Z5eUsrMU5JS0VkbXFnREFmSy85WmhLTkNWU2RFQU1KcWZBL3hvWW91QVdiMHM2aVZYWVdwbUcxRC9QdVJQallHSEtJZ05QNFYybGhnK2RvZDdnK05RbVkxdWkxZy0tcmpmYlM1TGlBdUovS3ZYQlkweGR2QT09--1e8116b5f2a51804b5f531f9ea30ddb48e782571;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310858814460","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/c9/22/0e/65/c9220e65-33ed-4115-b069-1734d94a1f80","@type":"oa:Annotation","hasBody":"_:g70310858814460","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942008858620","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/cd/31/c1/5e/cd31c15e-75f6-4b8a-a540-9a4613524634","@type":"oa:Annotation","hasBody":"_:g69942008858620","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:54 GMT
+  recorded_at: Thu, 28 May 2015 01:28:06 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:55 GMT
+      - Thu, 28 May 2015 01:28:07 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:55 GMT
+      - Thu, 28 May 2015 07:28:07 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:55 GMT
+  recorded_at: Thu, 28 May 2015 01:28:07 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:55 GMT
+      - Thu, 28 May 2015 01:28:07 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:55 GMT
+      - Thu, 28 May 2015 07:28:07 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:55 GMT
+  recorded_at: Thu, 28 May 2015 01:28:08 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:55 GMT
+      - Thu, 28 May 2015 01:28:08 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:55 GMT
+      - Thu, 28 May 2015 07:28:08 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:55 GMT
+  recorded_at: Thu, 28 May 2015 01:28:09 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:55 GMT
+      - Thu, 28 May 2015 01:28:09 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:55 GMT
+      - Thu, 28 May 2015 07:28:09 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:56 GMT
+  recorded_at: Thu, 28 May 2015 01:28:10 GMT
 - request:
     method: get
-    uri: http://localhost:3000/annotations/c9%2F22%2F0e%2F65%2Fc9220e65-33ed-4115-b069-1734d94a1f80
+    uri: http://localhost:3000/annotations/cd%2F31%2Fc1%2F5e%2Fcd31c15e-75f6-4b8a-a540-9a4613524634
     body:
       encoding: US-ASCII
       string: ''
@@ -2475,13 +2475,13 @@ http_interactions:
       Content-Length:
       - '128005'
       X-Request-Id:
-      - 9e050456-1cd0-45ee-a4f5-2794870a5fb9
+      - 67c7f280-ba3f-4d50-813d-8b1272d6c814
       X-Runtime:
-      - '0.350365'
+      - '0.285046'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:07:56 GMT
+      - Thu, 28 May 2015 01:28:10 GMT
       Connection:
       - Keep-Alive
     body:
@@ -3818,7 +3818,7 @@ http_interactions:
         && el) {\n          currentSource.className += \" hidden\";\n          el.className
         = el.className.replace(\" hidden\", \"\");\n          currentSource = el;\n
         \       }\n      }\n    }\n  </script>\n</div>\n\n  \n\n<h2 style=\"margin-top:
-        30px\">Request</h2>\n<p><b>Parameters</b>:</p> <pre>{&quot;id&quot;=&gt;&quot;c9/22/0e/65/c9220e65-33ed-4115-b069-1734d94a1f80&quot;}</pre>\n\n<div
+        30px\">Request</h2>\n<p><b>Parameters</b>:</p> <pre>{&quot;id&quot;=&gt;&quot;cd/31/c1/5e/cd31c15e-75f6-4b8a-a540-9a4613524634&quot;}</pre>\n\n<div
         class=\"details\">\n  <div class=\"summary\"><a href=\"#\" onclick=\"return
         toggleSessionDump()\">Toggle session dump</a></div>\n  <div id=\"session_dump\"
         style=\"display:none\"><pre></pre></div>\n</div>\n\n<div class=\"details\">\n
@@ -3828,7 +3828,7 @@ http_interactions:
         &quot;gzip, deflate&quot;\nREMOTE_ADDR: &quot;127.0.0.1&quot;\nREMOTE_HOST:
         &quot;127.0.0.1&quot;\nSERVER_NAME: &quot;localhost&quot;\nSERVER_PROTOCOL:
         &quot;HTTP/1.1&quot;</pre></div>\n</div>\n\n<h2 style=\"margin-top: 30px\">Response</h2>\n<p><b>Headers</b>:</p>
-        <pre>None</pre>\n\n</div>\n\n\n</body>\n</html>\n<div id=\"console\"\n  data-remote-path='console/repl_sessions/a460b424cb0b8e952d2370361c0198d2'\n
+        <pre>None</pre>\n\n</div>\n\n\n</body>\n</html>\n<div id=\"console\"\n  data-remote-path='console/repl_sessions/59684c87f3f6c109a447ed52b062c065'\n
         \ data-initial-prompt='>> '>\n</div>\n\n\n<script type=\"text/javascript\">\n(function()
         {\n  // DOM helpers\nfunction hasClass(el, className) {\n  var regex = new
         RegExp('(?:^|\\\\s)' + className + '(?!\\\\S)', 'g');\n  return el.className.match(regex);\n}\n\nfunction
@@ -4025,10 +4025,10 @@ http_interactions:
         \   resizerElement.addEventListener('mouseup', recordConsoleElementHeight);\n
         \ });\n});\n\n}).call(this);\n</script>\n\n"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:56 GMT
+  recorded_at: Thu, 28 May 2015 01:28:10 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/c9%2F22%2F0e%2F65%2Fc9220e65-33ed-4115-b069-1734d94a1f80
+    uri: http://localhost:3000/annotations/cd%2F31%2Fc1%2F5e%2Fcd31c15e-75f6-4b8a-a540-9a4613524634
     body:
       encoding: US-ASCII
       string: ''
@@ -4055,22 +4055,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 513f819e-5713-437d-834d-560da4b83953
+      - a31d06e7-e7e9-4ce3-82e9-7931063903fa
       X-Runtime:
-      - '0.253853'
+      - '0.185528'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:07:56 GMT
+      - Thu, 28 May 2015 01:28:11 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=YU9Wd0xEWHRNL2ZxR2tiVVhzTXZQNWRuOHBlV0VPZXk5a3J0ak1oV1htaVBQZmJDODRtbjhNZGRJU2lZMFQ1MWV5NjhrdU80S09hQVFNYzJsYnNXNmJLbS9oeUJBWXp2bnZiRDdSTGpMVStySFp4WXZkZWp0WnNWd1dkNjdEQnZUMFpUUlN4WWtTUWtwaHB2Q3dlTGpPcGRkZ2dJTXBsY1d6R1lQZzhoQU5kTUNHT25lZmVhbHFOYWVnMlBQWS8wLS1wSVp2RDdISUVrMDJPbmRtOGNNQnB3PT0%3D--148c480eb047c240941cc7e658a29ee6d385af1a;
+      - _internal_session=R2hCaGtPZGZsRkdQU0d2R0hyQjlTNllMNFJBOXJhR0x6TjdXTXpxL0dvdmg1cnVuYTlOU250UE00Y3NleE91TmxxVUhRdGVNejlabDJFaVhEYUorYytLNk5YNUV3L3hVNlRqakYyZHVZQldlcUtEbjMxN0Q4Q2NSeFp1RzNRbGFNTzFFcENib3Q3bnBadmtXNmRRc0ZNY3Rya3JYekhoeFVmeWhFak40ZC92MFpEY0xLYjJhcHhRL001eHlYczZZLS1uamlqU0pTcHkxYjZTZlFoVTBpRTl3PT0%3D--2fa84a4c1c2f2114e19cc970c442e96860169fb8;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:56 GMT
+  recorded_at: Thu, 28 May 2015 01:28:11 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/cannot_get_an_open_annotation_by_ID_with_content_type_application/n-triples_.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/cannot_get_an_open_annotation_by_ID_with_content_type_application/n-triples_.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"9c203846dc40cdd382585702dcd5006c"
+      - W/"40fd96b9e6b7b35868e19c9359e65400"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 2071bb09-3425-4abe-b79c-cff5d20d936e
+      - 03d13070-6702-436b-a4db-f6dc7c1b17c9
       X-Runtime:
-      - '1.724357'
+      - '2.378678'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:07:22 GMT
+      - Thu, 28 May 2015 01:27:30 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=SzhHU1hqUVZOVGt2dWRiV1FNOWRTTll6OHVUZzZYcHhpek5WdWlJT25tRUxLN0xYSThyU3BmTFoxaXdQR3BxWWtGbS9ZZWFPZ2dYaUVHUGFOdUJGUVVhVWxXWlh4RzJOZWtZckMvVjNFclNjOUs1Q0QyUmtNZEFJZVVsYmtWek9jN29hOGFoalNHQis2NzE0d1l0ejVvS0Rtc1VWcXRyYVZvZzBkN01FRWxya2VuTUo0cEp5Y0x5QVlLS1Y5OTh2cWw1SnFhK1FIcUlKcEhnMktVd3FRR1NvdEhNTHNwYTBKZkViOTdVcmlBZHdyTXA5dmFWMy91MVRTVENmZ0lrRi0tY3p5RG0xUnJYNGFHVnBpQU1IeXJSUT09--26caf2201656023490af8cb2e414d8652fe460c6;
+      - _internal_session=WHhzZHJBeDVSeE85cUNPWXg3M2xoUHhhZElNZEN6bDdDZ1Q0VzZRMWIxYjRWM3ptTXRBeHhjMzN0NWlSS1ovSDVrWSt2QnU1SEsrdU0rMU9iL0U4OHpLLy90Y0JZY3ZkbVhmeUdTY3Y0cERsQkVZYkYrM3ZxZlpwQVhCbndQTnJ1YUZSSHFTMDFvYm1pZUROY1NiTTlraCtoQXphZ3hpdFJrNSt1RVQ2STFZQVBESkJHZDM1a1RYR1FCUmNObkhzdDRLdGIvcGh4UG5pdWNONUI3SWNoNFZwWE5QbUM0MVZNNUJMVEtkRCtTTmRXbnVJM3Qzbk1rYkZnS1RzTEhETi0tOEg1My9iWUxOVWtseVZZc3E1cWsxUT09--a86e1f3c5f7ac37b1c11bc0f74e15b278347f0fb;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310878554220","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/06/7a/d4/9c/067ad49c-1a15-485c-a05e-b11c5d231b64","@type":"oa:Annotation","hasBody":"_:g70310878554220","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942027957080","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/a3/1a/b7/ed/a31ab7ed-50ad-4065-8b68-a2173d069b5b","@type":"oa:Annotation","hasBody":"_:g69942027957080","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:22 GMT
+  recorded_at: Thu, 28 May 2015 01:27:30 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:27 GMT
+      - Thu, 28 May 2015 01:27:30 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:27 GMT
+      - Thu, 28 May 2015 07:27:30 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:27 GMT
+  recorded_at: Thu, 28 May 2015 01:27:31 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:27 GMT
+      - Thu, 28 May 2015 01:27:31 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:27 GMT
+      - Thu, 28 May 2015 07:27:31 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:28 GMT
+  recorded_at: Thu, 28 May 2015 01:27:31 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:28 GMT
+      - Thu, 28 May 2015 01:27:31 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:28 GMT
+      - Thu, 28 May 2015 07:27:31 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:28 GMT
+  recorded_at: Thu, 28 May 2015 01:27:31 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:28 GMT
+      - Thu, 28 May 2015 01:27:31 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:28 GMT
+      - Thu, 28 May 2015 07:27:31 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:28 GMT
+  recorded_at: Thu, 28 May 2015 01:27:32 GMT
 - request:
     method: get
-    uri: http://localhost:3000/annotations/06%2F7a%2Fd4%2F9c%2F067ad49c-1a15-485c-a05e-b11c5d231b64
+    uri: http://localhost:3000/annotations/a3%2F1a%2Fb7%2Fed%2Fa31ab7ed-50ad-4065-8b68-a2173d069b5b
     body:
       encoding: US-ASCII
       string: ''
@@ -2475,13 +2475,13 @@ http_interactions:
       Content-Length:
       - '128007'
       X-Request-Id:
-      - 9ea36c8d-69cf-4c9b-8fdc-615a5c44ffb9
+      - 0722d0f0-5db2-4137-a98b-cb0d611a31c3
       X-Runtime:
-      - '0.324868'
+      - '0.331031'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:07:29 GMT
+      - Thu, 28 May 2015 01:27:32 GMT
       Connection:
       - Keep-Alive
     body:
@@ -3818,7 +3818,7 @@ http_interactions:
         && el) {\n          currentSource.className += \" hidden\";\n          el.className
         = el.className.replace(\" hidden\", \"\");\n          currentSource = el;\n
         \       }\n      }\n    }\n  </script>\n</div>\n\n  \n\n<h2 style=\"margin-top:
-        30px\">Request</h2>\n<p><b>Parameters</b>:</p> <pre>{&quot;id&quot;=&gt;&quot;06/7a/d4/9c/067ad49c-1a15-485c-a05e-b11c5d231b64&quot;}</pre>\n\n<div
+        30px\">Request</h2>\n<p><b>Parameters</b>:</p> <pre>{&quot;id&quot;=&gt;&quot;a3/1a/b7/ed/a31ab7ed-50ad-4065-8b68-a2173d069b5b&quot;}</pre>\n\n<div
         class=\"details\">\n  <div class=\"summary\"><a href=\"#\" onclick=\"return
         toggleSessionDump()\">Toggle session dump</a></div>\n  <div id=\"session_dump\"
         style=\"display:none\"><pre></pre></div>\n</div>\n\n<div class=\"details\">\n
@@ -3828,7 +3828,7 @@ http_interactions:
         &quot;gzip, deflate&quot;\nREMOTE_ADDR: &quot;127.0.0.1&quot;\nREMOTE_HOST:
         &quot;127.0.0.1&quot;\nSERVER_NAME: &quot;localhost&quot;\nSERVER_PROTOCOL:
         &quot;HTTP/1.1&quot;</pre></div>\n</div>\n\n<h2 style=\"margin-top: 30px\">Response</h2>\n<p><b>Headers</b>:</p>
-        <pre>None</pre>\n\n</div>\n\n\n</body>\n</html>\n<div id=\"console\"\n  data-remote-path='console/repl_sessions/ff9b3d36d460e768689b9a8cc1e9677f'\n
+        <pre>None</pre>\n\n</div>\n\n\n</body>\n</html>\n<div id=\"console\"\n  data-remote-path='console/repl_sessions/7e6754765f382b33876161efcb8dcb4b'\n
         \ data-initial-prompt='>> '>\n</div>\n\n\n<script type=\"text/javascript\">\n(function()
         {\n  // DOM helpers\nfunction hasClass(el, className) {\n  var regex = new
         RegExp('(?:^|\\\\s)' + className + '(?!\\\\S)', 'g');\n  return el.className.match(regex);\n}\n\nfunction
@@ -4025,10 +4025,10 @@ http_interactions:
         \   resizerElement.addEventListener('mouseup', recordConsoleElementHeight);\n
         \ });\n});\n\n}).call(this);\n</script>\n\n"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:29 GMT
+  recorded_at: Thu, 28 May 2015 01:27:32 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/06%2F7a%2Fd4%2F9c%2F067ad49c-1a15-485c-a05e-b11c5d231b64
+    uri: http://localhost:3000/annotations/a3%2F1a%2Fb7%2Fed%2Fa31ab7ed-50ad-4065-8b68-a2173d069b5b
     body:
       encoding: US-ASCII
       string: ''
@@ -4055,22 +4055,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - b329ae1e-5406-4bfd-a4a1-b09cc11ca86f
+      - 09517f36-88e9-4396-bcca-4aa780fcc677
       X-Runtime:
-      - '0.191027'
+      - '0.183926'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:07:29 GMT
+      - Thu, 28 May 2015 01:27:32 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=WVRCeEdEd0JDdS93YUw2ZWJIRTQ1ZTRKZmNEMWlUM2JHSk1EeFBFRmVrNXB3UXRmdGgySDgrdjJaYTNTTFdjQUhLVlB2ei93QjlncW56clVaWjZ3MnVrT0E4L2IrNmdTNFRGRmhNdElZQk03ZVovajNLSmxHU3ZVak5VcEZFaWExZmlwcnJhQy9uYVBoOTh3b2xGaURrNS9wL0JoWWd2bmFiOGtYa1hUZ3NSNzhpT1VBSnFuTEtvNGFHVWh1Tkl4LS1URTBJNUR6NGIzTWR2dEtzM0U4OC9BPT0%3D--08e63450576951d3e614f04cef02bd4cd33b1cf6;
+      - _internal_session=amwrK2s5Mzd5SHdyMFVBMjIyZkJtN3FwbVVMUFkxQUF3alpUQkdpNElNem11M0IzNzM4MVZnMUc2ckpvUVNtTGNRaldHaDBGYnBwYTlNMWFDemhGcFUyeno1c1kreWNyUHBvRW92Z1l3MHVSYmVkb2hQYkFmRVA4M0hWR0gwSWpxT2R6cXlBOHdua3hqMjBLQ3Yybm9YOEo3OGZTdjdiejRUT0lUWStrWVZrZ08yRUd6SW54WFUrUmxrQ212VXBvLS13ZFNYQXJEYW9JS2pMVklYRWJkeFZRPT0%3D--0e8a12251a061e33797064ec77ef134b804058a0;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:29 GMT
+  recorded_at: Thu, 28 May 2015 01:27:32 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/cannot_get_an_open_annotation_by_ID_with_content_type_application/rdf_json_.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/cannot_get_an_open_annotation_by_ID_with_content_type_application/rdf_json_.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"d3246cda7c13b5035df254234ad3fdbc"
+      - W/"6e7cb30d92e430c5445defb31404fd47"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - ef5af274-2407-4226-aef3-f09e672f521b
+      - e2dd4674-8f1a-450c-9dee-0277fa2f34a1
       X-Runtime:
-      - '1.875340'
+      - '2.349364'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:40 GMT
+      - Thu, 28 May 2015 01:26:38 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=cHM1YTAvMXhDTSs5ODdVTlFDSndaT3Z0b1hzQ3RrWWJkeW1aclkzS25hUHlSQ0xDTG5yWXViQ3V2TFlKN2QxbVFjVFoyUlgwblgvQkJDMFcyRXRycDQ2VmJHTzBJQm9ZWEY2aUMwVG9SUkljc2ZRYkdnRUZ6MWlWNXhuZW9KSHdxN0ZpSXZqN3lQZC9pZHNFVEZSTXY0eUJwZ1h5Y0V3YmUwT0kyblp6ZklieS9jb0wvQmxyaXZ2TmpyRlZFOTNjRklLdmxhRW4zbHJYL1ZqZDVpQnJuTVRKWWJtOE92bkx4M1dobk9NczhpYWNabjRETkIva05MRW54UTNMaHNQZS0tUCt5QVpqRDh1MFIyeUlCL1gxaGdXQT09--4e1cf941fe9b4484738a3933d2bf7f694e6b5f70;
+      - _internal_session=QTBwSllaeU83SGJXcVBrTjlpM3Bic21hWEVyS1lHeERmM3hQbUFZWWViWTR3RGhCUUZzRTRiREl1bHZyYTRYeDNzZlQ1Q3IyR3BpOEhVc2tCTGs0SlI0K2h3WFNtUmhqek9wbkNDQjlHRmFjZjBkUlFKemcwS3JvaXEwQXdiV3ZsNHc3TDBBNlloTURLaytjQXBPL0xXai9YS1lPOFplVU9PN2Yxc3RGREdRVUpuNlRJbkRndTQvUzgzdlhrbTVSMTlkUkVlT3MrTWYrSWtUMGYvMzBkUHJOemtkaXUyZ3dib2dqem1aTHZ4SUMzd09iQXU3dVV0TnFaLzBoU0U0Ny0tS0ZZb2x5TjFiYmVlUE5BOW15SzUydz09--39942bca29dd552ce8efcff9efceb50b24055175;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310842421900","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/28/ec/9d/7f/28ec9d7f-616c-45ce-8509-9dc7b1933097","@type":"oa:Annotation","hasBody":"_:g70310842421900","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942002576000","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/56/07/67/85/56076785-62af-4370-b4d7-dae482598cd4","@type":"oa:Annotation","hasBody":"_:g69942002576000","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:40 GMT
+  recorded_at: Thu, 28 May 2015 01:26:38 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:40 GMT
+      - Thu, 28 May 2015 01:26:38 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:40 GMT
+      - Thu, 28 May 2015 07:26:38 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:40 GMT
+  recorded_at: Thu, 28 May 2015 01:26:38 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:40 GMT
+      - Thu, 28 May 2015 01:26:38 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:40 GMT
+      - Thu, 28 May 2015 07:26:38 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:40 GMT
+  recorded_at: Thu, 28 May 2015 01:26:39 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:41 GMT
+      - Thu, 28 May 2015 01:26:39 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:41 GMT
+      - Thu, 28 May 2015 07:26:39 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:41 GMT
+  recorded_at: Thu, 28 May 2015 01:26:39 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:41 GMT
+      - Thu, 28 May 2015 01:26:39 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:41 GMT
+      - Thu, 28 May 2015 07:26:39 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:41 GMT
+  recorded_at: Thu, 28 May 2015 01:26:39 GMT
 - request:
     method: get
-    uri: http://localhost:3000/annotations/28%2Fec%2F9d%2F7f%2F28ec9d7f-616c-45ce-8509-9dc7b1933097
+    uri: http://localhost:3000/annotations/56%2F07%2F67%2F85%2F56076785-62af-4370-b4d7-dae482598cd4
     body:
       encoding: US-ASCII
       string: ''
@@ -2475,13 +2475,13 @@ http_interactions:
       Content-Length:
       - '128006'
       X-Request-Id:
-      - 4e9d7db7-0c42-4273-baa6-776924dfa8dd
+      - e2584e08-4f40-4fee-9471-8fafa6154d23
       X-Runtime:
-      - '0.366217'
+      - '0.293952'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:41 GMT
+      - Thu, 28 May 2015 01:26:40 GMT
       Connection:
       - Keep-Alive
     body:
@@ -3818,7 +3818,7 @@ http_interactions:
         && el) {\n          currentSource.className += \" hidden\";\n          el.className
         = el.className.replace(\" hidden\", \"\");\n          currentSource = el;\n
         \       }\n      }\n    }\n  </script>\n</div>\n\n  \n\n<h2 style=\"margin-top:
-        30px\">Request</h2>\n<p><b>Parameters</b>:</p> <pre>{&quot;id&quot;=&gt;&quot;28/ec/9d/7f/28ec9d7f-616c-45ce-8509-9dc7b1933097&quot;}</pre>\n\n<div
+        30px\">Request</h2>\n<p><b>Parameters</b>:</p> <pre>{&quot;id&quot;=&gt;&quot;56/07/67/85/56076785-62af-4370-b4d7-dae482598cd4&quot;}</pre>\n\n<div
         class=\"details\">\n  <div class=\"summary\"><a href=\"#\" onclick=\"return
         toggleSessionDump()\">Toggle session dump</a></div>\n  <div id=\"session_dump\"
         style=\"display:none\"><pre></pre></div>\n</div>\n\n<div class=\"details\">\n
@@ -3828,7 +3828,7 @@ http_interactions:
         &quot;gzip, deflate&quot;\nREMOTE_ADDR: &quot;127.0.0.1&quot;\nREMOTE_HOST:
         &quot;127.0.0.1&quot;\nSERVER_NAME: &quot;localhost&quot;\nSERVER_PROTOCOL:
         &quot;HTTP/1.1&quot;</pre></div>\n</div>\n\n<h2 style=\"margin-top: 30px\">Response</h2>\n<p><b>Headers</b>:</p>
-        <pre>None</pre>\n\n</div>\n\n\n</body>\n</html>\n<div id=\"console\"\n  data-remote-path='console/repl_sessions/606a0ca6ef1ea4134ec85b0f514e0335'\n
+        <pre>None</pre>\n\n</div>\n\n\n</body>\n</html>\n<div id=\"console\"\n  data-remote-path='console/repl_sessions/f7fc18620a6e72f2a17a21dcf2048bce'\n
         \ data-initial-prompt='>> '>\n</div>\n\n\n<script type=\"text/javascript\">\n(function()
         {\n  // DOM helpers\nfunction hasClass(el, className) {\n  var regex = new
         RegExp('(?:^|\\\\s)' + className + '(?!\\\\S)', 'g');\n  return el.className.match(regex);\n}\n\nfunction
@@ -4025,10 +4025,10 @@ http_interactions:
         \   resizerElement.addEventListener('mouseup', recordConsoleElementHeight);\n
         \ });\n});\n\n}).call(this);\n</script>\n\n"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:41 GMT
+  recorded_at: Thu, 28 May 2015 01:26:40 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/28%2Fec%2F9d%2F7f%2F28ec9d7f-616c-45ce-8509-9dc7b1933097
+    uri: http://localhost:3000/annotations/56%2F07%2F67%2F85%2F56076785-62af-4370-b4d7-dae482598cd4
     body:
       encoding: US-ASCII
       string: ''
@@ -4055,22 +4055,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - c0ab5d3b-b162-4b7d-a375-3675c1e4a73e
+      - da769498-1ea3-4a1e-824e-0b481c6ea7cd
       X-Runtime:
-      - '0.247942'
+      - '0.232797'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:42 GMT
+      - Thu, 28 May 2015 01:26:40 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=RXF6QkZRcDI2WEdKeFhNMzRCQy9LNW5kYWw2b3R0QjFmNHhLQnFzWE9ITHY0Z3hlRTJZcW9VYUpPc3dPNmxMYXNiMTRxeDFpT0xJcDNPSGpKVTh0Z0pZQTJwUWh0a2dVWDBWNHdPNCtYc1FEK1I0UThkUDNacVZ5MCtCelpJbDZKRitVWXBLck1FRGJETk1NUHgyOXV1LzFnQTkzR0VkSTBtbFdTSkNpSlhCRWdBM1NQZTV3THRVOU4wa1NBOGtjLS0zOXIyZUx2NC8xb2h5S0ZweXJxSFdBPT0%3D--98ff25e39746e6e4e6fe4a6c4ef768fdd8856d37;
+      - _internal_session=UzZHb1lPdDNiMVQ4UkxrQ3RoOU1TREI0b2FPTGFaVzd2bkg4Z0Y2L1JSL21abzJ2alR4NFVRWlRwR2NKbkFFNlRrdXZXVGszSzJaam5xdTh1WXVLWGFBVVZrS1dXMFNrTkRRNkNGcG1tNEJZWWF4bGtOUVlaUUd1QjQzaDREM01sU2prdzltdU1BaDhzNldtWFBFVDA4TlBxSjJGUisyKzliNFM4bFRBSGRwcnB0Z1pubi9iSEt4V1BSeHdqRlpULS03SndrWWVPMms4MEt0dVM4Rmlid1BRPT0%3D--f51f2448286a6d73f458e61d77581cb3b691ffa7;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:42 GMT
+  recorded_at: Thu, 28 May 2015 01:26:40 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/cannot_get_an_open_annotation_by_ID_with_content_type_application/rdf_n3_.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/cannot_get_an_open_annotation_by_ID_with_content_type_application/rdf_n3_.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"df921f15e0ce1445fa7aafa0b92fd5df"
+      - W/"679958bbb2c4f003d95f6753334d8166"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 6350c440-4b9f-478f-867a-ce812d3e4476
+      - 1f9f6fa8-8d54-49dc-94c2-be2f52bbf11d
       X-Runtime:
-      - '1.605393'
+      - '2.436326'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:07:34 GMT
+      - Thu, 28 May 2015 01:27:39 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=ZWRpVTU4anJqZE1saFJCQzJBelVLM2pDbGVMU1k1UFErSGt0ZzZWRnptWkJXdUVKMUJsUXd2UDdYUzdHbEJSQ2I1UFhxNkJiKytpZG1TVzE4UmM1cmwxdkxrVE13OW5HdjdJK2hINTBnbGM2TkQ4Wk5VZkJsakFMRTB6U3NsTHV4MXVWVFlHNGRvTEVjRVV4TkdVMVRJdnl1bEpqQ0V6RFhLbWZWWHREV3p1aE1xMnpZdkNJOUQ3ZFFVNHBWZGpGODRuN1pUUG9OdnpObzVuU002aVY1WlVTamRzN0h6eUZQRU5HSjYzTzRybEYxeUhDSFo2bkl2MkFQNUNyT0NMYS0tMHNPZFJzWWJmNkcwWXFjSUdWY2NIZz09--444996e59ec963d5601492ef20771bfa40fcbb9e;
+      - _internal_session=RXhrM3pqZ0Y5VWdyMDFnT1UzVHRQUlpDZy81cXhnQ2RyK2M2WXdBQ1ArWDEwZEp2SncyYWtGTEFibFBjUHRFVFdybm9vU1B5V25MQXF5WmRLZ0M2MFpwTDlmd1NreXFiQjFSSWJId2ZyS1BobWREWXF6T012dVNGTmQzUXB2aHVqR1BHWllNWnJwdU5hc2JZS0JwTVJKaTJvNHdld1picFVjaE1BUS9BbS9oU3BGQ3J6SW1HTmM1Vmp3cVNiUUpKS1ZaOGhjRXFyNXZhZDBNK2ZIMnVLenBuckRMM0hEbXhsUERTQk5nRkdDbmdFL0lmTlR2ZkVXY0pXTjNadEFFai0tUmwxeUdnb1k2TlEwcVVETTQ3STJNQT09--64868dd22e4592fa5dc789953d55b99ffc117549;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310857025900","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/cf/bd/1a/c6/cfbd1ac6-4a6b-4006-a741-52588f2dae70","@type":"oa:Annotation","hasBody":"_:g70310857025900","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942002020660","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/d9/bf/b9/48/d9bfb948-59cf-4b1e-b5e4-311751ae72b4","@type":"oa:Annotation","hasBody":"_:g69942002020660","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:34 GMT
+  recorded_at: Thu, 28 May 2015 01:27:39 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:34 GMT
+      - Thu, 28 May 2015 01:27:39 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:34 GMT
+      - Thu, 28 May 2015 07:27:39 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:34 GMT
+  recorded_at: Thu, 28 May 2015 01:27:40 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:34 GMT
+      - Thu, 28 May 2015 01:27:40 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:34 GMT
+      - Thu, 28 May 2015 07:27:40 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:35 GMT
+  recorded_at: Thu, 28 May 2015 01:27:40 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:35 GMT
+      - Thu, 28 May 2015 01:27:40 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:35 GMT
+      - Thu, 28 May 2015 07:27:40 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:35 GMT
+  recorded_at: Thu, 28 May 2015 01:27:40 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:35 GMT
+      - Thu, 28 May 2015 01:27:40 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:35 GMT
+      - Thu, 28 May 2015 07:27:40 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:35 GMT
+  recorded_at: Thu, 28 May 2015 01:27:41 GMT
 - request:
     method: get
-    uri: http://localhost:3000/annotations/cf%2Fbd%2F1a%2Fc6%2Fcfbd1ac6-4a6b-4006-a741-52588f2dae70
+    uri: http://localhost:3000/annotations/d9%2Fbf%2Fb9%2F48%2Fd9bfb948-59cf-4b1e-b5e4-311751ae72b4
     body:
       encoding: US-ASCII
       string: ''
@@ -2475,13 +2475,13 @@ http_interactions:
       Content-Length:
       - '128004'
       X-Request-Id:
-      - cd5929e2-cfa2-4bae-9909-83aeeca2f227
+      - c31dae58-fbf6-45d3-870a-4b6f0fcf2c5b
       X-Runtime:
-      - '0.361867'
+      - '0.325280'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:07:36 GMT
+      - Thu, 28 May 2015 01:27:41 GMT
       Connection:
       - Keep-Alive
     body:
@@ -3818,7 +3818,7 @@ http_interactions:
         && el) {\n          currentSource.className += \" hidden\";\n          el.className
         = el.className.replace(\" hidden\", \"\");\n          currentSource = el;\n
         \       }\n      }\n    }\n  </script>\n</div>\n\n  \n\n<h2 style=\"margin-top:
-        30px\">Request</h2>\n<p><b>Parameters</b>:</p> <pre>{&quot;id&quot;=&gt;&quot;cf/bd/1a/c6/cfbd1ac6-4a6b-4006-a741-52588f2dae70&quot;}</pre>\n\n<div
+        30px\">Request</h2>\n<p><b>Parameters</b>:</p> <pre>{&quot;id&quot;=&gt;&quot;d9/bf/b9/48/d9bfb948-59cf-4b1e-b5e4-311751ae72b4&quot;}</pre>\n\n<div
         class=\"details\">\n  <div class=\"summary\"><a href=\"#\" onclick=\"return
         toggleSessionDump()\">Toggle session dump</a></div>\n  <div id=\"session_dump\"
         style=\"display:none\"><pre></pre></div>\n</div>\n\n<div class=\"details\">\n
@@ -3828,7 +3828,7 @@ http_interactions:
         &quot;gzip, deflate&quot;\nREMOTE_ADDR: &quot;127.0.0.1&quot;\nREMOTE_HOST:
         &quot;127.0.0.1&quot;\nSERVER_NAME: &quot;localhost&quot;\nSERVER_PROTOCOL:
         &quot;HTTP/1.1&quot;</pre></div>\n</div>\n\n<h2 style=\"margin-top: 30px\">Response</h2>\n<p><b>Headers</b>:</p>
-        <pre>None</pre>\n\n</div>\n\n\n</body>\n</html>\n<div id=\"console\"\n  data-remote-path='console/repl_sessions/3cae29dbee58f494b90d235fee8483f3'\n
+        <pre>None</pre>\n\n</div>\n\n\n</body>\n</html>\n<div id=\"console\"\n  data-remote-path='console/repl_sessions/622cd9563856eeb39775b1da143cb627'\n
         \ data-initial-prompt='>> '>\n</div>\n\n\n<script type=\"text/javascript\">\n(function()
         {\n  // DOM helpers\nfunction hasClass(el, className) {\n  var regex = new
         RegExp('(?:^|\\\\s)' + className + '(?!\\\\S)', 'g');\n  return el.className.match(regex);\n}\n\nfunction
@@ -4025,10 +4025,10 @@ http_interactions:
         \   resizerElement.addEventListener('mouseup', recordConsoleElementHeight);\n
         \ });\n});\n\n}).call(this);\n</script>\n\n"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:36 GMT
+  recorded_at: Thu, 28 May 2015 01:27:41 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/cf%2Fbd%2F1a%2Fc6%2Fcfbd1ac6-4a6b-4006-a741-52588f2dae70
+    uri: http://localhost:3000/annotations/d9%2Fbf%2Fb9%2F48%2Fd9bfb948-59cf-4b1e-b5e4-311751ae72b4
     body:
       encoding: US-ASCII
       string: ''
@@ -4055,22 +4055,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 8fd37b7c-5bf9-4d92-bdaf-5c7ef893d767
+      - 03ec70ea-576c-45ac-9deb-62ba438e074a
       X-Runtime:
-      - '0.192591'
+      - '0.217479'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:07:36 GMT
+      - Thu, 28 May 2015 01:27:42 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=NCs3d3QrMGF0T0p3ZXZqR1JMOUovWHBMRlAvM3hDdFZ5K1RNbUg4TG9xUVNDSUVOQ281cDRGVnBwNHA5cmdGdW85UllmakxZbDUyY1dYNEtDd1FtV0s0ck5uS3F5K2JzL0xKbFNueTViQXdrK2luanpHc3lNVVV3ditzZ2YrdGg3QnFkQmxiUXl4YkxreUdRbnZXSGdnZzdSeE5FZzUxNmY5VW1XK0NyeDg5b3VDQXJpSG02KzRLckluLzBqVk5wLS10Z0l3YkNGQ2pCcWt3NENTM2o2M0NBPT0%3D--c63144a0f7a292a2592c9ea7de4a43b81c42d84a;
+      - _internal_session=bHBWQnhuR3BQTkRtVnZiVUNTTmkyOFB2MDJ5a3gvSERaNVVhZXd4dFh1bWM2TEwyZHBET1R6NG9iYzhPYWo5aS8yelNQQ2tuSnZ4WGVQTDltQlUwK1Bqc1VTU0xKZDk2c04rQ1NyWEV6alRUTGxTSTRDenFTTVB6cFN6QVZRb1hlUVhsTng5bjdWenFuVkZxSmFFRkxBU0ZmUU9uekhBQ3N6UDUrbUgrOEp4a1VlNnZFSlhUUFZHTHA2djlBSk9BLS1TNTBwWE9yRUVnMW5iaGJsZ3owU053PT0%3D--23acca7a1c5c14631a14ec18b1ae312288fdb753;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:36 GMT
+  recorded_at: Thu, 28 May 2015 01:27:42 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/cannot_get_an_open_annotation_by_ID_with_content_type_application/trig_.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/cannot_get_an_open_annotation_by_ID_with_content_type_application/trig_.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"7d9cc95f794300823f2840dffe29f648"
+      - W/"b16cc2924039feb18e9618086343ac05"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - f2774901-e975-4728-a35a-88730ac3fe73
+      - 3e98996a-a1bb-4569-a440-7df2d44dd729
       X-Runtime:
-      - '1.714655'
+      - '2.169325'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:08:09 GMT
+      - Thu, 28 May 2015 01:29:27 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=U1hVb3ROeXRSNjZIUndlcGpOcUxFamU4T3JoTHdHeDFXaDkrOWpsYW1neHZLRitQNEtWeUh5RlRicWpXZnU0MGFIaVYyS2VNMmp6OFVzZ3E4MUJwQ2JvSU9jditpelJUYVBiQXFiVFpiSDhFWDhjb1E3dzVLQXAvSSs1NWlEbXZFZ2VzL0xwdHVoTXJhcjYwTVpLOFRNZE1LZjZPT2gwQ3l0T3ZPMldSMm5uT1A3SkVlSi90c2tQN1JiTHJtbDlwTEZ0Z21SbXF6R1M1UzFWcWZuQm4vM0xKa2dCbXdGVzF2cllrUGxYR3NYZmVsVitlZnFFbDh2YnRNNUN6U2N3VS0tVlRmc3NGeURuSnNQWTJUdkxyVWcvQT09--73821c6dc0017cfabdddd0db3566951698286154;
+      - _internal_session=d1VrNW8vbktJU2JGUHBqdC93ejA4eTJWZ2pTODV2NVdGUWVpdVcvWHBBOHd6VGdQUExjSjRhUCtZeS9UQTVTbUE2U0tsdSt4aGY4K1IwMVl4MEVPRE02TUJSaFRtNklTR1RXcDZSci9DZ212TlVDTzFOUC9wM0VSeE4rRWNjU3NjU0w5TjhwTDJVaFY0RG16emZ6UlEzWVF1MERwanhkMTM1MVpYSVJCcmVlck8za3lvWEhoN2d2OWUxZGFsYmFYL2RSL0VrcmFENFJUSnZhQmhDTnBRUWtTY2tJOHdvdVJPN1RJK1pINzBScnJER0JRYzNLUzA5TjREUkQwbzVNai0tcGpxOSswanBUTnQ5RDFMZ2VvNVdKUT09--82c3a2e348f1901f67aa5e6109959866b2b8235c;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310858837660","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/a4/9e/43/19/a49e4319-955f-4f3a-b372-69ada480b3b4","@type":"oa:Annotation","hasBody":"_:g70310858837660","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942001864960","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/94/90/4f/0a/94904f0a-8045-40d4-afc6-602b0eec16c0","@type":"oa:Annotation","hasBody":"_:g69942001864960","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:09 GMT
+  recorded_at: Thu, 28 May 2015 01:29:27 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:09 GMT
+      - Thu, 28 May 2015 01:29:27 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:09 GMT
+      - Thu, 28 May 2015 07:29:27 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:09 GMT
+  recorded_at: Thu, 28 May 2015 01:29:28 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:09 GMT
+      - Thu, 28 May 2015 01:29:28 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:09 GMT
+      - Thu, 28 May 2015 07:29:28 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:09 GMT
+  recorded_at: Thu, 28 May 2015 01:29:28 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:10 GMT
+      - Thu, 28 May 2015 01:29:28 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:10 GMT
+      - Thu, 28 May 2015 07:29:28 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:10 GMT
+  recorded_at: Thu, 28 May 2015 01:29:28 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:10 GMT
+      - Thu, 28 May 2015 01:29:28 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:10 GMT
+      - Thu, 28 May 2015 07:29:28 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:10 GMT
+  recorded_at: Thu, 28 May 2015 01:29:29 GMT
 - request:
     method: get
-    uri: http://localhost:3000/annotations/a4%2F9e%2F43%2F19%2Fa49e4319-955f-4f3a-b372-69ada480b3b4
+    uri: http://localhost:3000/annotations/94%2F90%2F4f%2F0a%2F94904f0a-8045-40d4-afc6-602b0eec16c0
     body:
       encoding: US-ASCII
       string: ''
@@ -2475,13 +2475,13 @@ http_interactions:
       Content-Length:
       - '128002'
       X-Request-Id:
-      - 5170ca39-a296-48c1-b093-9a4ff8d171e2
+      - 15dcc7ba-4a94-437a-93ca-ffa50f42714e
       X-Runtime:
-      - '0.345370'
+      - '0.275314'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:08:10 GMT
+      - Thu, 28 May 2015 01:29:29 GMT
       Connection:
       - Keep-Alive
     body:
@@ -3818,7 +3818,7 @@ http_interactions:
         && el) {\n          currentSource.className += \" hidden\";\n          el.className
         = el.className.replace(\" hidden\", \"\");\n          currentSource = el;\n
         \       }\n      }\n    }\n  </script>\n</div>\n\n  \n\n<h2 style=\"margin-top:
-        30px\">Request</h2>\n<p><b>Parameters</b>:</p> <pre>{&quot;id&quot;=&gt;&quot;a4/9e/43/19/a49e4319-955f-4f3a-b372-69ada480b3b4&quot;}</pre>\n\n<div
+        30px\">Request</h2>\n<p><b>Parameters</b>:</p> <pre>{&quot;id&quot;=&gt;&quot;94/90/4f/0a/94904f0a-8045-40d4-afc6-602b0eec16c0&quot;}</pre>\n\n<div
         class=\"details\">\n  <div class=\"summary\"><a href=\"#\" onclick=\"return
         toggleSessionDump()\">Toggle session dump</a></div>\n  <div id=\"session_dump\"
         style=\"display:none\"><pre></pre></div>\n</div>\n\n<div class=\"details\">\n
@@ -3828,7 +3828,7 @@ http_interactions:
         &quot;gzip, deflate&quot;\nREMOTE_ADDR: &quot;127.0.0.1&quot;\nREMOTE_HOST:
         &quot;127.0.0.1&quot;\nSERVER_NAME: &quot;localhost&quot;\nSERVER_PROTOCOL:
         &quot;HTTP/1.1&quot;</pre></div>\n</div>\n\n<h2 style=\"margin-top: 30px\">Response</h2>\n<p><b>Headers</b>:</p>
-        <pre>None</pre>\n\n</div>\n\n\n</body>\n</html>\n<div id=\"console\"\n  data-remote-path='console/repl_sessions/b53a60f27f2921398b63560ed2098416'\n
+        <pre>None</pre>\n\n</div>\n\n\n</body>\n</html>\n<div id=\"console\"\n  data-remote-path='console/repl_sessions/a8678795036c8f5b377e950504742121'\n
         \ data-initial-prompt='>> '>\n</div>\n\n\n<script type=\"text/javascript\">\n(function()
         {\n  // DOM helpers\nfunction hasClass(el, className) {\n  var regex = new
         RegExp('(?:^|\\\\s)' + className + '(?!\\\\S)', 'g');\n  return el.className.match(regex);\n}\n\nfunction
@@ -4025,10 +4025,10 @@ http_interactions:
         \   resizerElement.addEventListener('mouseup', recordConsoleElementHeight);\n
         \ });\n});\n\n}).call(this);\n</script>\n\n"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:10 GMT
+  recorded_at: Thu, 28 May 2015 01:29:29 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/a4%2F9e%2F43%2F19%2Fa49e4319-955f-4f3a-b372-69ada480b3b4
+    uri: http://localhost:3000/annotations/94%2F90%2F4f%2F0a%2F94904f0a-8045-40d4-afc6-602b0eec16c0
     body:
       encoding: US-ASCII
       string: ''
@@ -4055,22 +4055,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - c7eaf9b0-2c26-4534-a90e-b0bfa131749f
+      - 87b8afae-d90f-4ccb-b108-648e1dfdc57b
       X-Runtime:
-      - '0.233034'
+      - '0.184099'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:08:11 GMT
+      - Thu, 28 May 2015 01:29:29 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=MHFQamt2MmRrM3RLTVhjYWlsS21RekpNWE8wVHZMZFBpT01CUnRlUklaQm9DS1lNbzFkZUhwdmgxaU02RUhxNDloa1pzUmJXLzRYQi8rZmpCMGYydDVGUjRuUWZvVkluelBjc2hvTUNEN05tWTFPR0hwZ0ZXRDNvMUljOWNOb01BZ0xDZXJQZjBQb3BlZDgwK09KMjdZZ2VFRmlnaDdsc0tNYUFDU3FaN2hLVDdiaWYvb3E1WTZhR2VES09XNlVILS1BNzJXcE1zVVlRK2pMSHhvRjNMNUd3PT0%3D--f691c451ae881c832aa8e1cff869e644a32411d0;
+      - _internal_session=MWk4VE9kcGROSytrVVlKS2R1eUNuUlNVWlduTnJMbDFHWlFiWVdvRk45bGx3NkdJNzEzRFNGNUNJaHNkeW1VcjRzRWtWTlMrRlhlUUJtQ0pzUE0rVWtobk1oUkl4bHBVWUtndEpGQ3ZaTVQ4QnZ3dEwySk5ycHBpc3R4bEdxZzEweWpUVkhpQm52K1JRdEpQUGtQL2t0ZVFiS0tFVHlXakVUa1pKRE9OUWM3U0tzRytVczlLdkxoeGI1NTR1dUhHLS1TTHoxSXh5QWZ3NUVuQ3BJZW1sRyt3PT0%3D--6bf8dc0f4732eb02abd4d29b6f2ad467e49df034;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:11 GMT
+  recorded_at: Thu, 28 May 2015 01:29:29 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/cannot_get_an_open_annotation_by_ID_with_content_type_application/trix_.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/cannot_get_an_open_annotation_by_ID_with_content_type_application/trix_.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"fa9d3710573fef42c211fc0c4304b687"
+      - W/"b9519c343feaca18ca0265937d59839f"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 3b58e871-ea4a-45bd-a6e7-c06f29d983d0
+      - eaca1f03-5bc8-448a-83e6-c5cb159b2a2e
       X-Runtime:
-      - '1.603887'
+      - '2.157337'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:08:23 GMT
+      - Thu, 28 May 2015 01:29:44 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=QzNpZElhYXEvWEdaVmZDSW5VOXFvK3lMdkx1eklDWW40TDJDcFFPZ3FnSms1R1BBRGlXU0Ntd09zQk5VeVBTOVBQSlY1UmRrcS8vR2U2NjRyYTRwcWpyWmtwVVE0REpZdGNKbWd1VStkK0dEMUpGWjdlZ3lidldaK1psT1ovcVdoTVdVT09iY0YwUlk0SjNvZ0hIUk00OGNhc0tQMmd3RHBOOGdVRWZPUEJ5R1FGQldWWkI0SmJ5R1Mvam0rdnA0VmgvS1hvK3dJZS9KZEIvV01SNUIya1ptOG1LQ2Z5Wjk2OGpqMURGcThZb0pYaHdrQ0svTXlJNlAwYXhvV3FZdS0tRENoT2JJSXZSNi9LeVVxZDF5d1daQT09--92493aa49632d273aacd959e9cd7b12bd92c1595;
+      - _internal_session=ZjB4VnFJV0ViZXlaWlJlZEhSZGQwaHlidjZCdWpzTlNTb0J6UCs5TVN6RmFHOS9hclgvMUtKWUMvdUxiTXRPOVFVR1J4Wi9VV1JyaEhzU3c5bm5vc1cyV0wwNW15TVNqck9pTGhhK2NYV0JxVlZveHBQN1V0YUxXMWlDYUtQZWhXWDkvTkQzZ0MxckdjbTh6NWIxanp5Rng0aFJSc1hwMXFIN1cxN3VCK3pCQjU0Y1Q4YmpJTytVRHNWd2dkd29Dck45bGpvUjlwVUIvYUwzU01vSW04OGhHTlhuN2wzWkpTdlQxS0lpOVlhVVhaY0NTSUp5bDlMSWM2TG5QTEs5TC0tb0xrc3ZBenFIYm5DdmtyUU1UWDlPUT09--69d8215f811ae2ed220e6bc17732418532620405;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310859229000","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/85/ec/ce/45/85ecce45-8728-44c5-b103-f8142d772d3c","@type":"oa:Annotation","hasBody":"_:g70310859229000","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942033464300","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/ea/0d/83/04/ea0d8304-1ea6-425f-a790-23d80c8a22b8","@type":"oa:Annotation","hasBody":"_:g69942033464300","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:23 GMT
+  recorded_at: Thu, 28 May 2015 01:29:44 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:23 GMT
+      - Thu, 28 May 2015 01:29:44 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:23 GMT
+      - Thu, 28 May 2015 07:29:44 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:23 GMT
+  recorded_at: Thu, 28 May 2015 01:29:44 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:23 GMT
+      - Thu, 28 May 2015 01:29:45 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:23 GMT
+      - Thu, 28 May 2015 07:29:45 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:23 GMT
+  recorded_at: Thu, 28 May 2015 01:29:45 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:24 GMT
+      - Thu, 28 May 2015 01:29:45 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:24 GMT
+      - Thu, 28 May 2015 07:29:45 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:24 GMT
+  recorded_at: Thu, 28 May 2015 01:29:45 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:24 GMT
+      - Thu, 28 May 2015 01:29:45 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:24 GMT
+      - Thu, 28 May 2015 07:29:45 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:24 GMT
+  recorded_at: Thu, 28 May 2015 01:29:46 GMT
 - request:
     method: get
-    uri: http://localhost:3000/annotations/85%2Fec%2Fce%2F45%2F85ecce45-8728-44c5-b103-f8142d772d3c
+    uri: http://localhost:3000/annotations/ea%2F0d%2F83%2F04%2Fea0d8304-1ea6-425f-a790-23d80c8a22b8
     body:
       encoding: US-ASCII
       string: ''
@@ -2475,13 +2475,13 @@ http_interactions:
       Content-Length:
       - '128002'
       X-Request-Id:
-      - 9aef72bb-16cd-4a86-a427-21ea1e68f9ad
+      - 7da7cffe-ea0d-4894-b50c-163b1bc7e3fa
       X-Runtime:
-      - '0.339254'
+      - '0.276313'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:08:24 GMT
+      - Thu, 28 May 2015 01:29:46 GMT
       Connection:
       - Keep-Alive
     body:
@@ -3818,7 +3818,7 @@ http_interactions:
         && el) {\n          currentSource.className += \" hidden\";\n          el.className
         = el.className.replace(\" hidden\", \"\");\n          currentSource = el;\n
         \       }\n      }\n    }\n  </script>\n</div>\n\n  \n\n<h2 style=\"margin-top:
-        30px\">Request</h2>\n<p><b>Parameters</b>:</p> <pre>{&quot;id&quot;=&gt;&quot;85/ec/ce/45/85ecce45-8728-44c5-b103-f8142d772d3c&quot;}</pre>\n\n<div
+        30px\">Request</h2>\n<p><b>Parameters</b>:</p> <pre>{&quot;id&quot;=&gt;&quot;ea/0d/83/04/ea0d8304-1ea6-425f-a790-23d80c8a22b8&quot;}</pre>\n\n<div
         class=\"details\">\n  <div class=\"summary\"><a href=\"#\" onclick=\"return
         toggleSessionDump()\">Toggle session dump</a></div>\n  <div id=\"session_dump\"
         style=\"display:none\"><pre></pre></div>\n</div>\n\n<div class=\"details\">\n
@@ -3828,7 +3828,7 @@ http_interactions:
         &quot;gzip, deflate&quot;\nREMOTE_ADDR: &quot;127.0.0.1&quot;\nREMOTE_HOST:
         &quot;127.0.0.1&quot;\nSERVER_NAME: &quot;localhost&quot;\nSERVER_PROTOCOL:
         &quot;HTTP/1.1&quot;</pre></div>\n</div>\n\n<h2 style=\"margin-top: 30px\">Response</h2>\n<p><b>Headers</b>:</p>
-        <pre>None</pre>\n\n</div>\n\n\n</body>\n</html>\n<div id=\"console\"\n  data-remote-path='console/repl_sessions/74a8b4645661561f9a3ae3a091141edb'\n
+        <pre>None</pre>\n\n</div>\n\n\n</body>\n</html>\n<div id=\"console\"\n  data-remote-path='console/repl_sessions/63f2a507f02d10f78a9bec9f96c0dce0'\n
         \ data-initial-prompt='>> '>\n</div>\n\n\n<script type=\"text/javascript\">\n(function()
         {\n  // DOM helpers\nfunction hasClass(el, className) {\n  var regex = new
         RegExp('(?:^|\\\\s)' + className + '(?!\\\\S)', 'g');\n  return el.className.match(regex);\n}\n\nfunction
@@ -4025,10 +4025,10 @@ http_interactions:
         \   resizerElement.addEventListener('mouseup', recordConsoleElementHeight);\n
         \ });\n});\n\n}).call(this);\n</script>\n\n"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:24 GMT
+  recorded_at: Thu, 28 May 2015 01:29:46 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/85%2Fec%2Fce%2F45%2F85ecce45-8728-44c5-b103-f8142d772d3c
+    uri: http://localhost:3000/annotations/ea%2F0d%2F83%2F04%2Fea0d8304-1ea6-425f-a790-23d80c8a22b8
     body:
       encoding: US-ASCII
       string: ''
@@ -4055,22 +4055,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - c9a6e5b4-5314-4699-a281-fd4af4da41e0
+      - adf67252-b957-4d1e-b780-6211484ca2e3
       X-Runtime:
-      - '0.187929'
+      - '0.179805'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:08:25 GMT
+      - Thu, 28 May 2015 01:29:46 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=NE5WUnVoYm1PS0U3enFoVEd6a1Q0ZGVrUy94c2pvNWI4eVJkVzlPaHBhc3RIRzJFR080cW52N0F6WGczSVBmQ0ZQYjlWS2plcko4bXVUSG5MN09mckdNK01MR3JibWY0OWNmM3NvYkdSYnhvcnZybEpuQzkxOTZad1pqWFIxWXhKdGR4OUg1c0kyT2RJd1Zqc1ZEN29EenpwTUtvSlg2elNwUlZ5OXBVNHlmaUhtQm50SEJxR2djQ0hNVWNwdWk1LS05NU9rNTRHbjBoYVE5eTBVVU42Y1NRPT0%3D--09e94047c2b9a3720e6cad92d31ce968bace14dc;
+      - _internal_session=TlBUa2RqWWxNSnpSdjU4V3hIZjhNNHhnOWRKTWNkSGhsSUlGbXRwUVBxQTlRV3UwUHlxRnY2aWl2NXVrZGxNc1JMOTd1aXNXSUtTYlB1TnQ5Mno1bkFXdmRCaDZ6dm5iVUlNY1lkRU44RTlXbTdaK1hLYXd5TU9PdnkrVm5HZlJ5czA1VTN0dm1HdXhMU2hYMVMrTnpDUHdZZnovQVhuNEJPTTM0UTYxcXFLRXNqejM0d2VSMVVMbzlYSDRlNlJBLS1jYXZZVGJZWnpKM0QzclF0Z3Vqc3RBPT0%3D--23cec2eb64b0c8554b5448306f571efea0905e5e;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:25 GMT
+  recorded_at: Thu, 28 May 2015 01:29:46 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/cannot_get_an_open_annotation_by_ID_with_content_type_application/turtle_.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/cannot_get_an_open_annotation_by_ID_with_content_type_application/turtle_.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"47780e1d341a1987edb49e0484a3b465"
+      - W/"028469360565d6d4b766f750eaa148b3"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 6599a70c-202b-4408-a041-d4d7dd4eec2d
+      - fd49c077-1a71-43e4-ba89-5d1d2d816db5
       X-Runtime:
-      - '1.702650'
+      - '2.106565'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:07:09 GMT
+      - Thu, 28 May 2015 01:27:13 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=SU1NVkYzT1FTaWtjSTRvdmpldTBsOCtZMXE5WTF2U2NwTHY1YzVRYmMyVG94ekVtN3B2LzlGb001SURwZW5RblBBVDNPaVBHTTJ3RU1iTFd3dmhXcWpYNlVsSjBNaWhpWHdTOG9KUUJuOGJ1Sm1XY1d2aVZaWUhiMVNsNTZzd3FXQ3VycytlaFdBSE5WUlE3SWthRlhZLyt2d3A3aHhMYnprUmxuanNvaURwdmFPRFh1ZzlkSTUxQUN2cXJHSDZkU1FRSlhKcnNIVXp3TElQSDc5aGN3M1NaaGJtbnoyRUJHcmJYS0Z3REFUYmljZC9PdkJTM05RWG5oeWJqSkt1WC0tZnZITzNuY0VaWm11RmwyV2RveThsQT09--ca7a191356bb294c65c8885a59c9f20af4433ca5;
+      - _internal_session=S3phTEY5WTVVUHY1Sm9kcW9qNVRReXcreWJ5cllZN2tqeDRLakZrY2hFTXczZ1BQOC84QTcxTW95SGNVYVBUZWlGMkxUQWRjR1lsQVlzT0g1RWNVb1JYalBUOVFEVWM0SDMwSXVaNm9xNkpOQWxmaURneDBMMlg3b2FHbG1HVUhaeWxUUVplaXVGMnJ0ZmVzd01NSU4yNVhnWTBqbFVRTERKcnd1N2c3cjFQOUx4UWFGeWo2TDNhU3l3MkJWY0FYSzV1SlJ5dUdBa0o3WTJhSnEwR1ptWlBORWg0M1JQTjE5Z0hSQU9nR0RIMUJYWmIwL0FGdEhhdDFSOS90bHc1bC0tRXcrT1pvblo4RCs4dEZJZ2FRa2dHZz09--7aaed52939cafbb971b8f8f1c46574cef02c02f5;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310875657160","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/d9/3b/90/0c/d93b900c-76ca-4256-b659-d3c28934d071","@type":"oa:Annotation","hasBody":"_:g70310875657160","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942002658400","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/4a/07/b7/25/4a07b725-0da9-4490-9c48-4b9e385095e5","@type":"oa:Annotation","hasBody":"_:g69942002658400","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:09 GMT
+  recorded_at: Thu, 28 May 2015 01:27:13 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:09 GMT
+      - Thu, 28 May 2015 01:27:13 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:09 GMT
+      - Thu, 28 May 2015 07:27:13 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:09 GMT
+  recorded_at: Thu, 28 May 2015 01:27:13 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:09 GMT
+      - Thu, 28 May 2015 01:27:13 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:09 GMT
+      - Thu, 28 May 2015 07:27:13 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:09 GMT
+  recorded_at: Thu, 28 May 2015 01:27:14 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:09 GMT
+      - Thu, 28 May 2015 01:27:14 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:09 GMT
+      - Thu, 28 May 2015 07:27:14 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:09 GMT
+  recorded_at: Thu, 28 May 2015 01:27:14 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:09 GMT
+      - Thu, 28 May 2015 01:27:14 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:09 GMT
+      - Thu, 28 May 2015 07:27:14 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:10 GMT
+  recorded_at: Thu, 28 May 2015 01:27:15 GMT
 - request:
     method: get
-    uri: http://localhost:3000/annotations/d9%2F3b%2F90%2F0c%2Fd93b900c-76ca-4256-b659-d3c28934d071
+    uri: http://localhost:3000/annotations/4a%2F07%2Fb7%2F25%2F4a07b725-0da9-4490-9c48-4b9e385095e5
     body:
       encoding: US-ASCII
       string: ''
@@ -2475,13 +2475,13 @@ http_interactions:
       Content-Length:
       - '128004'
       X-Request-Id:
-      - 2e53df5c-8966-4028-9f19-1c35869e9d52
+      - 0700a4e2-f31c-41f7-b4be-ec338fb86676
       X-Runtime:
-      - '0.327789'
+      - '0.276731'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:07:10 GMT
+      - Thu, 28 May 2015 01:27:15 GMT
       Connection:
       - Keep-Alive
     body:
@@ -3818,7 +3818,7 @@ http_interactions:
         && el) {\n          currentSource.className += \" hidden\";\n          el.className
         = el.className.replace(\" hidden\", \"\");\n          currentSource = el;\n
         \       }\n      }\n    }\n  </script>\n</div>\n\n  \n\n<h2 style=\"margin-top:
-        30px\">Request</h2>\n<p><b>Parameters</b>:</p> <pre>{&quot;id&quot;=&gt;&quot;d9/3b/90/0c/d93b900c-76ca-4256-b659-d3c28934d071&quot;}</pre>\n\n<div
+        30px\">Request</h2>\n<p><b>Parameters</b>:</p> <pre>{&quot;id&quot;=&gt;&quot;4a/07/b7/25/4a07b725-0da9-4490-9c48-4b9e385095e5&quot;}</pre>\n\n<div
         class=\"details\">\n  <div class=\"summary\"><a href=\"#\" onclick=\"return
         toggleSessionDump()\">Toggle session dump</a></div>\n  <div id=\"session_dump\"
         style=\"display:none\"><pre></pre></div>\n</div>\n\n<div class=\"details\">\n
@@ -3828,7 +3828,7 @@ http_interactions:
         &quot;gzip, deflate&quot;\nREMOTE_ADDR: &quot;127.0.0.1&quot;\nREMOTE_HOST:
         &quot;127.0.0.1&quot;\nSERVER_NAME: &quot;localhost&quot;\nSERVER_PROTOCOL:
         &quot;HTTP/1.1&quot;</pre></div>\n</div>\n\n<h2 style=\"margin-top: 30px\">Response</h2>\n<p><b>Headers</b>:</p>
-        <pre>None</pre>\n\n</div>\n\n\n</body>\n</html>\n<div id=\"console\"\n  data-remote-path='console/repl_sessions/c8109025952d8b1234c954ccb5169a86'\n
+        <pre>None</pre>\n\n</div>\n\n\n</body>\n</html>\n<div id=\"console\"\n  data-remote-path='console/repl_sessions/e7a7e6b803956aea0bceea70698c7505'\n
         \ data-initial-prompt='>> '>\n</div>\n\n\n<script type=\"text/javascript\">\n(function()
         {\n  // DOM helpers\nfunction hasClass(el, className) {\n  var regex = new
         RegExp('(?:^|\\\\s)' + className + '(?!\\\\S)', 'g');\n  return el.className.match(regex);\n}\n\nfunction
@@ -4025,10 +4025,10 @@ http_interactions:
         \   resizerElement.addEventListener('mouseup', recordConsoleElementHeight);\n
         \ });\n});\n\n}).call(this);\n</script>\n\n"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:10 GMT
+  recorded_at: Thu, 28 May 2015 01:27:15 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/d9%2F3b%2F90%2F0c%2Fd93b900c-76ca-4256-b659-d3c28934d071
+    uri: http://localhost:3000/annotations/4a%2F07%2Fb7%2F25%2F4a07b725-0da9-4490-9c48-4b9e385095e5
     body:
       encoding: US-ASCII
       string: ''
@@ -4055,22 +4055,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - c1b7c17f-358a-4459-be95-59d29b5c827a
+      - 4eff47fa-c8c2-4833-a2aa-3801f4c3deb2
       X-Runtime:
-      - '0.217669'
+      - '0.175078'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:07:10 GMT
+      - Thu, 28 May 2015 01:27:15 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=S051YTExZEN3VTAzQXoyNjFTKzRSb0h3NlRhMW5MMnAraURWeFRwUXFVeDBXNzZpaXR5QUpUaTh6eDhhMkZ2SnlZS2xIbDNsdHc1NTBiZ0trMTJPTHJXN2UvT0VFZnVmb051WEQ5bGxJZi92NnpkOHZLNnVZbXpVZTZqMlB3Mm94elUzYnhsY2hrSmNKQWtFbVBRUFlVdkRiRHc0QWhJMjZ5SGdZNXV0eHhMSFpaWDRFMzhiei8xamZqRGowWHhBLS04aDduM2E4UzJORnpYQkZkd3ByNUtnPT0%3D--641baf3cd339c0f8c336850420355d44249547e3;
+      - _internal_session=eDhsNmttVHIxT09xUEY0Rm9hTnNxdytLcVY1anFCdnVraVpGY201RjBnV2hpTVNjYmM1bmFVTUM4SEdwb3Z4U2V4bWQrYi9GVkRqRzIvVEtPNFVUUE1NbjE0ZmFsL1J0TWVXTjg0T3h2cXRJalhaTWpkNzVjMmxIOFgvb2lQN2lsbWRzbEh2MUJMTW9zZ3pGcjNpbmo0aVVkY3ZpdEZmdUJDNE9pQjRLcDFTbTVpUGRRaTBKWWpST25KY1g2OWdTLS1kVVJiRkQ2VWpEOG5pZ1pqek5wYkJnPT0%3D--c774a7ae820202532df5e7e596081310eb7a6bd9;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:10 GMT
+  recorded_at: Thu, 28 May 2015 01:27:15 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/cannot_get_an_open_annotation_by_ID_with_content_type_application/x-ld_json_.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/cannot_get_an_open_annotation_by_ID_with_content_type_application/x-ld_json_.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"3277203c1aeb07b652904bf10fc8b3a5"
+      - W/"207b3340b4d7e000955b764c24919191"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 74081066-954d-4b87-a3dc-31614a780026
+      - 2a0ef5f5-20fe-44e1-bb13-6d8b4a81d6be
       X-Runtime:
-      - '1.835927'
+      - '2.131502'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:33 GMT
+      - Thu, 28 May 2015 01:26:29 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=VTh5eVZMODVRTnJxanQ1WndNZkpXd3hWcGRRenZ4OUFhUnFheEtVU3hCbHg3SjR2cGU4QjRiS0plMXBoSHI5WFRSSGl0eWZ6dndDcXhlakdjaFcyeHVCeTdHcGptVi9BMmFkY3RJZU1zSW9uOFYwR1dJcXFTUE5kejJOVmxNODBjU09haHNyYnMrRVhTSlgwdTNISTJmbG9hcEpveDQ3Tk1tZEJkc0NiaHc2MXZHK3IrTlIraHhTN1JBaHpZY216eVdIQit0aHRIOVdIenFDSVpIM04zZ0FMSlZmR0thOXJpbFk5YURYbVB6QzJXNUduNGhHVndMeWljb0YxdDJjSC0tMEwyQ25QZ2lqUkQ2R3hLemkxV21VQT09--14fccd112b2fa4a88c5a8678891f63a6b8bd01cb;
+      - _internal_session=Y1VZelk0WVF6L094SUs2cmVFY1FoTE1qbTErUWhxaUNtOWFwL05laHhyWjJTUlF1NjRJcXRrNTQ1QWwwSmMwSVBES0x4U3luZ0ltVHYwbldkM3cyelZNTmo4azJrdmVieW9GRDFQYW4wQlo3RHkva1kyR2h6VXFwVWoxbGl1M1o1bmtqVUhhSDVva1d6OVpLSUlJSlg2czVmZTZ0R1luRS9xNTB1Q1R0Q1BlR1RtbnRaVjExQ0JxMHVmMXMrTlIvNkZwVE1PSXA3cTB5VEE5aEUwT1JyM2NMMXlGbEFaMlAwMXA4d09wRXU4dm96cHpWVTZ0RGh2dXBoYUNxaWNaUC0tYjNCMnJyUTBDZmRBQi94bGRpQ3NjZz09--9e71189642bccd551b53d26cbee5aec83cd649e6;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310886954540","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/65/6b/a8/93/656ba893-ae95-4338-a031-6bf1583172d6","@type":"oa:Annotation","hasBody":"_:g70310886954540","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942030663180","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/57/14/8e/91/57148e91-cc08-46ef-868b-abcaa46b2350","@type":"oa:Annotation","hasBody":"_:g69942030663180","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:33 GMT
+  recorded_at: Thu, 28 May 2015 01:26:29 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:33 GMT
+      - Thu, 28 May 2015 01:26:29 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:33 GMT
+      - Thu, 28 May 2015 07:26:29 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:33 GMT
+  recorded_at: Thu, 28 May 2015 01:26:29 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:33 GMT
+      - Thu, 28 May 2015 01:26:29 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:33 GMT
+      - Thu, 28 May 2015 07:26:29 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:33 GMT
+  recorded_at: Thu, 28 May 2015 01:26:30 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:33 GMT
+      - Thu, 28 May 2015 01:26:30 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:33 GMT
+      - Thu, 28 May 2015 07:26:30 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:33 GMT
+  recorded_at: Thu, 28 May 2015 01:26:30 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:34 GMT
+      - Thu, 28 May 2015 01:26:30 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:34 GMT
+      - Thu, 28 May 2015 07:26:30 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:34 GMT
+  recorded_at: Thu, 28 May 2015 01:26:30 GMT
 - request:
     method: get
-    uri: http://localhost:3000/annotations/65%2F6b%2Fa8%2F93%2F656ba893-ae95-4338-a031-6bf1583172d6
+    uri: http://localhost:3000/annotations/57%2F14%2F8e%2F91%2F57148e91-cc08-46ef-868b-abcaa46b2350
     body:
       encoding: US-ASCII
       string: ''
@@ -2475,13 +2475,13 @@ http_interactions:
       Content-Length:
       - '128007'
       X-Request-Id:
-      - d08a64fb-8d01-4b11-911e-fbabf6705398
+      - a054f852-e4df-4509-bf9f-8a6d03d551a0
       X-Runtime:
-      - '0.350267'
+      - '0.290473'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:34 GMT
+      - Thu, 28 May 2015 01:26:31 GMT
       Connection:
       - Keep-Alive
     body:
@@ -3818,7 +3818,7 @@ http_interactions:
         && el) {\n          currentSource.className += \" hidden\";\n          el.className
         = el.className.replace(\" hidden\", \"\");\n          currentSource = el;\n
         \       }\n      }\n    }\n  </script>\n</div>\n\n  \n\n<h2 style=\"margin-top:
-        30px\">Request</h2>\n<p><b>Parameters</b>:</p> <pre>{&quot;id&quot;=&gt;&quot;65/6b/a8/93/656ba893-ae95-4338-a031-6bf1583172d6&quot;}</pre>\n\n<div
+        30px\">Request</h2>\n<p><b>Parameters</b>:</p> <pre>{&quot;id&quot;=&gt;&quot;57/14/8e/91/57148e91-cc08-46ef-868b-abcaa46b2350&quot;}</pre>\n\n<div
         class=\"details\">\n  <div class=\"summary\"><a href=\"#\" onclick=\"return
         toggleSessionDump()\">Toggle session dump</a></div>\n  <div id=\"session_dump\"
         style=\"display:none\"><pre></pre></div>\n</div>\n\n<div class=\"details\">\n
@@ -3828,7 +3828,7 @@ http_interactions:
         &quot;gzip, deflate&quot;\nREMOTE_ADDR: &quot;127.0.0.1&quot;\nREMOTE_HOST:
         &quot;127.0.0.1&quot;\nSERVER_NAME: &quot;localhost&quot;\nSERVER_PROTOCOL:
         &quot;HTTP/1.1&quot;</pre></div>\n</div>\n\n<h2 style=\"margin-top: 30px\">Response</h2>\n<p><b>Headers</b>:</p>
-        <pre>None</pre>\n\n</div>\n\n\n</body>\n</html>\n<div id=\"console\"\n  data-remote-path='console/repl_sessions/542b99ed8b7d41113a3420109bbdf766'\n
+        <pre>None</pre>\n\n</div>\n\n\n</body>\n</html>\n<div id=\"console\"\n  data-remote-path='console/repl_sessions/1d021b36cb4f39118cb98b296ed10d03'\n
         \ data-initial-prompt='>> '>\n</div>\n\n\n<script type=\"text/javascript\">\n(function()
         {\n  // DOM helpers\nfunction hasClass(el, className) {\n  var regex = new
         RegExp('(?:^|\\\\s)' + className + '(?!\\\\S)', 'g');\n  return el.className.match(regex);\n}\n\nfunction
@@ -4025,10 +4025,10 @@ http_interactions:
         \   resizerElement.addEventListener('mouseup', recordConsoleElementHeight);\n
         \ });\n});\n\n}).call(this);\n</script>\n\n"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:34 GMT
+  recorded_at: Thu, 28 May 2015 01:26:31 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/65%2F6b%2Fa8%2F93%2F656ba893-ae95-4338-a031-6bf1583172d6
+    uri: http://localhost:3000/annotations/57%2F14%2F8e%2F91%2F57148e91-cc08-46ef-868b-abcaa46b2350
     body:
       encoding: US-ASCII
       string: ''
@@ -4055,22 +4055,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 80514d5f-7458-47c6-89f4-8cec6dec2a80
+      - 59b31c88-4ccc-41f1-99d3-d7b26738f042
       X-Runtime:
-      - '0.302691'
+      - '0.194864'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:35 GMT
+      - Thu, 28 May 2015 01:26:31 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=YkxORU5ZZDE2aFQwM1BTSG41T0pFQnVPMVQ1NHhMTDZOQStlamNTck5Kd0o1RDhWOE0yZE0rVmNxM1A0dzlyckpQU2pPaHgvZG5SbmZOV3pCVS9yUEtoS29XVlF1dlFFTXlUNFpvRVYwdEJqdGhRTGhqZEVETW9ERzlUYk5rK3JlTEtzWGhDTkxrQmI5czdvMStWMEtSQVR5NmxTTzJKcDhRdlRkWkRFenRaQ01BdHZtc1k0WDlydmZrS3dWUzlvLS1MeTJpTjBwMkVtWGtFa3poMVRySkV3PT0%3D--b0f3e3a218146f08164c29eba84acbe8a6069e20;
+      - _internal_session=Slk4VjcxZFBhRG5SRnUxNlgzT21SUjF1QnFzT3Q0ZllFTnJmTVA4bllWa1ZmSVZTMzIwamZYamVVWWVZdEhkZ3N3RUlqa3BSQmNHNTgxd2pzdVdPdlM2Z1p1VHh6OVgxSFY2UUJOMmJTZm4vUEhnbEJjaUd2Y1JYSW5USno1WVU2bjNNdkw3Zld2UEV1UG5VN096ckYrWTVnUWt2VjF5RlFJN0IvU2FyckllbVlFOTdybElLNG5rR2pxbEZpdTBmLS1RaXJmOFNHeENyYnpqK1hzVCtwaUlBPT0%3D--7049f28c7417ea9031891ce49271e01d7cb699d6;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:35 GMT
+  recorded_at: Thu, 28 May 2015 01:26:31 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/cannot_get_an_open_annotation_by_ID_with_content_type_application/x-trig_.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/cannot_get_an_open_annotation_by_ID_with_content_type_application/x-trig_.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"dcc0491116de8499e15cf42954e4f579"
+      - W/"20c5664398293e9c10ab9d6e4c48b94e"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 9ffaa2ef-065c-4448-b680-0c1c14a584aa
+      - 8ac0d9b4-323d-407d-857a-7bf8471f4628
       X-Runtime:
-      - '1.691512'
+      - '2.227561'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:08:16 GMT
+      - Thu, 28 May 2015 01:29:36 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=bzZQRzc3YW0xejNHRUd4WGhxSzdOYWMyMEk4UWZuZ3FISDducTNkSkw5cWRucEV5QlBPL2tSaHVCbncwVm9rUyswZUFjTlUwa01GYnF6Q3U3Vk4vblVITjVkMGwrSzVQS2dna3BITHVHeVhyaEMyYm9OV0VxRVdseGNzaTViNFhTWEFleWNZNjh2RGk2YjJtTTUybCsvcTVuRFJGWU5sTUk2NHdQblpXc1I5MVBpZFVKbEFXM0QwSGtqbTg5N2JHTng2YXhHQ0t5bkx6V0NlMm9ObzRJWWJGZ3hPN1NDcHFyeVVNWmVrRlh6NGg4ZmFpTmY4Y1ViMUhPVldTVGRlRC0tZE9ndGRNWHlXRVRIeDZKS25GcmRoUT09--4d8561cbc33cc4ac4d04b684e5048fec828ded5e;
+      - _internal_session=UzAvUUJuQW4zNTdTdWtiNVNhUXlkeGZYdmZyRk53cXRnUFJ2MG9xSDRiWFlHWDFSZnhhTGVVclVnSitQT1Q4YmhxcFYzV0ZWSWV6UDNnUmxXUDFtZXkraXlwa1N2bmFlbVA0YkMyZkFZK1pvZkRnMndUTUZ2SlVNSlFCeENBRGlwaFRlZytnNFlyS3ZJdEQ1VGsxVCt4SVNJRFdQbGhZWHdYQlBUZXJWbm9JNGxsOUtnZDQ3KytTNUJoWmtheElKdXlZNVNkZVl2aVVEWmo5NUYrNWp3MktVbm91TVN6VUhyVGp3NG4zaW55K01VK2V5ckNjWVhnTU9yZWZNR1lSZS0tRVdMUmkzTXRBRFZVbVpORUNNa3ZSZz09--1622306b5a82343bd124eb986785020be8fd3f50;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310858825040","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/3d/f8/09/1e/3df8091e-6ad8-4f94-94a1-2341aac41a5b","@type":"oa:Annotation","hasBody":"_:g70310858825040","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942003084560","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/58/ba/61/65/58ba6165-64f0-4341-9bca-ab9b651faefb","@type":"oa:Annotation","hasBody":"_:g69942003084560","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:16 GMT
+  recorded_at: Thu, 28 May 2015 01:29:36 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:16 GMT
+      - Thu, 28 May 2015 01:29:36 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:16 GMT
+      - Thu, 28 May 2015 07:29:36 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:16 GMT
+  recorded_at: Thu, 28 May 2015 01:29:36 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:16 GMT
+      - Thu, 28 May 2015 01:29:36 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:16 GMT
+      - Thu, 28 May 2015 07:29:36 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:16 GMT
+  recorded_at: Thu, 28 May 2015 01:29:37 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:17 GMT
+      - Thu, 28 May 2015 01:29:37 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:17 GMT
+      - Thu, 28 May 2015 07:29:37 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:17 GMT
+  recorded_at: Thu, 28 May 2015 01:29:37 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:17 GMT
+      - Thu, 28 May 2015 01:29:37 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:17 GMT
+      - Thu, 28 May 2015 07:29:37 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:17 GMT
+  recorded_at: Thu, 28 May 2015 01:29:38 GMT
 - request:
     method: get
-    uri: http://localhost:3000/annotations/3d%2Ff8%2F09%2F1e%2F3df8091e-6ad8-4f94-94a1-2341aac41a5b
+    uri: http://localhost:3000/annotations/58%2Fba%2F61%2F65%2F58ba6165-64f0-4341-9bca-ab9b651faefb
     body:
       encoding: US-ASCII
       string: ''
@@ -2475,13 +2475,13 @@ http_interactions:
       Content-Length:
       - '128004'
       X-Request-Id:
-      - 10b76ccb-401c-4211-8adc-c60f096675ad
+      - ff327a19-d4b1-4c75-80c9-998577b32113
       X-Runtime:
-      - '0.455594'
+      - '0.277161'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:08:18 GMT
+      - Thu, 28 May 2015 01:29:38 GMT
       Connection:
       - Keep-Alive
     body:
@@ -3818,7 +3818,7 @@ http_interactions:
         && el) {\n          currentSource.className += \" hidden\";\n          el.className
         = el.className.replace(\" hidden\", \"\");\n          currentSource = el;\n
         \       }\n      }\n    }\n  </script>\n</div>\n\n  \n\n<h2 style=\"margin-top:
-        30px\">Request</h2>\n<p><b>Parameters</b>:</p> <pre>{&quot;id&quot;=&gt;&quot;3d/f8/09/1e/3df8091e-6ad8-4f94-94a1-2341aac41a5b&quot;}</pre>\n\n<div
+        30px\">Request</h2>\n<p><b>Parameters</b>:</p> <pre>{&quot;id&quot;=&gt;&quot;58/ba/61/65/58ba6165-64f0-4341-9bca-ab9b651faefb&quot;}</pre>\n\n<div
         class=\"details\">\n  <div class=\"summary\"><a href=\"#\" onclick=\"return
         toggleSessionDump()\">Toggle session dump</a></div>\n  <div id=\"session_dump\"
         style=\"display:none\"><pre></pre></div>\n</div>\n\n<div class=\"details\">\n
@@ -3828,7 +3828,7 @@ http_interactions:
         &quot;gzip, deflate&quot;\nREMOTE_ADDR: &quot;127.0.0.1&quot;\nREMOTE_HOST:
         &quot;127.0.0.1&quot;\nSERVER_NAME: &quot;localhost&quot;\nSERVER_PROTOCOL:
         &quot;HTTP/1.1&quot;</pre></div>\n</div>\n\n<h2 style=\"margin-top: 30px\">Response</h2>\n<p><b>Headers</b>:</p>
-        <pre>None</pre>\n\n</div>\n\n\n</body>\n</html>\n<div id=\"console\"\n  data-remote-path='console/repl_sessions/cd6e0e9a340d8d4643e82d20b19d7f69'\n
+        <pre>None</pre>\n\n</div>\n\n\n</body>\n</html>\n<div id=\"console\"\n  data-remote-path='console/repl_sessions/1af5e72e1a5480cd867ec3f476f3e943'\n
         \ data-initial-prompt='>> '>\n</div>\n\n\n<script type=\"text/javascript\">\n(function()
         {\n  // DOM helpers\nfunction hasClass(el, className) {\n  var regex = new
         RegExp('(?:^|\\\\s)' + className + '(?!\\\\S)', 'g');\n  return el.className.match(regex);\n}\n\nfunction
@@ -4025,10 +4025,10 @@ http_interactions:
         \   resizerElement.addEventListener('mouseup', recordConsoleElementHeight);\n
         \ });\n});\n\n}).call(this);\n</script>\n\n"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:18 GMT
+  recorded_at: Thu, 28 May 2015 01:29:38 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/3d%2Ff8%2F09%2F1e%2F3df8091e-6ad8-4f94-94a1-2341aac41a5b
+    uri: http://localhost:3000/annotations/58%2Fba%2F61%2F65%2F58ba6165-64f0-4341-9bca-ab9b651faefb
     body:
       encoding: US-ASCII
       string: ''
@@ -4055,22 +4055,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - fef274e6-5777-444b-a9bb-ba70ea5a62a2
+      - e0ab0cd1-0cc6-46f0-b78c-58dc99458821
       X-Runtime:
-      - '0.208942'
+      - '0.157887'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:08:18 GMT
+      - Thu, 28 May 2015 01:29:38 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=YWxiOWxzUDFpcXNuQmtWRDhkRkRoNzJ3blhiODljS3lsZzdIUUpUaERyL1gwVHdnNlY2anJxdFluN3ZFOEV0WnhWU0VUa0U5SHplSmg0QnZlNmhXWVJEZkVhSnRiZ21YVXhKTFYzanNhTHNqUXRiNWpsTjRGMUhlZ3pIMVFvKzk4d0RTQkw5a1l3TVg0a2ZTNEJ2WGFKamFWRjVabUxweVh3TWFwYXIrQy93bVBMVHNKK01tVldWNEFFdnN2RzdILS1iV05xSHBMV3Z6NElMNWlKTGNWeGFBPT0%3D--9e4a2f790772659e774ea40fa36bee6ac0302122;
+      - _internal_session=MGo4d1poaFdsdjMxQ3BBRzBUckV6NXV4aHhwNGZWVGgyT2VJazdmcVJvSEQ3cmlrVkxGTGI0YnQyaFZKd0JROUkwU0tleWI5YTR1emcxZXBISXFQS3BEWTd5ZFdPN0hUK2p0VEVteVY1UTc1NWVkUFY5WXNNcGd1dnZtbmRvTDNGSU1MYnZjdnB0bGw2VmhtZTFXYTU4T2daQ3lRMENjczhxcCt6NkxIcS9HNmU2M0U4ZDJVaGs4NU9TejRHcXZOLS1NVW0zUU90aDN4SEZYOGxmWWxGVUR3PT0%3D--0922defceca5d482106206c82f32081c6e663c8f;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:18 GMT
+  recorded_at: Thu, 28 May 2015 01:29:38 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/cannot_get_an_open_annotation_by_ID_with_content_type_text/n3_.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/cannot_get_an_open_annotation_by_ID_with_content_type_text/n3_.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"40f681ec348ea7afee143951dbda8d32"
+      - W/"d3feb43fd9925ab1940ad25e4b0b4d44"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 71d3a7f2-8b18-4268-b492-c01a8808ebe9
+      - 4d095d74-6a9c-441d-ad18-5c59718ba6d7
       X-Runtime:
-      - '1.629012'
+      - '2.641733'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:07:41 GMT
+      - Thu, 28 May 2015 01:27:48 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=ZEh3dlhZMUhlYkQwV0V3UEZqK2FqbTY1amRKbmlWVTZ1aEdDWXZEYWJVcWczbFo1MUhVd09uR2JOZ1kvViszSUhvejlSOGFoY0JXVlhXazF4ank1OVRGa2FvdkNEUFc0ajhnbmNRVnFqdTAxdk9iMVE1RndONWRqcnZJRlU2dDdGaHdiUlFKK1NDenN2SmRQdWlWN05aUER5LzRvQ0ZOYlIvanloeTlDV0g0SmtaQzk2WmFQWlJXczE0dW5FRWIzMndRYUUzRE5mMHhSa0srZkxmVkdzRlVCN2h0Q1g3U20zcnhNRzBVcE5ucjNWNC9hSUpUdlZ1clkxTE5mS1JWUi0tQ1podnJDQmd2WGFWQ1ZCb0lmS1Fodz09--f921999b5449c798d717dffb75a3f53093e1ffae;
+      - _internal_session=bmJ3M2srUXIrUzZIQ1Q3UUZ4UEFWT0RFSTlabWxwaG14R0xmUzMzQmJzYnBzckdCeVhoWUc4ZTJYQnVoNnViTGg4NUxtNThzY2UzOFVGTWYvekRKUlQzay83LzVNcFVqdXgrTnpYdVk0NFAvRS95YlpmWVpud2VpaGsycjQwMS9lZUoySmc4WVFyeDFiWHIwWlBhUHR4VFBNYks1T25HZlRlRW5BNmxGQmdmdG5qYTA5NVl4Wld3b2JmNDBHOE1vYm9yY0pYRTV3c0p6NmhzTXptazRoQjY4Mm8yWkhhMkFVZExHMkhNT1EyQ1JGc2dhM2RHQzRMV2JZUWJ4bm1RNS0tT09xL2N2SkliK0Y0RmlxSjkxemdvQT09--bcef7ed1a33e9a2e58a7d0dba5a9b9764b6b9948;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310858610640","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/ba/6e/ca/69/ba6eca69-cb1e-4d82-a6b1-2690f5c3431f","@type":"oa:Annotation","hasBody":"_:g70310858610640","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942024265520","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/b8/c6/2a/af/b8c62aaf-79af-48e4-b552-cbe900be69d0","@type":"oa:Annotation","hasBody":"_:g69942024265520","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:41 GMT
+  recorded_at: Thu, 28 May 2015 01:27:48 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:41 GMT
+      - Thu, 28 May 2015 01:27:48 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:41 GMT
+      - Thu, 28 May 2015 07:27:48 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:41 GMT
+  recorded_at: Thu, 28 May 2015 01:27:48 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:41 GMT
+      - Thu, 28 May 2015 01:27:49 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:41 GMT
+      - Thu, 28 May 2015 07:27:49 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:41 GMT
+  recorded_at: Thu, 28 May 2015 01:27:49 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:41 GMT
+      - Thu, 28 May 2015 01:27:49 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:41 GMT
+      - Thu, 28 May 2015 07:27:49 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:41 GMT
+  recorded_at: Thu, 28 May 2015 01:27:49 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:42 GMT
+      - Thu, 28 May 2015 01:27:49 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:42 GMT
+      - Thu, 28 May 2015 07:27:49 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:42 GMT
+  recorded_at: Thu, 28 May 2015 01:27:50 GMT
 - request:
     method: get
-    uri: http://localhost:3000/annotations/ba%2F6e%2Fca%2F69%2Fba6eca69-cb1e-4d82-a6b1-2690f5c3431f
+    uri: http://localhost:3000/annotations/b8%2Fc6%2F2a%2Faf%2Fb8c62aaf-79af-48e4-b552-cbe900be69d0
     body:
       encoding: US-ASCII
       string: ''
@@ -2475,13 +2475,13 @@ http_interactions:
       Content-Length:
       - '127993'
       X-Request-Id:
-      - 551f584f-8fe0-4f27-8eba-2511e4892900
+      - ea052b90-bcf6-452d-93e6-7bcfb59ff1a8
       X-Runtime:
-      - '0.482949'
+      - '0.392533'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:07:42 GMT
+      - Thu, 28 May 2015 01:27:50 GMT
       Connection:
       - Keep-Alive
     body:
@@ -3818,7 +3818,7 @@ http_interactions:
         && el) {\n          currentSource.className += \" hidden\";\n          el.className
         = el.className.replace(\" hidden\", \"\");\n          currentSource = el;\n
         \       }\n      }\n    }\n  </script>\n</div>\n\n  \n\n<h2 style=\"margin-top:
-        30px\">Request</h2>\n<p><b>Parameters</b>:</p> <pre>{&quot;id&quot;=&gt;&quot;ba/6e/ca/69/ba6eca69-cb1e-4d82-a6b1-2690f5c3431f&quot;}</pre>\n\n<div
+        30px\">Request</h2>\n<p><b>Parameters</b>:</p> <pre>{&quot;id&quot;=&gt;&quot;b8/c6/2a/af/b8c62aaf-79af-48e4-b552-cbe900be69d0&quot;}</pre>\n\n<div
         class=\"details\">\n  <div class=\"summary\"><a href=\"#\" onclick=\"return
         toggleSessionDump()\">Toggle session dump</a></div>\n  <div id=\"session_dump\"
         style=\"display:none\"><pre></pre></div>\n</div>\n\n<div class=\"details\">\n
@@ -3828,7 +3828,7 @@ http_interactions:
         &quot;gzip, deflate&quot;\nREMOTE_ADDR: &quot;127.0.0.1&quot;\nREMOTE_HOST:
         &quot;127.0.0.1&quot;\nSERVER_NAME: &quot;localhost&quot;\nSERVER_PROTOCOL:
         &quot;HTTP/1.1&quot;</pre></div>\n</div>\n\n<h2 style=\"margin-top: 30px\">Response</h2>\n<p><b>Headers</b>:</p>
-        <pre>None</pre>\n\n</div>\n\n\n</body>\n</html>\n<div id=\"console\"\n  data-remote-path='console/repl_sessions/084e9a4333d6e61fae158c784a69a79f'\n
+        <pre>None</pre>\n\n</div>\n\n\n</body>\n</html>\n<div id=\"console\"\n  data-remote-path='console/repl_sessions/238b90bb5cd71669736461aed4803906'\n
         \ data-initial-prompt='>> '>\n</div>\n\n\n<script type=\"text/javascript\">\n(function()
         {\n  // DOM helpers\nfunction hasClass(el, className) {\n  var regex = new
         RegExp('(?:^|\\\\s)' + className + '(?!\\\\S)', 'g');\n  return el.className.match(regex);\n}\n\nfunction
@@ -4025,10 +4025,10 @@ http_interactions:
         \   resizerElement.addEventListener('mouseup', recordConsoleElementHeight);\n
         \ });\n});\n\n}).call(this);\n</script>\n\n"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:42 GMT
+  recorded_at: Thu, 28 May 2015 01:27:50 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/ba%2F6e%2Fca%2F69%2Fba6eca69-cb1e-4d82-a6b1-2690f5c3431f
+    uri: http://localhost:3000/annotations/b8%2Fc6%2F2a%2Faf%2Fb8c62aaf-79af-48e4-b552-cbe900be69d0
     body:
       encoding: US-ASCII
       string: ''
@@ -4055,22 +4055,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 961d31f5-06fa-4fed-a01c-1f36e3619e0d
+      - c7d68e07-6bce-4c73-b901-ae0481fcf6fd
       X-Runtime:
-      - '0.200504'
+      - '0.174346'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:07:43 GMT
+      - Thu, 28 May 2015 01:27:50 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=SUJlblBQRWlOYVcyT1B0eHhOb3lJcE5KREtFZFIrZ0k3ckVDTnRuZEZmOE93c0w3TFZMK1FHY0VWTlp3a1ZZYjVGZXlyeSswc0RSanRYc0VNb0FKUWRsWGJJanlkTDdvMWdJakU1ejlUWUoyYkVWVVlGVjY1VUZoaG94STBpUzIxQm9ZVGxsK2pWWWpyU1AwWCtYejJVNFo3MHJNY3R2K3dLemN0akpFdHE0dVprdXR5YWYya2NRN2JiYitlb09tLS1ZbWlBQ2R4c0pCZURpcElzanJBODlBPT0%3D--4bc4cf9efb07094aebe2856ef6984f40d58367e1;
+      - _internal_session=U3JKQlJtSzZQQ0hoc2pPU0UyL1AwREhIa3p3a2Q1RVkwOTlaUVd0WkgrM2I0Sktyd2RwcXFHUTJna0RBK3hyVlpsU3Zydll3U0JjODBPWTRjS1RSSjNZaXNXMCsxMHBJTkdJWmZrc3cyODN5bVFLUUpYK3FhVEh5cDZVTzVUcHloaFRpQXlhSXBQSEtRc2JrTlNMajRLT21JQnJYR0xMbGZNdkszTUpMUFF2ZWJGczUzNmh1WXoyY0ltQ1N1YmFpLS1MVXBUdnlBcEVUdmxWZUZKUjZRMmhnPT0%3D--b402eea4ccf2b718f0384fa7bc38d5d382521f2e;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:43 GMT
+  recorded_at: Thu, 28 May 2015 01:27:50 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/cannot_get_an_open_annotation_by_ID_with_content_type_text/rdf_n3_.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/cannot_get_an_open_annotation_by_ID_with_content_type_text/rdf_n3_.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"d62c4542198381b6ae6689efce1ff332"
+      - W/"2dce930cb6c8ecd8e7573a9afda8cf14"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 60b72d90-74d1-4b2d-9630-0b607b64077a
+      - 770d1c29-5f98-43d2-b3bf-0ed5c128fada
       X-Runtime:
-      - '1.699568'
+      - '2.255708'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:07:48 GMT
+      - Thu, 28 May 2015 01:27:57 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=UkZrdFJSa0RaWElEVTFvOGxZenBNVXY0UzlHY2hDOFYyRmVPWVdEbDNxMkJMRG9CTm0wU1IyY3pocnZINzFYbFl1VjNCYmpEUFRyakVjRzZHa1MrcVpFL0hxZ2srbDdwQnkyTWdoWTdZUGFmQW5ZQ3BsdW5rVURGVDlrbUYyUk5xK0RvNjdLOFVORU0yUEJoMDhXWEZ0Mk9QbVo3dk1YcUpueXI5dHByak1paFA2UEJiQ3JSczRuWlVFN3d3SmFuL1Q3djIyUzYwc3pYcFRhOGc3VWJMaU5zV245b05JZmxhVjBVTENUV0t1YmM5R1pJWkk1dGhPbVhhVkk5MUw3bS0tQ09aNk5kQ0YxQWUrc0ZSWWoySHBOdz09--567b5bda83f49d3a32ada4d30898cc8185bb6c5e;
+      - _internal_session=N1BzU21hN0NtdUFuTjFBY3JHVHg5TmN2ZmhjNFIxVmZwcGRyeFhBSi9pOXlOYVB5VkhJWmpmSGhFTGZUOXg3VkFQK1ZiczFYbHR6aGpKaDhocXd3WEpscXhVTVVOV1NyRys4b0ltM2hKaCtFZ3RPZjdjODREd09kN0RCRWx6U0hSb2c2MEtsM2NQYWRjcWE3OE1ab3pDVHI3Zi9iTS9sZ1NscUlBMzdFV0lLWitrNk1ZY1A4TEgzbFhRRmVvUzBIeGdLSWwxOTFvU3F4R2Z1Y1BaRVFaN2Mxb2c5RjhVT3NZMWRjM0RmYXR4VkxiN29nVDNPTm5JWktzeXNjZzBaYS0tdjJoNVZYanJmRlFpN3NrL0xxZmVYdz09--a30b1dbfc1d787d95ca7a69bd310eaf8abf4d746;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310858732980","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/0e/28/03/67/0e280367-3ccb-4d01-83d3-9c23b912eac5","@type":"oa:Annotation","hasBody":"_:g70310858732980","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942036505200","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/d2/92/f4/d6/d292f4d6-cf79-4a43-b1d6-72b2d0f8aa92","@type":"oa:Annotation","hasBody":"_:g69942036505200","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:48 GMT
+  recorded_at: Thu, 28 May 2015 01:27:57 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:48 GMT
+      - Thu, 28 May 2015 01:27:57 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:48 GMT
+      - Thu, 28 May 2015 07:27:57 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:48 GMT
+  recorded_at: Thu, 28 May 2015 01:27:58 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:48 GMT
+      - Thu, 28 May 2015 01:27:58 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:48 GMT
+      - Thu, 28 May 2015 07:27:58 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:48 GMT
+  recorded_at: Thu, 28 May 2015 01:27:58 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:48 GMT
+      - Thu, 28 May 2015 01:27:58 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:48 GMT
+      - Thu, 28 May 2015 07:27:58 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:48 GMT
+  recorded_at: Thu, 28 May 2015 01:27:59 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:49 GMT
+      - Thu, 28 May 2015 01:27:59 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:49 GMT
+      - Thu, 28 May 2015 07:27:59 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:49 GMT
+  recorded_at: Thu, 28 May 2015 01:27:59 GMT
 - request:
     method: get
-    uri: http://localhost:3000/annotations/0e%2F28%2F03%2F67%2F0e280367-3ccb-4d01-83d3-9c23b912eac5
+    uri: http://localhost:3000/annotations/d2%2F92%2Ff4%2Fd6%2Fd292f4d6-cf79-4a43-b1d6-72b2d0f8aa92
     body:
       encoding: US-ASCII
       string: ''
@@ -2475,13 +2475,13 @@ http_interactions:
       Content-Length:
       - '127997'
       X-Request-Id:
-      - 8231e0e5-e865-4bac-bc42-7188622f95d6
+      - 3b74f1d0-9a75-4202-9620-4315cb72bfb4
       X-Runtime:
-      - '0.363218'
+      - '0.333579'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:07:49 GMT
+      - Thu, 28 May 2015 01:27:59 GMT
       Connection:
       - Keep-Alive
     body:
@@ -3818,7 +3818,7 @@ http_interactions:
         && el) {\n          currentSource.className += \" hidden\";\n          el.className
         = el.className.replace(\" hidden\", \"\");\n          currentSource = el;\n
         \       }\n      }\n    }\n  </script>\n</div>\n\n  \n\n<h2 style=\"margin-top:
-        30px\">Request</h2>\n<p><b>Parameters</b>:</p> <pre>{&quot;id&quot;=&gt;&quot;0e/28/03/67/0e280367-3ccb-4d01-83d3-9c23b912eac5&quot;}</pre>\n\n<div
+        30px\">Request</h2>\n<p><b>Parameters</b>:</p> <pre>{&quot;id&quot;=&gt;&quot;d2/92/f4/d6/d292f4d6-cf79-4a43-b1d6-72b2d0f8aa92&quot;}</pre>\n\n<div
         class=\"details\">\n  <div class=\"summary\"><a href=\"#\" onclick=\"return
         toggleSessionDump()\">Toggle session dump</a></div>\n  <div id=\"session_dump\"
         style=\"display:none\"><pre></pre></div>\n</div>\n\n<div class=\"details\">\n
@@ -3828,7 +3828,7 @@ http_interactions:
         &quot;gzip, deflate&quot;\nREMOTE_ADDR: &quot;127.0.0.1&quot;\nREMOTE_HOST:
         &quot;127.0.0.1&quot;\nSERVER_NAME: &quot;localhost&quot;\nSERVER_PROTOCOL:
         &quot;HTTP/1.1&quot;</pre></div>\n</div>\n\n<h2 style=\"margin-top: 30px\">Response</h2>\n<p><b>Headers</b>:</p>
-        <pre>None</pre>\n\n</div>\n\n\n</body>\n</html>\n<div id=\"console\"\n  data-remote-path='console/repl_sessions/e2f7ec04ec8f94344e093b63f12160cb'\n
+        <pre>None</pre>\n\n</div>\n\n\n</body>\n</html>\n<div id=\"console\"\n  data-remote-path='console/repl_sessions/db4b3b8bee464973451caca3bea911c7'\n
         \ data-initial-prompt='>> '>\n</div>\n\n\n<script type=\"text/javascript\">\n(function()
         {\n  // DOM helpers\nfunction hasClass(el, className) {\n  var regex = new
         RegExp('(?:^|\\\\s)' + className + '(?!\\\\S)', 'g');\n  return el.className.match(regex);\n}\n\nfunction
@@ -4025,10 +4025,10 @@ http_interactions:
         \   resizerElement.addEventListener('mouseup', recordConsoleElementHeight);\n
         \ });\n});\n\n}).call(this);\n</script>\n\n"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:49 GMT
+  recorded_at: Thu, 28 May 2015 01:27:59 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/0e%2F28%2F03%2F67%2F0e280367-3ccb-4d01-83d3-9c23b912eac5
+    uri: http://localhost:3000/annotations/d2%2F92%2Ff4%2Fd6%2Fd292f4d6-cf79-4a43-b1d6-72b2d0f8aa92
     body:
       encoding: US-ASCII
       string: ''
@@ -4055,22 +4055,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 096a425d-dcc7-4d19-a88c-709587382edb
+      - 9d32076f-ceaf-4558-a40f-9ee830a137bd
       X-Runtime:
-      - '0.207025'
+      - '0.194772'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:07:49 GMT
+      - Thu, 28 May 2015 01:28:00 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=ZE1BVllOdzNPS0RkOXJSNXNZVmtvUVl3OXEyeTR6WTZKWUplZ3pZUTVXcmxvUEo1c2R6a1cvNnhYS2VpYVhROW42VDFRYjgxbklkcTVSV2hXMG83Zkw5TnFDMEtuemRrUXdoYmUzNG9NZXZHc2NPS2VCK1I3bUZCOGdVdUdnS0NBbmQzU3hZVGVPRDIrRTRQSnJRMjJyOVlXVGN2dHkzYWZtR1JaVmlTL3VaczdySkR1NzFEb1ZYaUZXR0JxQUdaLS1BaGFXaDRzSGMvN2ZRTm4rM1E2QzR3PT0%3D--bfb97083c2ad14066ce6331be1d958b7cdc8e23a;
+      - _internal_session=MVg5NlBXV0t5Y3hUNWFMaTJYR3Q1ZGU3TGRhUUlVTkdzVXRMNmNqc005RE1WcGNBUTBNV2FJR3hJRXZGNEhXNnA4NlR3Mk9FV3liSytyUVZkbzhkK3ZXUW56SzNRNy84VERlOWVreVZXR1djZ1FYMVZVK0JUUUVuMlhpM25JL0cwQjYvWW51VEF4NENUUjBONzNGQVNDNSt0b0M0dmdJQWdwUWs3U2hLeHZ2cVBFNUNEMUZPWWl0Q3hMd3VLWE02LS15SWJuNlBUWFl3NU1kRXhUMGJvSGxRPT0%3D--fdfb5c38a8f1a70b65318f1412dbb559013d0aa1;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:49 GMT
+  recorded_at: Thu, 28 May 2015 01:28:00 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/cannot_get_an_open_annotation_by_ID_with_content_type_text/rdf_turtle_.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/cannot_get_an_open_annotation_by_ID_with_content_type_text/rdf_turtle_.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"8a777ef01f0d86b00c702c357899cc9a"
+      - W/"fb39443cfc7ebcf32a48c5f4649af1e3"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 4f5b290f-6cb9-4af6-8bc6-242f078ec59c
+      - 2e69b576-e1ce-4902-99db-dc63c92783ef
       X-Runtime:
-      - '1.758480'
+      - '2.164084'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:07:01 GMT
+      - Thu, 28 May 2015 01:27:04 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=TFlPdG53Y0piVEN5THdhSTIvb0YwVVRLZUhVazZRR0ljSVF4NWV1TUpLYm82YzRhT3Bra3htY0IwblgrMWcxZndMVHg4YTFKbi9LVDdra2VLRVBPWVB4dm1CVXZaY01uaVRrcnM2ckZPOHV2NEJxZUt0UHVwcFV5TmxLR1UwVWhLM2hZSUJTQWRmWFErdmdUempubDloRGMvTmk3U1BPYTQvdmNqMHluRkh6WGJGcm1TTWxlUmx4VVJYYWIrRVB3UFZETDEzSGZQQUhvUGRDZDFWdWN1bURpYytRWU9rbVNEYmFNR05ROVdrQ0hvVGZodGx0czg5L0l4VnRBcXkxNi0tdk8vNGU4OGxEMGhlZCtBNm55N1lEUT09--72b7a1d8bb10d07f36fbcd0e9a2091cb4da0e2b7;
+      - _internal_session=dmdrb0FiZkVFVUREeTROWERvaE5wWE1IdGhTNlZQZ0ZESUJITmh5TVZkWjJtOTROaUV4QU4yWU84NTBMQzJaNk1GNWxKZ3A1Y1JGbStvYkZsbUVaa0EzUzY1QlR2dUN2U2ZrVU5ycmY1QWNzdXkzdHNoK1YrWVAwNEVVbk5XeWlDQklaNGFSaEtTNysrUXNyNUtrNGhJWjVHZUtNY2dSdGhrdWJkeFZwUmdQS3IwRWsrSXFQZEZmOEVwdDlWTm9wd1U0VlRITHhFR1pNVFZRVmhybDhHVThOM2NtK09WUnZMcHZkK3B0cUNpWUExd1F3eFBza0VZQ1M4UlZhak5VRC0tODkzQkJ6UC9sWDNXSXRzZGhzNVVndz09--81135cd42f61ac467ec4e9163768d0855923f7d1;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310852959840","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/02/8a/c2/90/028ac290-9cda-4eff-93d3-6d0258dfa24e","@type":"oa:Annotation","hasBody":"_:g70310852959840","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942030090840","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/36/b5/7d/3e/36b57d3e-7d40-43ad-aaab-191a05f58382","@type":"oa:Annotation","hasBody":"_:g69942030090840","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:01 GMT
+  recorded_at: Thu, 28 May 2015 01:27:04 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:01 GMT
+      - Thu, 28 May 2015 01:27:04 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:01 GMT
+      - Thu, 28 May 2015 07:27:04 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:01 GMT
+  recorded_at: Thu, 28 May 2015 01:27:04 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:02 GMT
+      - Thu, 28 May 2015 01:27:04 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:02 GMT
+      - Thu, 28 May 2015 07:27:04 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:02 GMT
+  recorded_at: Thu, 28 May 2015 01:27:05 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:02 GMT
+      - Thu, 28 May 2015 01:27:05 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:02 GMT
+      - Thu, 28 May 2015 07:27:05 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:02 GMT
+  recorded_at: Thu, 28 May 2015 01:27:05 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:02 GMT
+      - Thu, 28 May 2015 01:27:05 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:02 GMT
+      - Thu, 28 May 2015 07:27:05 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:03 GMT
+  recorded_at: Thu, 28 May 2015 01:27:06 GMT
 - request:
     method: get
-    uri: http://localhost:3000/annotations/02%2F8a%2Fc2%2F90%2F028ac290-9cda-4eff-93d3-6d0258dfa24e
+    uri: http://localhost:3000/annotations/36%2Fb5%2F7d%2F3e%2F36b57d3e-7d40-43ad-aaab-191a05f58382
     body:
       encoding: US-ASCII
       string: ''
@@ -2475,13 +2475,13 @@ http_interactions:
       Content-Length:
       - '128001'
       X-Request-Id:
-      - 941fba35-7cc8-4b4b-b8b5-194ea874deda
+      - b8addac4-85cb-4d48-af9e-e314662cdc62
       X-Runtime:
-      - '0.360080'
+      - '0.286318'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:07:03 GMT
+      - Thu, 28 May 2015 01:27:06 GMT
       Connection:
       - Keep-Alive
     body:
@@ -3818,7 +3818,7 @@ http_interactions:
         && el) {\n          currentSource.className += \" hidden\";\n          el.className
         = el.className.replace(\" hidden\", \"\");\n          currentSource = el;\n
         \       }\n      }\n    }\n  </script>\n</div>\n\n  \n\n<h2 style=\"margin-top:
-        30px\">Request</h2>\n<p><b>Parameters</b>:</p> <pre>{&quot;id&quot;=&gt;&quot;02/8a/c2/90/028ac290-9cda-4eff-93d3-6d0258dfa24e&quot;}</pre>\n\n<div
+        30px\">Request</h2>\n<p><b>Parameters</b>:</p> <pre>{&quot;id&quot;=&gt;&quot;36/b5/7d/3e/36b57d3e-7d40-43ad-aaab-191a05f58382&quot;}</pre>\n\n<div
         class=\"details\">\n  <div class=\"summary\"><a href=\"#\" onclick=\"return
         toggleSessionDump()\">Toggle session dump</a></div>\n  <div id=\"session_dump\"
         style=\"display:none\"><pre></pre></div>\n</div>\n\n<div class=\"details\">\n
@@ -3828,7 +3828,7 @@ http_interactions:
         &quot;gzip, deflate&quot;\nREMOTE_ADDR: &quot;127.0.0.1&quot;\nREMOTE_HOST:
         &quot;127.0.0.1&quot;\nSERVER_NAME: &quot;localhost&quot;\nSERVER_PROTOCOL:
         &quot;HTTP/1.1&quot;</pre></div>\n</div>\n\n<h2 style=\"margin-top: 30px\">Response</h2>\n<p><b>Headers</b>:</p>
-        <pre>None</pre>\n\n</div>\n\n\n</body>\n</html>\n<div id=\"console\"\n  data-remote-path='console/repl_sessions/5816238e53fbf6f03e4c74da9a0bb2d6'\n
+        <pre>None</pre>\n\n</div>\n\n\n</body>\n</html>\n<div id=\"console\"\n  data-remote-path='console/repl_sessions/20756adf6b034f1539f90f13f9ce100a'\n
         \ data-initial-prompt='>> '>\n</div>\n\n\n<script type=\"text/javascript\">\n(function()
         {\n  // DOM helpers\nfunction hasClass(el, className) {\n  var regex = new
         RegExp('(?:^|\\\\s)' + className + '(?!\\\\S)', 'g');\n  return el.className.match(regex);\n}\n\nfunction
@@ -4025,10 +4025,10 @@ http_interactions:
         \   resizerElement.addEventListener('mouseup', recordConsoleElementHeight);\n
         \ });\n});\n\n}).call(this);\n</script>\n\n"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:03 GMT
+  recorded_at: Thu, 28 May 2015 01:27:06 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/02%2F8a%2Fc2%2F90%2F028ac290-9cda-4eff-93d3-6d0258dfa24e
+    uri: http://localhost:3000/annotations/36%2Fb5%2F7d%2F3e%2F36b57d3e-7d40-43ad-aaab-191a05f58382
     body:
       encoding: US-ASCII
       string: ''
@@ -4055,22 +4055,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - b6b97b02-c4c6-4a8a-8755-3d97e80d42ca
+      - a1de64cb-46bd-4ac7-be69-7ca110c0cf27
       X-Runtime:
-      - '0.303610'
+      - '0.222970'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:07:03 GMT
+      - Thu, 28 May 2015 01:27:06 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=dDhOWEhpSHdGcjRVWUFsYlBlbEFibW43TStvak9ncXBnNG9EenNpaGVXZmhoZnROWTlveTlsVjF4WnJ5TVo3TmgvTlVaTzl4ZFhjc0t4cG9HNWsrQzMxQW1EZ3MxWTNnOElYNVpEN3IrN21GVExrUC92bkNwRnJDSnhrbXRPSXAxUU1zTzRmWmhDeW45Y2dIdVI2TmZoMFlNallPTWZvdUIxYmUrL2dqUnJaOVE1SHJYV1RhVFE0Rk40U1cwM3FlLS1XYUcxSlA1blNlemtrNXZ4ZUFQRmdRPT0%3D--31a895c0e8896f894b37b8a87db119b76518c025;
+      - _internal_session=UGExNHlUK1ZyanN1T2o4SUdTNmhWMG5kWUlnU1dUZ1NhU2lwd1ZyN2twOEdtM28rNWNOVlorMDFBTy81YlRjSjhMb2ZvWWxMeE4wc0htQVQ1bW5tWkp3Q2thNFZqMmsvZGZSUGRhQlVjN0c1L0ptam9MT0tlUmVBZFQxOWdSVEFBcTdNL05VTTJXREdwaDltY0poR3VrNEpZUFdOTkUrY1ZKZlFmc1NuaEQwWUtxSlNIaVBCMFlQWmdWOXBNUXNKLS15bk5XNFBnZTVMMmwwd0J1KzBqUE9BPT0%3D--a0fdfebb9368fdba9678ebe7d302981298e219f7;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:03 GMT
+  recorded_at: Thu, 28 May 2015 01:27:06 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/cannot_get_an_open_annotation_by_ID_with_content_type_text/x-nquads_.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/cannot_get_an_open_annotation_by_ID_with_content_type_text/x-nquads_.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"e91952778c52b56fa67863c615739f9e"
+      - W/"1d436fdb5ebec04bc0e5ba18f0c76735"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 25b3a6ed-6d79-4551-b432-001ce21756da
+      - 605e8bb2-86eb-4cc5-b595-944443348263
       X-Runtime:
-      - '1.619081'
+      - '2.267499'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:08:01 GMT
+      - Thu, 28 May 2015 01:28:17 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=VFJlbHZtcFVaeVJzUVdJTnlkd1lpajB2UnorTU9POHlubVNTQjJPWkZ6SzFPM1EyVHBORGwyWmp6YTgwak42TERLWmJ5dzFUbVRMbDZjQk5Pc1p0aHB4OFBnaWVxODgxa1o4UExFcGc2aXh3SzdPODlqWXFQcUpLNU5LcmtWQSt4QWZ1WGJlMEZUazJvOFNhc3Vnc2p6MkEySENrQy9qdncyYnNrdTZodmsrSkVkdnpLNzJuN1N3RC92R3RYRGdLUDRNSDFwcFB2eVc0dzYwUHlSQkRLclplZGI4NHFHZ2lkZEFJaHVoN0hpV0UrajJodWF1YmNaaDcvN0VPbld6by0tM2RHMEx0Z0hJZEpoV2l3NlVLYVljZz09--cd58eb2024163cd26e1705c7549eb08583edc63b;
+      - _internal_session=dGFrcFpkRFVPeXZUZkNPSmJxSFN5dWxWdWJCNTJXRWEwRm95Uy9GcWhVTm5mUlpxK2wvem5NTWhrWVI1c1puTFpYOUVKMGl1U010ekd5ZnREa1piU0pNMmxvSHVsWUIycXA1cEFkY0RNL2dadHA1ZWJtVlNmSHgvbWJSNFlEM1lka0Y5ajVpek1EN3R1a005K1hDNlpncDRpSTlibi9RTDZ5YStqelhHTmF3akpRUUtvVU50UEljTDBCclF6N0JUQ01YYUZ5MEhZVUwrS0hVbVRaZm54U0IzZ2FuOUh4aVkyYUJGSkI0ZlZWQzEvMG00Y1Q1UGE2UCtJbG5aZCsyMi0tWHdUanl6c1l1eURxaFp0UlJLRWo5QT09--8f05abfc403924ca1654991a82b987400ef5c60b;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310860346080","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/1d/e5/af/a1/1de5afa1-72e5-4b51-96f5-a675bff6f04c","@type":"oa:Annotation","hasBody":"_:g70310860346080","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942029229620","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/e0/b3/de/6b/e0b3de6b-11dd-4a47-9dcd-268a1fff8c63","@type":"oa:Annotation","hasBody":"_:g69942029229620","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:01 GMT
+  recorded_at: Thu, 28 May 2015 01:28:17 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:01 GMT
+      - Thu, 28 May 2015 01:28:18 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:01 GMT
+      - Thu, 28 May 2015 07:28:18 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:01 GMT
+  recorded_at: Thu, 28 May 2015 01:28:18 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:02 GMT
+      - Thu, 28 May 2015 01:28:18 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:02 GMT
+      - Thu, 28 May 2015 07:28:18 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:02 GMT
+  recorded_at: Thu, 28 May 2015 01:28:18 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:02 GMT
+      - Thu, 28 May 2015 01:28:19 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:02 GMT
+      - Thu, 28 May 2015 07:28:19 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:02 GMT
+  recorded_at: Thu, 28 May 2015 01:28:19 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:02 GMT
+      - Thu, 28 May 2015 01:28:19 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:02 GMT
+      - Thu, 28 May 2015 07:28:19 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:03 GMT
+  recorded_at: Thu, 28 May 2015 01:28:19 GMT
 - request:
     method: get
-    uri: http://localhost:3000/annotations/1d%2Fe5%2Faf%2Fa1%2F1de5afa1-72e5-4b51-96f5-a675bff6f04c
+    uri: http://localhost:3000/annotations/e0%2Fb3%2Fde%2F6b%2Fe0b3de6b-11dd-4a47-9dcd-268a1fff8c63
     body:
       encoding: US-ASCII
       string: ''
@@ -2475,13 +2475,13 @@ http_interactions:
       Content-Length:
       - '127999'
       X-Request-Id:
-      - 0ac2e5c8-57ac-4b91-adb0-afafdeee48b8
+      - df253e7f-11f1-4ba8-958f-fa44d54b9109
       X-Runtime:
-      - '0.341914'
+      - '0.282105'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:08:03 GMT
+      - Thu, 28 May 2015 01:28:20 GMT
       Connection:
       - Keep-Alive
     body:
@@ -3818,7 +3818,7 @@ http_interactions:
         && el) {\n          currentSource.className += \" hidden\";\n          el.className
         = el.className.replace(\" hidden\", \"\");\n          currentSource = el;\n
         \       }\n      }\n    }\n  </script>\n</div>\n\n  \n\n<h2 style=\"margin-top:
-        30px\">Request</h2>\n<p><b>Parameters</b>:</p> <pre>{&quot;id&quot;=&gt;&quot;1d/e5/af/a1/1de5afa1-72e5-4b51-96f5-a675bff6f04c&quot;}</pre>\n\n<div
+        30px\">Request</h2>\n<p><b>Parameters</b>:</p> <pre>{&quot;id&quot;=&gt;&quot;e0/b3/de/6b/e0b3de6b-11dd-4a47-9dcd-268a1fff8c63&quot;}</pre>\n\n<div
         class=\"details\">\n  <div class=\"summary\"><a href=\"#\" onclick=\"return
         toggleSessionDump()\">Toggle session dump</a></div>\n  <div id=\"session_dump\"
         style=\"display:none\"><pre></pre></div>\n</div>\n\n<div class=\"details\">\n
@@ -3828,7 +3828,7 @@ http_interactions:
         &quot;gzip, deflate&quot;\nREMOTE_ADDR: &quot;127.0.0.1&quot;\nREMOTE_HOST:
         &quot;127.0.0.1&quot;\nSERVER_NAME: &quot;localhost&quot;\nSERVER_PROTOCOL:
         &quot;HTTP/1.1&quot;</pre></div>\n</div>\n\n<h2 style=\"margin-top: 30px\">Response</h2>\n<p><b>Headers</b>:</p>
-        <pre>None</pre>\n\n</div>\n\n\n</body>\n</html>\n<div id=\"console\"\n  data-remote-path='console/repl_sessions/ce2dc0b266b0ac990735583af5ab92dc'\n
+        <pre>None</pre>\n\n</div>\n\n\n</body>\n</html>\n<div id=\"console\"\n  data-remote-path='console/repl_sessions/e08877857b79910b064a15143aa0dc2e'\n
         \ data-initial-prompt='>> '>\n</div>\n\n\n<script type=\"text/javascript\">\n(function()
         {\n  // DOM helpers\nfunction hasClass(el, className) {\n  var regex = new
         RegExp('(?:^|\\\\s)' + className + '(?!\\\\S)', 'g');\n  return el.className.match(regex);\n}\n\nfunction
@@ -4025,10 +4025,10 @@ http_interactions:
         \   resizerElement.addEventListener('mouseup', recordConsoleElementHeight);\n
         \ });\n});\n\n}).call(this);\n</script>\n\n"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:03 GMT
+  recorded_at: Thu, 28 May 2015 01:28:20 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/1d%2Fe5%2Faf%2Fa1%2F1de5afa1-72e5-4b51-96f5-a675bff6f04c
+    uri: http://localhost:3000/annotations/e0%2Fb3%2Fde%2F6b%2Fe0b3de6b-11dd-4a47-9dcd-268a1fff8c63
     body:
       encoding: US-ASCII
       string: ''
@@ -4055,22 +4055,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 64f66c8e-c4f4-4b81-bb8d-b1d176edd5e3
+      - 39d06d79-6138-4d73-b50c-032805d0fdc4
       X-Runtime:
-      - '0.199600'
+      - '0.179395'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:08:03 GMT
+      - Thu, 28 May 2015 01:28:20 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=bk9CMmg1bFIra1R6eTRJMXJCeUVTSDlRS3M5aFpSTUNtOE5mR3UrQ2lJQVhGSHBtQWptOEhjeGdwR2NnNjZlTW9qSXZaZE9SMCs3TG84RG9ESWpEWWRiOWovc0FDdVNLQVI1OFVmK25IN0Z1U1pPWW92UXJpTnVDWTRPeEhGVS9oVGlWU3BFWGxOVTF4eFNySlNmSHNTOFJzRlJ0YmdjQkZIbVUzWUgvYWlNQiszRXNrRTZHR3RLSDFKWEluYVY1LS11dmFDcEl6Qzc0UWFzVzNodVMycHhBPT0%3D--99766a5275655d164124971a93c77a6aab260a1c;
+      - _internal_session=UU5BL25mdjBOd2gybVNrK1dUeHVsTW00ZGZhWC9UaDlLK1Jkc3dBV2lVSStZL293TWN1MnEwTXhCT2xNa1BDcmtnRTdsMmVmVW02TlB1bEVyNi8rRGNmbmhiZzlXaGd4UGc2eG9KSlBjTzlJK2JLRzlpLy80cjRpWFE4Vk1ZcTJqTXc3WHJzaHJMUjkrRFJCeE85Q2dpQ3VCSTQzTkVHZUI4UC8vZGx2MGpWWFVSd3F2cEZ0SytIcm9Ma0NmVmJOLS1MUjV3NDhCbUxMQk1hUGNhL2NzWXVnPT0%3D--ed34af31fcdc9cf75ce50385c027b4c46a8378c6;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:03 GMT
+  recorded_at: Thu, 28 May 2015 01:28:20 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/gets_an_open_annotation_by_ID_with_content_type_application/ld_json_.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/gets_an_open_annotation_by_ID_with_content_type_application/ld_json_.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"66e9b0fa27b6bb453c23be858df6c62b"
+      - W/"aa037a95180c7bad9718f9d30e3d3c0f"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 8e23dc13-3390-43b5-b2cd-802423940308
+      - e4576b76-ff24-4375-b4dd-4201b0b990cd
       X-Runtime:
-      - '1.486280'
+      - '3.960338'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:24 GMT
+      - Thu, 28 May 2015 01:26:11 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=OWpodFNYU0VKVmJxb2RHcll6K0d6aHQ5aUgzeEplZmg1cnBKR3l3NXdvV1NCUVVzTkxGQlhpTXUzekZFSFNoejhzam9XR091NHorQUIzKzF5aWw3dHRLZ1FKa3EyeFRXZElZM0RPUlNLeWlqNC9KVTVBMk9IZ2lSQW1wNDFUUExmYjFKb0crM0NmbDdLdGFkR0hjNzE5emVpMGFQWlFoaWJ4Q0p0YjdUSnRDU3lZdGwvS1BBNWV4c3RSd1RYU0JhdUVZVWU4S1J4L2JJeU9CS2x3VFc0MDZoUGpBV2UyUDNBVlZBZWtzQXlEWHcxTHpGVXNIN3h5MUxvNEMrZGplZS0tTU1pNS94eTR0RkpNK1RQQnN1MURKZz09--8139cc779c4e85fcf21bee9c5913f7e8f4e6ad3d;
+      - _internal_session=UUdUOElrcWtSSjRsczNQc1lZb1R5U0U4cHhQR1VkOGdzQmpuakJFQk5oRXdjd2liMi9xZUphUEdUamZ5NXFvRDRneWxWdHdVOGNwMlpVdytNa0h1TDd0aEFyNloxL3ZSN0YyYVk5N2dDNnNLdkhTQXhybCtEcU1vY0xmL1BYM09aYkYvaytjWEc1RTc1ZHRzT1I3YnplMmhMNzNpTWpCU20xQ01KSWhyc0FlODFqQ012SURTVmRqdFp1SzYrWkdYME15akJWbUFFRWhPUThZbGdnZmRhRzY0Rmdudis4a2NaanlCZCtlTE1YMHdXR1hUZ2JBU0tBcUJBaDhFOWlaci0tTXBZWWZPaFA2SzYvNFI1VlpwcU9ZQT09--f060afdf65f97c9529ba843a55f4349e20c81b85;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310856682260","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/23/58/f6/62/2358f662-3c2f-46cf-93ee-5353a5c9df87","@type":"oa:Annotation","hasBody":"_:g70310856682260","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942033589520","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/58/aa/97/d4/58aa97d4-aabc-40c1-8479-a7104050e9b5","@type":"oa:Annotation","hasBody":"_:g69942033589520","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:24 GMT
+  recorded_at: Thu, 28 May 2015 01:26:11 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:24 GMT
+      - Thu, 28 May 2015 01:26:11 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:24 GMT
+      - Thu, 28 May 2015 07:26:11 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:24 GMT
+  recorded_at: Thu, 28 May 2015 01:26:11 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:24 GMT
+      - Thu, 28 May 2015 01:26:11 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:24 GMT
+      - Thu, 28 May 2015 07:26:11 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:25 GMT
+  recorded_at: Thu, 28 May 2015 01:26:12 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:25 GMT
+      - Thu, 28 May 2015 01:26:12 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:25 GMT
+      - Thu, 28 May 2015 07:26:12 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:25 GMT
+  recorded_at: Thu, 28 May 2015 01:26:12 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:25 GMT
+      - Thu, 28 May 2015 01:26:13 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:25 GMT
+      - Thu, 28 May 2015 07:26:13 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:25 GMT
+  recorded_at: Thu, 28 May 2015 01:26:19 GMT
 - request:
     method: get
-    uri: http://localhost:3000/annotations/23%2F58%2Ff6%2F62%2F2358f662-3c2f-46cf-93ee-5353a5c9df87
+    uri: http://localhost:3000/annotations/58%2Faa%2F97%2Fd4%2F58aa97d4-aabc-40c1-8479-a7104050e9b5
     body:
       encoding: US-ASCII
       string: ''
@@ -2479,27 +2479,27 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"c7ecfe18ffd9df96ed50d8c53e1fc1af"
+      - W/"b49fba7f48796c77c1bb30c1d814d007"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - c0ad729b-6664-4117-bc9f-a4c148efb164
+      - 0d067e89-3ed1-4f80-9858-a98f7c488090
       X-Runtime:
-      - '0.820868'
+      - '1.027470'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:26 GMT
+      - Thu, 28 May 2015 01:26:20 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310876142400","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/23/58/f6/62/2358f662-3c2f-46cf-93ee-5353a5c9df87","@type":"oa:Annotation","hasBody":"_:g70310876142400","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942033561040","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/58/aa/97/d4/58aa97d4-aabc-40c1-8479-a7104050e9b5","@type":"oa:Annotation","hasBody":"_:g69942033561040","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:26 GMT
+  recorded_at: Thu, 28 May 2015 01:26:21 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -2519,7 +2519,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:26 GMT
+      - Thu, 28 May 2015 01:26:21 GMT
       Server:
       - Apache/2
       Location:
@@ -2527,7 +2527,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:26 GMT
+      - Thu, 28 May 2015 07:26:21 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -2543,7 +2543,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:26 GMT
+  recorded_at: Thu, 28 May 2015 01:26:21 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -2565,7 +2565,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:26 GMT
+      - Thu, 28 May 2015 01:26:21 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -2579,7 +2579,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:26 GMT
+      - Thu, 28 May 2015 07:26:21 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -3697,7 +3697,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:27 GMT
+  recorded_at: Thu, 28 May 2015 01:26:21 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -3717,7 +3717,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:27 GMT
+      - Thu, 28 May 2015 01:26:21 GMT
       Server:
       - Apache/2
       Location:
@@ -3725,7 +3725,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:27 GMT
+      - Thu, 28 May 2015 07:26:21 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -3741,7 +3741,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:27 GMT
+  recorded_at: Thu, 28 May 2015 01:26:22 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -3763,7 +3763,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:27 GMT
+      - Thu, 28 May 2015 01:26:22 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -3777,7 +3777,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:27 GMT
+      - Thu, 28 May 2015 07:26:22 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -4895,10 +4895,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:27 GMT
+  recorded_at: Thu, 28 May 2015 01:26:22 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/23%2F58%2Ff6%2F62%2F2358f662-3c2f-46cf-93ee-5353a5c9df87
+    uri: http://localhost:3000/annotations/58%2Faa%2F97%2Fd4%2F58aa97d4-aabc-40c1-8479-a7104050e9b5
     body:
       encoding: US-ASCII
       string: ''
@@ -4925,22 +4925,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 6ae3c214-1639-418a-9ba3-0d77c0a28160
+      - 3faa5d0d-0a3e-459e-a4b7-b4c0b708196e
       X-Runtime:
-      - '0.276218'
+      - '0.230006'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:27 GMT
+      - Thu, 28 May 2015 01:26:22 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=YmJJMnlVM0R2ejFSd0wvNHdDZGlNMFlJZTRLcHdVMFpQYjAxeW14Q0J2bC9uaFZEdTZKakpienNzS3hYZ1I0Mlg1UlJ5Z1BkenhJOW5lTEcwWW9zVW5lMEV2dzJtUVJ5OXBaZkgzRHd1VkhIc0VYK3JLT0FHNGU3c2o3YUJVdnBVYjRmQlh1VWx5dnh0VmlhQytSODNOazJ4dXB6V1doNUdoQlBCMjZhWmRlbG12VTFvUDRIdUNIa01kM2gweEl3LS10SFhkZ0lDMDcvczBseXdsMURqdlNnPT0%3D--a593890f432534a1b951b482f81ba66c2ce37c29;
+      - _internal_session=eUxEejdLaG5EZUVxM0hVa2E4UzhVWFRnT3VpeVpkOTMyR2VRb0RLcUpORi9WQjMxdmk2MzVoTTJ3My95WlJMdWtxencwSG82TGxnbVlLZndTMjJEdWZWZlRIb1UrRTcyUW9odFQxem05a0dtcVJFbjl0VGtGSWtLaFBuOThMNzZpdEpMbnJwNHVieEowTHRLZDAzbWlOOHl1d0lYa2NwYVZ0b0hUL1hieG1rZlNpQ3JUNzg0WWxOUFhQT1BSUEJmLS1jMHc3aEF4ZE1aeWpqZEczL01MVGNRPT0%3D--f093cd1a0f234ad5ee9d9bd377a137fd6f81f7a6;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:27 GMT
+  recorded_at: Thu, 28 May 2015 01:26:22 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/gets_an_open_annotation_by_ID_with_content_type_application/rdf_xml_.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/gets_an_open_annotation_by_ID_with_content_type_application/rdf_xml_.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"98789c4bb30d8a5c023dd141e88d8edd"
+      - W/"8fd78982f1e0187601316663ac853a79"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 3e611c5a-8ff4-4903-bfd6-900083229142
+      - fd865252-2a6d-40e6-992e-46152161e5fc
       X-Runtime:
-      - '1.741883'
+      - '2.370618'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:47 GMT
+      - Thu, 28 May 2015 01:26:47 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=UXdoNGkvVWZJdmN3SjREZjJXdSszUkdhVkZKWDROWTYxb0R0YXJ5MEx5bHNWSXBtOVdkaysrUFZUQUJBdW5PRlhJcENMaXZ3KzZodkJEaWExd0hCVEFjSmwyNU1zYTlKRzRjVUtmRURPTHdWWU5PR0IwejF5ckgvNEpZVlNrMFJ6aUg1OGtLUHVxcW4wcHVtVnEzTXpYUVFPZVFIc1BxR2RaL2oxVDQ1S3J3ZVRSQzFSMXd2N0pKUEFURm9vTzNzc0FmaWx4ZFVzK1VvZHBybUZwV21ISU0zbXFEcGFSaGJrL3Q5N2pxN0g1SFY2Vm94aExNKzhMc09lWnJzaG4weC0td0MrcTZTTUdGMDBMMXEyOUsyb3B5dz09--47637b5ffff74bc988ab319cfb987564a18b62f6;
+      - _internal_session=SStaTFhGdURJQlBMek1iTmljeExHS251WDY0Z0Q1ZC9xY2cxaDlpaVNESFlDYmFYNklDU2tRMVdyNFVhai9iNXlsVTlHK05WcU5seU44TjQ4cFRBOU9yWGhjZGZDdE45WVhJZXpMb2xJQnZUai9yNFVvRVo5TldMOE5rckhsNUswYm04YTh5eU94Q1pucXQyczNYNjM2V0FTaWN1MjdjL3NXSEpYeU1TSUM3S3AzZ2RQTzhlcENnK1BrN2ZuMzYwVGp3Y3Q3RnZVVmZ6Tm0wQkpDdXRzc2hXYlNzTzdHa2g1S1Q2MElFZlVGd0orbmFNSlg0aDJNUHNaU3VvSWZHdS0taWtjZUp0RnhxV05PSW84RG1PWUZiZz09--989e316a549d529cc834c172f315ab9fcf291be9;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310845350660","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/46/05/a5/b2/4605a5b2-fe2b-4da2-a6c9-d49c80a47d37","@type":"oa:Annotation","hasBody":"_:g70310845350660","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942025250480","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/42/6f/8d/2b/426f8d2b-621a-4f82-825a-b69b7fbc70c1","@type":"oa:Annotation","hasBody":"_:g69942025250480","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:47 GMT
+  recorded_at: Thu, 28 May 2015 01:26:47 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:47 GMT
+      - Thu, 28 May 2015 01:26:47 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:47 GMT
+      - Thu, 28 May 2015 07:26:47 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:47 GMT
+  recorded_at: Thu, 28 May 2015 01:26:47 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:47 GMT
+      - Thu, 28 May 2015 01:26:47 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:47 GMT
+      - Thu, 28 May 2015 07:26:47 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:48 GMT
+  recorded_at: Thu, 28 May 2015 01:26:48 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:48 GMT
+      - Thu, 28 May 2015 01:26:48 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:48 GMT
+      - Thu, 28 May 2015 07:26:48 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:48 GMT
+  recorded_at: Thu, 28 May 2015 01:26:48 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:48 GMT
+      - Thu, 28 May 2015 01:26:48 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:48 GMT
+      - Thu, 28 May 2015 07:26:48 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:48 GMT
+  recorded_at: Thu, 28 May 2015 01:26:49 GMT
 - request:
     method: get
-    uri: http://localhost:3000/annotations/46%2F05%2Fa5%2Fb2%2F4605a5b2-fe2b-4da2-a6c9-d49c80a47d37
+    uri: http://localhost:3000/annotations/42%2F6f%2F8d%2F2b%2F426f8d2b-621a-4f82-825a-b69b7fbc70c1
     body:
       encoding: US-ASCII
       string: ''
@@ -2479,17 +2479,17 @@ http_interactions:
       Content-Type:
       - application/rdf+xml; charset=utf-8
       Etag:
-      - W/"f1e6615f9b6ea869e4d5094b64abe4df"
+      - W/"90d1c94f1962bd0d9e606e8aaf23e6a1"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - e02ce82d-ee70-423d-849a-12f6c0fd528f
+      - ff8a761f-db02-4bc0-9292-06928729b826
       X-Runtime:
-      - '0.255719'
+      - '0.147515'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:48 GMT
+      - Thu, 28 May 2015 01:26:49 GMT
       Content-Length:
       - '909'
       Connection:
@@ -2499,9 +2499,9 @@ http_interactions:
       string: |
         <?xml version='1.0' encoding='utf-8' ?>
         <rdf:RDF xmlns:cnt='http://www.w3.org/2011/content#' xmlns:dc11='http://purl.org/dc/elements/1.1/' xmlns:dcmitype='http://purl.org/dc/dcmitype/' xmlns:oa='http://www.w3.org/ns/oa#' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
-          <oa:Annotation rdf:about='http://your.triannon-server.com/annotations/46/05/a5/b2/4605a5b2-fe2b-4da2-a6c9-d49c80a47d37'>
+          <oa:Annotation rdf:about='http://your.triannon-server.com/annotations/42/6f/8d/2b/426f8d2b-621a-4f82-825a-b69b7fbc70c1'>
             <oa:hasBody>
-              <dcmitype:Text rdf:nodeID='g70310874745000'>
+              <dcmitype:Text rdf:nodeID='g69942025655820'>
                 <rdf:type rdf:resource='http://www.w3.org/2011/content#ContentAsText'></rdf:type>
                 <dc11:format>text/plain</dc11:format>
                 <dc11:language>en</dc11:language>
@@ -2514,10 +2514,10 @@ http_interactions:
 
         </rdf:RDF>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:48 GMT
+  recorded_at: Thu, 28 May 2015 01:26:49 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/46%2F05%2Fa5%2Fb2%2F4605a5b2-fe2b-4da2-a6c9-d49c80a47d37
+    uri: http://localhost:3000/annotations/42%2F6f%2F8d%2F2b%2F426f8d2b-621a-4f82-825a-b69b7fbc70c1
     body:
       encoding: US-ASCII
       string: ''
@@ -2544,22 +2544,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 7bbe13f6-3938-4697-b949-e620610ad92a
+      - 07892d58-d7cc-4569-a546-0053c3e56e57
       X-Runtime:
-      - '0.301621'
+      - '0.203552'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:49 GMT
+      - Thu, 28 May 2015 01:26:49 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=cnFQWWlDeXVmRnJuVHJCTHFxTlJHN3hxWVRMUm5nc0xaa1A2Mk8yL0lWYXFiUG02aGdKU1U2V2FzUWxxZmxhLzlwVWpaNzJtMHlGSVA3QTBtYytMUTVQalFaM25MSVpzZ3J2dk1OZnY5QVp3VXNyMnBWM3Jka0IvMUd5RGhPQTZrN0J6N1MvYzByelhOdGlhZ3haQTdxUy9uNStuaU1wOGRra1NWRnppdGIxd2JUZGs4WEFYNStVNHpQcS83Z2RCLS1heEJQVUpTV3NmS0FKTEVpdm9MMDh3PT0%3D--83d436c1f6c44317999de13073cd80df34501a48;
+      - _internal_session=NStLOXB4andGVHZaMmRWWkcySzFqdGFMcnh5UDBOa2h0TmVsZU96SmF1OEFiL09RU0RPd1B6NmxkZHpqMnQvL2t3WlZHWVA2OVBOMWFuZWZJRmNXUlFzVkMyaC9KN3R3NUpUeDh1b3dWOU9lbSt4SlZYMlpnSXF5ZUM5TlVMREF6RHhPR3RXd01pZjc2c0RFQTl6Q040MCtqc2dpY0t5ZElXYTUybmdrRGwvTU50Y0NPN3I4VW5vT3lzeVBOZVQ1LS1GQkFmRmJQQzhMeW9jMjV5ZWwwSml3PT0%3D--0166873a7c0a1f0f2ca01bf0dbe24b20f6958028;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:49 GMT
+  recorded_at: Thu, 28 May 2015 01:26:49 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/gets_an_open_annotation_by_ID_with_content_type_application/x-turtle_.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/gets_an_open_annotation_by_ID_with_content_type_application/x-turtle_.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"9a023f01e654890c1e26b7c2ea0af262"
+      - W/"1468e645b22cbdd5241b253406857883"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - ec3a05ae-c30d-40fd-851b-fa1139a26ed9
+      - 72618300-f6c9-4c0f-a443-45087ad67c51
       X-Runtime:
-      - '1.632540'
+      - '2.211007'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:07:15 GMT
+      - Thu, 28 May 2015 01:27:21 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=MERHZFRrNG9Ca1BucnF1TzlveWo3L01DSEV2K1VlNlV0SHFWT2tObTFUaFl5SDJxYWVNZlZ5aUgzcnBOczUrN1hMbElaU2VjZ2ZzcnhSbEwzKzFsVmlkWXdxWEY3cDBaclJkNCs4aDNrYjlaZ0hhazVuVHBmQTNLV2piN3Jwak90OUtqRStqSUpJTGM0UGdGUi9XK2Z0clFGVzBJdHdPR3ZSNmhEbHcvOGtKZjFIM2NJT0ZzNjBiRTBaREZjOHFwZUpwNHpyUjhqUG5IbGdBMFh6N3pVc25UMTNzTzRKQzlkZlVyV0U2eVFoUmYwN0IzWmdGQ0xzaUF4MjhNeGRQWi0tTW5XSVUwejVZMWc3dnNlN0d4UVoxQT09--a1f300decc18fdc24346d8cfc785126e3ef89763;
+      - _internal_session=UDB4NTh4eUJaOFJRWUJycVRqaWZ5aE5NNVZGSW1INWRZM2Y2bWEvMEl6ZmpRSXZjeGl4RlFSWkkrV1ErTGNJYUpBVlRHZkdNYlZEbStKTHdGOXFLdDFLMUJpN2c3TDhMN3JXZDAzNkdxMis4ejBVOXQvem9EMnJhYVJHdWRyeVNFeHBPQzUxNmRNR2hxa3NIZmxEa3IxcnV1dzJvWVNpenNoTkhUSmN6WUxTaExDb1drZFJST3JlWWN5b3NMc05QdWFQTjVPeXNEeHZpQTQ0Q2Y3dzlib29TUVRtYXYxTDYxZURhNnhHc1drYmVwT0hBcEVrTFNrRWFERkNqMGl1di0tMkcrVTByWFVKMWVMSUp2M01haFhWUT09--1e386058ed8ae4b06813126f09fa72cf969f83bb;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310876475560","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/fe/15/30/c1/fe1530c1-5617-41c8-ab1f-60db3ca0758c","@type":"oa:Annotation","hasBody":"_:g70310876475560","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942024626020","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/7b/9f/bf/d5/7b9fbfd5-14fe-43aa-95fe-c7d78c13ae8c","@type":"oa:Annotation","hasBody":"_:g69942024626020","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:15 GMT
+  recorded_at: Thu, 28 May 2015 01:27:21 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:15 GMT
+      - Thu, 28 May 2015 01:27:21 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:15 GMT
+      - Thu, 28 May 2015 07:27:21 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:15 GMT
+  recorded_at: Thu, 28 May 2015 01:27:22 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:16 GMT
+      - Thu, 28 May 2015 01:27:22 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:16 GMT
+      - Thu, 28 May 2015 07:27:22 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:16 GMT
+  recorded_at: Thu, 28 May 2015 01:27:22 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:16 GMT
+      - Thu, 28 May 2015 01:27:22 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:16 GMT
+      - Thu, 28 May 2015 07:27:22 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:16 GMT
+  recorded_at: Thu, 28 May 2015 01:27:22 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:16 GMT
+      - Thu, 28 May 2015 01:27:23 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:16 GMT
+      - Thu, 28 May 2015 07:27:23 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:17 GMT
+  recorded_at: Thu, 28 May 2015 01:27:23 GMT
 - request:
     method: get
-    uri: http://localhost:3000/annotations/fe%2F15%2F30%2Fc1%2Ffe1530c1-5617-41c8-ab1f-60db3ca0758c
+    uri: http://localhost:3000/annotations/7b%2F9f%2Fbf%2Fd5%2F7b9fbfd5-14fe-43aa-95fe-c7d78c13ae8c
     body:
       encoding: US-ASCII
       string: ''
@@ -2479,17 +2479,17 @@ http_interactions:
       Content-Type:
       - application/x-turtle; charset=utf-8
       Etag:
-      - W/"4dbbf981cf66571da0fd6016307d07a1"
+      - W/"1a79d84dbf918a209db3d70eabd5d697"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 33f4096a-3b6f-4f70-b743-dd946fba7f17
+      - 22238541-d63e-4ebc-b616-e7d65a54cf03
       X-Runtime:
-      - '0.149692'
+      - '0.156919'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:07:17 GMT
+      - Thu, 28 May 2015 01:27:23 GMT
       Content-Length:
       - '663'
       Connection:
@@ -2504,7 +2504,7 @@ http_interactions:
         @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
         @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-        <http://your.triannon-server.com/annotations/fe/15/30/c1/fe1530c1-5617-41c8-ab1f-60db3ca0758c> a oa:Annotation;
+        <http://your.triannon-server.com/annotations/7b/9f/bf/d5/7b9fbfd5-14fe-43aa-95fe-c7d78c13ae8c> a oa:Annotation;
            oa:hasBody [
              a dcmitype:Text,
                cnt:ContentAsText;
@@ -2515,10 +2515,10 @@ http_interactions:
            oa:hasTarget <http://purl.stanford.edu/kq131cs7229>;
            oa:motivatedBy oa:commenting .
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:17 GMT
+  recorded_at: Thu, 28 May 2015 01:27:23 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/fe%2F15%2F30%2Fc1%2Ffe1530c1-5617-41c8-ab1f-60db3ca0758c
+    uri: http://localhost:3000/annotations/7b%2F9f%2Fbf%2Fd5%2F7b9fbfd5-14fe-43aa-95fe-c7d78c13ae8c
     body:
       encoding: US-ASCII
       string: ''
@@ -2545,22 +2545,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 8443e198-00ed-4bef-a8c7-8631f62e7851
+      - 6f9c2bcf-ae06-4500-9410-b74ada368eb5
       X-Runtime:
-      - '0.219288'
+      - '0.243685'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:07:17 GMT
+      - Thu, 28 May 2015 01:27:24 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=dG1oT2JLUVc1SjROUE5PNzZpUnpRdVIvYzUxajY1VEFKUnZQaFFtdWszNTZUeFAyMnJtSDZuV3JoRDdVVXFWdUpYYmZvcW9WRUpydWsybTQvSU8vQ3FQeVNOL0MyRWFpdGpKY1pudWNLWGlsYWQ4Y3M2OFdSeU5QTmNEOTAza05xVHJ2RG9tUDZta1NNakg5VkQwM1VMRWxQa0k0RXpRMFAwNXRldkVRTGZLYStuVWI1ZWpMa20zcU5XL2RTNUJyLS00NENrc2RORVZQQzQwYXdWZ0JnMlBnPT0%3D--88ee7c067d970068dd6b8bfbaa0cf0e57400ffba;
+      - _internal_session=WW1LdzA1TC9OUi9uRjhHdGgrSHJsSUlQdXlDT2M2ZUhuZXVwZUR3VEpaaENtRXlZYkdUL0huU202amNMWlY4VGYzbitoNU1tWmlQK1RCQ1B3cG1FOTlOc2N4Skh0U3A1a0c0QVhtOFRFQ0c4ZnhHQ1NyZGZCYld6UDVGaHJnOGM0UlB0UndHSDMxOHNxVmZZOXJTaGxad1ZwQ0ZPRGlKK3piNkVXREt4aDVOY3QrMVhENWZvdkNiV1FQOUNRWS8vLS16VXRBV3NlSkxMNThyWXlvc2Mxd0NBPT0%3D--e80f8588fb8a94078ad711cd884af616418c3498;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:17 GMT
+  recorded_at: Thu, 28 May 2015 01:27:24 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/gets_an_open_annotation_by_ID_with_content_type_text/turtle_.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/gets_an_open_annotation_by_ID_with_content_type_text/turtle_.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"29d40598978fc5c4ceefc7186e4f4035"
+      - W/"1aacb3b4372d924e6f075594309cba31"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 07308755-7017-47fd-9d89-1fe1c48a3ef3
+      - 5e04b61b-93bf-4ce3-bd39-1ef99cc0095e
       X-Runtime:
-      - '1.734672'
+      - '2.186937'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:54 GMT
+      - Thu, 28 May 2015 01:26:55 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=OXFQWUZDaC85aVRsbk1oUERYZjlzSmVuNWg1aHpDc05mSmRIWmsvaUhCU0JrUmo1OEVpQkRmeW96Z2RUVEE0dVZzbjBINndRWlkycXBrUEcxK2g2RlZYNDBVNWdxaHpyN3lrVXJ6R2JEalh2ZEk3Rk5wdkltdzZweHEwY2JiWi9YbkE3cGdMWGJHMDluL1ExMjBFbEFhRGk0aStraG5rRmc3YmtzZDRvR0xESmsyV2RiS2luSXk1RHd2TG9JN3YwYjJ3YjJBTjNzNXc3cnBxcWJsMTZ1dzY2WG1UK0N1S05EQ0VFUXhZNDN4OVZnNWYvd2Y3YXZHeWdlWk1sYW5Nai0tTFhQTWdvTk16WURyQlM0UFJKaEFqUT09--334445aab6f9ac5dc6cbd99e456a0478cb611081;
+      - _internal_session=WlhUNmw2WXRkTTZLNllOZElEaElJY0xoYTJhRlJjazM3dGRnTDFDQmJ4TnNWMnQ1NXh0N0RXRHdIOTVnL2lpN0hBSGd5S1hFQkhDNzVST1hEa1dKOFVSalNleGdrNU9nMzhZTFBPYVZhRDU3YmIxMFFwRTBPdWJvSkpKdXA4aHMrc3VUT3IyMFIvb1RZdzRsV21ZQ0xrUHpueE1DRFpRcDdqdXlucVdGMGdvakJqQWpRaTRIV3E3SCs3TmlmOGxRY1RHNXlkeXR3NmNOMytNakh4b0cxVTdoejdYMUFRM2h4dHpYei9SNzhEVDdXWkhDTXI1Q09tZTVYZjJ6aHRMTS0tRmpMNUo3MGpFMUF2bG9MZzB4R2ZIdz09--1fb31d41eb3cc182998f806c0d2c408cf9b4ffb1;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310877989980","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/dd/29/3c/fe/dd293cfe-af84-487d-9c27-7773e8e4a833","@type":"oa:Annotation","hasBody":"_:g70310877989980","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942027116860","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/78/57/43/b7/785743b7-a17f-4592-bf5d-524bd1ed8722","@type":"oa:Annotation","hasBody":"_:g69942027116860","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:54 GMT
+  recorded_at: Thu, 28 May 2015 01:26:55 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:55 GMT
+      - Thu, 28 May 2015 01:26:55 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:55 GMT
+      - Thu, 28 May 2015 07:26:55 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:55 GMT
+  recorded_at: Thu, 28 May 2015 01:26:56 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:55 GMT
+      - Thu, 28 May 2015 01:26:56 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:55 GMT
+      - Thu, 28 May 2015 07:26:56 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:55 GMT
+  recorded_at: Thu, 28 May 2015 01:26:56 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:55 GMT
+      - Thu, 28 May 2015 01:26:56 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:55 GMT
+      - Thu, 28 May 2015 07:26:56 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:55 GMT
+  recorded_at: Thu, 28 May 2015 01:26:56 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:55 GMT
+      - Thu, 28 May 2015 01:26:57 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:55 GMT
+      - Thu, 28 May 2015 07:26:57 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:56 GMT
+  recorded_at: Thu, 28 May 2015 01:26:57 GMT
 - request:
     method: get
-    uri: http://localhost:3000/annotations/dd%2F29%2F3c%2Ffe%2Fdd293cfe-af84-487d-9c27-7773e8e4a833
+    uri: http://localhost:3000/annotations/78%2F57%2F43%2Fb7%2F785743b7-a17f-4592-bf5d-524bd1ed8722
     body:
       encoding: US-ASCII
       string: ''
@@ -2479,17 +2479,17 @@ http_interactions:
       Content-Type:
       - text/turtle; charset=utf-8
       Etag:
-      - W/"b95197ff2f20e9c8dbc3d24438a757fd"
+      - W/"37b1d6b742cb632665126b227b8e5e94"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - bd904fa5-7e14-4546-9c52-063177a8ac5c
+      - 9b7a77df-f76c-4db5-ba51-938bda35013c
       X-Runtime:
-      - '0.152849'
+      - '0.136659'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:56 GMT
+      - Thu, 28 May 2015 01:26:57 GMT
       Content-Length:
       - '663'
       Connection:
@@ -2504,7 +2504,7 @@ http_interactions:
         @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
         @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-        <http://your.triannon-server.com/annotations/dd/29/3c/fe/dd293cfe-af84-487d-9c27-7773e8e4a833> a oa:Annotation;
+        <http://your.triannon-server.com/annotations/78/57/43/b7/785743b7-a17f-4592-bf5d-524bd1ed8722> a oa:Annotation;
            oa:hasBody [
              a dcmitype:Text,
                cnt:ContentAsText;
@@ -2515,10 +2515,10 @@ http_interactions:
            oa:hasTarget <http://purl.stanford.edu/kq131cs7229>;
            oa:motivatedBy oa:commenting .
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:56 GMT
+  recorded_at: Thu, 28 May 2015 01:26:57 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/dd%2F29%2F3c%2Ffe%2Fdd293cfe-af84-487d-9c27-7773e8e4a833
+    uri: http://localhost:3000/annotations/78%2F57%2F43%2Fb7%2F785743b7-a17f-4592-bf5d-524bd1ed8722
     body:
       encoding: US-ASCII
       string: ''
@@ -2545,22 +2545,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 6a18bbcd-beec-46b7-883b-aa4c3c8dcd01
+      - 42e36f03-bc39-4777-8822-e910cbf7d442
       X-Runtime:
-      - '0.208494'
+      - '0.190511'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:56 GMT
+      - Thu, 28 May 2015 01:26:57 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=UXRsTFlnQW41V29wTW1rRXNldHBxd0g4aEVCZkdhbFdrdUoyUGRzSnRPcjY2NG5PNjIvUTZmdHRlSXlJVndkRTQ1ZGV4aDdCc2t2UGp4Z0J2MGZ0dHJqOFYwQXk4STRxanZ3bUtZRFk2WmVhaU5HTG1UY0NsVjdMaGZkRVhuWFMxc0tXOHNiaE1iSVRPT2JVT1dXb2VqdnlsMmFRaHcyaC9TM21xdHBHbFhBVzlucWdNVHRaZUV6OUc4cDNYQ3dpLS15Qy9oeVBXbUpNdnZMWlFIUmZyaHF3PT0%3D--9ba1bfc8bfa92008184d456b60c1f5cd237d39c5;
+      - _internal_session=cm9xNkpld1hkSjN3TU9Eamo4RDFleEtRbmNiblBzQmFlSnNaU2M3YVR5clBLd1ZPUmZGQUYxaERsUWlqNDlZeWlqWVk0aE9ReDE3RmEzem9OQU5zcFUwVHdHcVI4ZnNLeXczODRyQmZpaUdaeGwvVysrZ3VCdFA2ZnRjRGZVdWtWUktIS2pFMzlEZTBIQ09aWkwxNDR0VHRWZEd5S1dWamptOFlBK3dUVHVibzgxU3Z0R1k1RDdDMUJLVFhaSkZuLS0yMnZLMUw3QzQvTWIvdWQ5K2x6VmJRPT0%3D--5f9e87347fd68a2553adae3e4c945bd6cfea8e8a;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:56 GMT
+  recorded_at: Thu, 28 May 2015 01:26:57 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/requests_an_open_annotation_by_ID_with_content_type_application/ld_json_.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/requests_an_open_annotation_by_ID_with_content_type_application/ld_json_.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"95d0b31d0fcacf72474f0c0d8efefe8b"
+      - W/"9972b9530be6e4a5083a70f21f7680e1"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - dede4d8e-07a2-44a7-a06c-bd6fa4e2059c
+      - f9c633f1-efba-454a-be97-03f7e39c56f5
       X-Runtime:
-      - '1.797100'
+      - '2.043037'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:21 GMT
+      - Thu, 28 May 2015 01:26:05 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=RWFFYnlDVUxOaWF3UmtFK3g4ODZxTGc4cGFsbmxvakZaUk9VN3ZjMVpUMm05eExpcklzMXBNMXBmYVczcWs0YWFBTHBsS3hPSlFQWkhjWENsRWZUMjIvU1lpQ055SUppMkdjQ0J4YWlOSVRaMk5vdkRPOVlzUFRqZytXRzBjb0xrRHNkTmh3ZW0vWXlvSkZvd0tjbzNGamg2dTRtL0libEpyS1NQZzliZ01JditHWWg5WEIyWitIQWVmVkFuTFlPZ2J6am85Uk9IODQvNnBlL1FiNk5qN29mMHVGdWNaTkp2L0hoOGtjTnZ0Y1laWVJKQWUrYjN0TmwrMVJMMEtIay0tSEl6ZFVFY0tVK1FLRFhxdlRqM2xydz09--82241483e0f612cf5afa9665246222c33b5e2fd3;
+      - _internal_session=VTZtSHNEZ0I3NW5mU1VZTklVN0l3cWZKYWZ1QkdxSGlNUFBMVHNWRUpYSGRKc0lwT0c1NSs3VU52K21IcG1EQVVIbmhVMXJTZ3JXcUEwbmg3TTBDSDNYdzBFdDFsRG51Wi82MDZXYTd1QmR4dGZRam9qdFcxakVFU2FxMFR6VWdoLzd2bStjUjR1N2F5eXk0dnJTbEZUd2dPVStMd3dkTWNWeUZ5TVg4d0JrN2haQXhQTWNNL0RLQ1BUMjNjRGo5eUp0ZWFnRnJmeGpCVWhWN0FYcFlUdWMzMXJzZ0p3aUlnSjkreFRMNmFFSTM2UnFuS1Z0aTh1NDF1N0xGT1pnaS0tR0RiQm5OY05zUmNISjhmK3UrVkNSZz09--a3eb51299eaef7f11fe51bb1aefc14f83d68b04e;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310877852400","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/16/bb/9f/67/16bb9f67-9cc5-4658-b416-28e44ac45d03","@type":"oa:Annotation","hasBody":"_:g70310877852400","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942025952580","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/61/ee/d6/fe/61eed6fe-8005-4854-8fbc-3a1cb1188744","@type":"oa:Annotation","hasBody":"_:g69942025952580","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:21 GMT
+  recorded_at: Thu, 28 May 2015 01:26:05 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:21 GMT
+      - Thu, 28 May 2015 01:26:05 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:21 GMT
+      - Thu, 28 May 2015 07:26:05 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:21 GMT
+  recorded_at: Thu, 28 May 2015 01:26:05 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:21 GMT
+      - Thu, 28 May 2015 01:26:05 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:21 GMT
+      - Thu, 28 May 2015 07:26:05 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:21 GMT
+  recorded_at: Thu, 28 May 2015 01:26:06 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:21 GMT
+      - Thu, 28 May 2015 01:26:06 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:21 GMT
+      - Thu, 28 May 2015 07:26:06 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:21 GMT
+  recorded_at: Thu, 28 May 2015 01:26:06 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:22 GMT
+      - Thu, 28 May 2015 01:26:06 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:22 GMT
+      - Thu, 28 May 2015 07:26:06 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:22 GMT
+  recorded_at: Thu, 28 May 2015 01:26:07 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/16%2Fbb%2F9f%2F67%2F16bb9f67-9cc5-4658-b416-28e44ac45d03
+    uri: http://localhost:3000/annotations/61%2Fee%2Fd6%2Ffe%2F61eed6fe-8005-4854-8fbc-3a1cb1188744
     body:
       encoding: US-ASCII
       string: ''
@@ -2481,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 73693259-258a-41e2-903a-918da99bf9b1
+      - c570f705-c786-4ccf-bca6-464befd5098e
       X-Runtime:
-      - '0.257090'
+      - '0.180181'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:22 GMT
+      - Thu, 28 May 2015 01:26:07 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=eGtUcnd6dXVhZVZ6Y1hLVUxMWnZzUE9FVm04bWN5a296SkllcGxqK1ZrNHJ6MENNemtzOTNBN25jTUwvS0xmZGpTS2Mxd1dUVHVRQS9LOHVLOWN4Q29UMEMrNkZCS0ZPNjZwelZQK0grOWxVb1BZQkRJMkNwOXhDS2VZc0VNaENlaVZMRU4xQkJjR2pnNjk5TDFtMHhDbUh5dGRPazYrY1FXRzVFdWcyQ3BKZHlFeDEwNFpBV0tqSnNkdTZHNEs1LS1IR1BvSVEyc0VMVW16dXZIVUdDbkhnPT0%3D--a63365a5a4f4e46de8e420b2aa1c4243edf3814d;
+      - _internal_session=Sm0wbU9OcTk5bmcwengzMUxwc0pqTmt4UGx0b245SE0razBkdUg0VWY1ZlozWGtkdHdGN2tjTVJOL3orUXQ5eVF1L2hzR1A5OC9lRFQvZ2JPWWtTYkw4Zm9Ydk1uNE5xUXBVMXZzVGtOWmVmTi9MTGtRS1pjdEhmZlN4Q0xJV3BKL1RTYjVveHM3YUVEU1RObForYkF2Ti9PQzhRWDM5SW1GTXJKZTlpSnRMNGcrU3hGOG1uOGNLbk1aLzI1L3c0LS1QVUwrKy9rUnFtOGFhMGdCR01PVFNRPT0%3D--b1d4a020c4addfc213311437f477a9c4ad8656a1;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:22 GMT
+  recorded_at: Thu, 28 May 2015 01:26:07 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/requests_an_open_annotation_by_ID_with_content_type_application/n-quads_.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/requests_an_open_annotation_by_ID_with_content_type_application/n-quads_.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"dbcb5579d994b7bc7c291ed10e3ddba6"
+      - W/"68ae52cd2be962bf4ff5ab0161cc2746"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 48977092-fad6-46d9-90e3-cf90d59166ce
+      - c07afeda-9d61-4bca-844e-db756a141be6
       X-Runtime:
-      - '1.774456'
+      - '2.195341'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:07:51 GMT
+      - Thu, 28 May 2015 01:28:02 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=V2lQNWhBemV6Tzd6V1ZvS2xGeWcyR0cyM3ZvV3gwU1dvamw0bnNoR1RWM2E1VERGK1kyVzhEMU10d0l4NVFWOEtPMDUxQm5NSjNLUWpId2g5QVdlVzBYRmplN3RIQi81NUdPRi9CUWNJR1lzemtKS1RtemhuTzNnRTJ5ZUViMm1zYTlhQUxPVENSaVNIZkxtMEhxbk5nWjFwbDJ0OVhrR1VweFVYWURaVTVSN1A5YjF1RjhPUDBaUCsvdXVaNytJbXVMeFBBU3VVTHBsVFl4Zm9Rd210Qkg3MFBQZ1plWjdzRFd5TnpWS2RMbTEyWGxJQ2NkTURsTFFqc1N4MWtsaC0tZThnbERVU3pvQUdjQzVjNkZYKy9OQT09--1b43ec875f14d6c68d122fab8c9171430edf6e1f;
+      - _internal_session=emNrbEVlekFpK3U2NUJ2YmZCQk0xWW1UK25UdThLMkg2anVLVUNhZisyZ3pNdm1SZWNxNXNWeC9mOTAvVmpta21CTElxL0dnQUF0TXVFaHptc0NyQ3REcUJpRWo1aWMzWUo1eTducW9aeHRsR1U5SU91S0FDWTJ3aERqQXBtRUozOGVJNk8xSGxqUWxSbmdzMTZwc0xZUko0SGdFUlRFVFg1UnM1Q1lnK3JTc2dyT05kK2tkbEdTTVFXbG0wcXRxTGVKNjBrdWJpbDdEMUZBaWljVjZUbkk1M2lSdXBiaTFaYy93N0pidG1ndklnZ2VHVDVsdUhHYlBYYWRaTGNOLy0tRlF1NWJOVUhadXVsZkNZd3lMcVkvQT09--31441e9ddce4e3ed7edf3f8b108b76ab7d960fd3;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310881454620","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/41/0b/ec/a3/410beca3-0659-4775-a527-a960c7501af1","@type":"oa:Annotation","hasBody":"_:g70310881454620","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942002037120","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/99/f4/88/2c/99f4882c-f22d-46c3-8f08-e49518dca4de","@type":"oa:Annotation","hasBody":"_:g69942002037120","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:51 GMT
+  recorded_at: Thu, 28 May 2015 01:28:02 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:51 GMT
+      - Thu, 28 May 2015 01:28:02 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:51 GMT
+      - Thu, 28 May 2015 07:28:02 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:51 GMT
+  recorded_at: Thu, 28 May 2015 01:28:02 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:52 GMT
+      - Thu, 28 May 2015 01:28:02 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:52 GMT
+      - Thu, 28 May 2015 07:28:02 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:52 GMT
+  recorded_at: Thu, 28 May 2015 01:28:03 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:52 GMT
+      - Thu, 28 May 2015 01:28:03 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:52 GMT
+      - Thu, 28 May 2015 07:28:03 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:52 GMT
+  recorded_at: Thu, 28 May 2015 01:28:03 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:52 GMT
+      - Thu, 28 May 2015 01:28:03 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:52 GMT
+      - Thu, 28 May 2015 07:28:03 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:53 GMT
+  recorded_at: Thu, 28 May 2015 01:28:04 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/41%2F0b%2Fec%2Fa3%2F410beca3-0659-4775-a527-a960c7501af1
+    uri: http://localhost:3000/annotations/99%2Ff4%2F88%2F2c%2F99f4882c-f22d-46c3-8f08-e49518dca4de
     body:
       encoding: US-ASCII
       string: ''
@@ -2481,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 67a7f9cb-d074-47fb-95c6-508bf8226f54
+      - b69ebb01-7f14-4e41-9321-7f5cbe6c6dba
       X-Runtime:
-      - '0.213549'
+      - '0.189818'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:07:53 GMT
+      - Thu, 28 May 2015 01:28:04 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=djZVeVdmYlVrdDJGditIajVTc0RwS3Y5bnVncjZQVEtrWkE5TU9EQW1nTGdTeDAwU3B4dWlvZEtjNW9zcEMvVjNOQ1N2VmlHY3kvOXpSZG0ydkRwUG5DMWpHZnovRjRTR1pFRi9yVktFZzZ3WVlZUHZadU96b2hUbUxDRUdtN0l6MEkvVTUzNW5vQzBnNVh0OFhnR1c1NGEvS1dXdGhoVlBaMFJNQk9tQUZjNU40YXIyUmY4OW1IVmhQaUNsZmsrLS1jWWV1TWtmcCtmWWZ1TUlQYUFBMjdnPT0%3D--564e8ba21301a1aa8e9259858f6bd180e2cc8cca;
+      - _internal_session=ejdRMjBSUzlEaEhpY2F2bDNKblJIY2xKeUs0RllnZndHZ3hPTVVicmxGU255anp5Z1FqMVlVMTl4bDBGMHZ0YW4zc0dTOGxUbUQ2OHNhZ0ZsUzlZUlY0YXVKeHROR0NYZ1hJQjh3N0RiYldRZjB6dmJiYlhnOU9STFpOZ1BxL0QyNEVFblByb0ZlK0VzellTUWxwTGhwL3p0bE5nT0tyYmthdWhxWk4rekVlTkJjRE16T1NEVGlVd1NCK0FFWDl5LS1mYVdzaUVFdE1wNEpHcWhUcHFVQkxRPT0%3D--5eaf78ad43f21e0a96eda1cfa0750c4455b7b34a;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:53 GMT
+  recorded_at: Thu, 28 May 2015 01:28:04 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/requests_an_open_annotation_by_ID_with_content_type_application/n-triples_.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/requests_an_open_annotation_by_ID_with_content_type_application/n-triples_.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"77dd16ccd6e9633472184df1f46e7d6f"
+      - W/"684998cd54eb48c9e479ad2d75bd8d56"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 4103014b-8e0c-4de7-9417-3947f98f58c1
+      - 618cecc6-f61a-4458-94a5-b07ea7a3794a
       X-Runtime:
-      - '1.669721'
+      - '2.286062'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:07:19 GMT
+      - Thu, 28 May 2015 01:27:26 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=dzhrQ3VYanJGY0dtUDdaVUUzNjlLYlMwMnBMRDh4cGNndHU4SnJVeSt5MTBjbWIxWHE1YVU1S3ByL283WG8zR2lDUmFXcWQ5RWJqMTg3L1lvZE1TaUhMLyttaWlOdlhkQkFnemhRS0U1Nm9EZjdMVUNkTGJBbDFFdi94MTN4alNla1Z5NHUwam1hTE5WNHNOdjl5L1hrMTBsQW1KWWRYdDBIR1ZVaWRJSVo0Sks3T2V1Y1VBUmlXNU5yemhEcERwQ2V2NkxyNk9rcWRsRU1PZ2ljalVMaEhRMnJPUGxpQXhxaVRBODVFVWFzZENEcjNjZVAzaGp4QUVBVlZVcnl2Ui0tODNHbUxIZ3NpR1BLd0UyU2xzaUQrQT09--6a32afffc88805fa5958d24dab8a73b3a2a8ef3b;
+      - _internal_session=cDhYYUs3NTZib1JROEZhZWNRUHBPZTY5ZXB3U204a2xzejVYandmOURqSW1SZllxNDBrQTBrSW1CblppTWhtTFQ5empTWXdrbHdPZUpEVGN1RUp5TzMwenhsWGk0U2FlQ1NDYWQydWZwQnkydmxhbXN0d2dya052K3d1V09KVWNsejVSQmF1dVRldjNpRjJZblJjRFVQNjc3Nndzc1Z1OE12RlJLQjhidUhkWTFmU0JVOTFsL0wwMitBNGF2Smtwa09EYkFzZVRmL0RYWmFyMXlZMC9iRmtMK1pnYnpnYW0zakNOaEVLTGN4QjlwRVRmcEUwMUVTRGRrc25ud1ZOZC0tL0o2b3NHQXpuQ0FPdHBNRGhuNWR5UT09--f3e87dbc32242fb06a2d3044a12cd31ffbe3c032;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310877590160","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/bc/64/a2/9e/bc64a29e-593b-4230-8a16-5408bba8977d","@type":"oa:Annotation","hasBody":"_:g70310877590160","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942008505460","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/bc/e6/dd/ba/bce6ddba-8ff6-4973-ab58-030e67cf202b","@type":"oa:Annotation","hasBody":"_:g69942008505460","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:19 GMT
+  recorded_at: Thu, 28 May 2015 01:27:26 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:19 GMT
+      - Thu, 28 May 2015 01:27:26 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:19 GMT
+      - Thu, 28 May 2015 07:27:26 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:19 GMT
+  recorded_at: Thu, 28 May 2015 01:27:26 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:19 GMT
+      - Thu, 28 May 2015 01:27:26 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:19 GMT
+      - Thu, 28 May 2015 07:27:26 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:19 GMT
+  recorded_at: Thu, 28 May 2015 01:27:27 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:19 GMT
+      - Thu, 28 May 2015 01:27:27 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:19 GMT
+      - Thu, 28 May 2015 07:27:27 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:19 GMT
+  recorded_at: Thu, 28 May 2015 01:27:27 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:20 GMT
+      - Thu, 28 May 2015 01:27:27 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:20 GMT
+      - Thu, 28 May 2015 07:27:27 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:20 GMT
+  recorded_at: Thu, 28 May 2015 01:27:28 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/bc%2F64%2Fa2%2F9e%2Fbc64a29e-593b-4230-8a16-5408bba8977d
+    uri: http://localhost:3000/annotations/bc%2Fe6%2Fdd%2Fba%2Fbce6ddba-8ff6-4973-ab58-030e67cf202b
     body:
       encoding: US-ASCII
       string: ''
@@ -2481,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - bb6b324b-9bfe-4b4a-b97d-0e46accf33a9
+      - e2086aa2-ec70-45d0-aad7-a565776fb0bd
       X-Runtime:
-      - '0.213713'
+      - '0.187066'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:07:20 GMT
+      - Thu, 28 May 2015 01:27:28 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=SVdDdWhBUklNOFVqSzJXd016UkFSSnpDdjFMNWhoMVllVWF3N2Nnd01sb2Z4dkRhMTVscld0VTJJVUtHOVVnbFBaTkRHREJNbGZOQkkzdlROWmh0b2V2cHZ3YWpoL2hIT2VuM2lnSnZBa0c3dldVbnRMWDlqQmRmNHMweXhoMmtPOXhTM1dXN3UwZFk2TmlGRWRUbk5lUXNDdnVNbGZKTER1M0c0SkhuMkpkQU5GK0Q4VWs1T21SWnExSllmQ0pTLS1nOEoyQnFBa1duSER5TFZrRHRxVHZ3PT0%3D--097b31f16893cbf83fc18e81da23d2bd90857d19;
+      - _internal_session=MDJxWk5Yb04xejZ2M05aM3h4dzRqMTFrd1ZQZmFRVjJPYW5VSTUreVVqeG5Xb1RHNkpkcFo1TTBIbHpxSlhLMXUzWVVYakFjeHhGT0JVTlVLRmc4WjJMSDFsRloyYkRoYW1YeEU1YTJZZUdVUXU4TlM3MmRpTEFYdUNiN2NkcUxCR3hNcStKbjJ3dU1QL1NYcjFFWStZdXV3cE02dlMyKzB1a254Ylo2bDdZQkVhS1crT2Zob0phTXk4Vmg5WVR2LS03d0ZkNk5EdmUyOW9zd0V5d2NQdzBBPT0%3D--7910e2ef961eb3e076dc6a068552b42139018cac;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:20 GMT
+  recorded_at: Thu, 28 May 2015 01:27:28 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/requests_an_open_annotation_by_ID_with_content_type_application/rdf_json_.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/requests_an_open_annotation_by_ID_with_content_type_application/rdf_json_.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"09de809246d860b68f4f85450d20c4d5"
+      - W/"6d5f63b53623d4748b59da9c5d476692"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 942b2861-fc55-4b93-bc87-a4eb831aae36
+      - ad836364-5930-4e02-94e7-b2180e4a8d4f
       X-Runtime:
-      - '1.729220'
+      - '2.412358'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:36 GMT
+      - Thu, 28 May 2015 01:26:33 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=Qk5PNDVIUHFNZVUxM3AyR0xwVGN0WWVneGVEZnFGOTFhcHRxZzJZWGp0aUphUGlYWDJGamo1TUg1d21sME1ZOGZRVnJYQUVFSDBZZjVUZW1UODl5UmRQNU5QY3BTVmpZejJKMERHOXcvYVZuUitIYk1vd01LMHRNMTBzSUljT21YNEVLN2lVZGllN2s0YmdObWtFYlZ3dDJxa2NXYUFLVzdLa1dPVFRtK1YrSGd3K2Y3Ujhsc09WQk1xKzJlZE5jcy82STcyR3IwVFZMRUc3amMrUUtQTHd5c0pkNDMrWTBRN0dGcVlpYnFoS21wTzFVRHhva2c2NFBnSExwMnVhRy0tQmNiRzQwOFh3WVdmY004K050c0RUZz09--4bb75ad141e3157686e794e922f4ff45e3a71008;
+      - _internal_session=WFozSHl6YkhQZE1IYTgxQm1DSWtJUVZCNDZBYmgzS1pUL3cyU0lRLzZmcFJlemZWOC9EZzRHU294Q3NGQmpDV2ZxdWlMby9BWHc0b29VWWo4bDM1Q3F6aHBIVUJ5VXRNeUVxRkZqVk1YcWhxMjh0dlNMS2RLcmh6aTI5ZlN1YzFSNmdFbHNiOEdjL08yT0hLWGYzVG1BYkppRzIzaHh4RHQ1Ny9QUXVxTFRWNkhWYjRxdWtHNUJxQ04yNnp1amZuWEZKeXVNZjJpck5YUjYwVUphVFVGNlFiY0VDMHRLRC9ES1RWVWtiZXdjeGVRSGpxQzZkWDRPVDl0a1VaVG1EVy0tWVNnME5zTFRSUzZNVDZibDhIZXhuQT09--8dcc320da0bf528777469f38596a0f09f4102cb0;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310853277520","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/64/3b/e4/c7/643be4c7-68d4-48ec-8154-c7f2caadf08d","@type":"oa:Annotation","hasBody":"_:g70310853277520","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942036164020","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/c3/c7/45/ff/c3c745ff-3070-46a4-9506-58d3c167c65d","@type":"oa:Annotation","hasBody":"_:g69942036164020","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:36 GMT
+  recorded_at: Thu, 28 May 2015 01:26:33 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:36 GMT
+      - Thu, 28 May 2015 01:26:34 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:36 GMT
+      - Thu, 28 May 2015 07:26:34 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:36 GMT
+  recorded_at: Thu, 28 May 2015 01:26:34 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:37 GMT
+      - Thu, 28 May 2015 01:26:34 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:37 GMT
+      - Thu, 28 May 2015 07:26:34 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:37 GMT
+  recorded_at: Thu, 28 May 2015 01:26:34 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:37 GMT
+      - Thu, 28 May 2015 01:26:34 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:37 GMT
+      - Thu, 28 May 2015 07:26:34 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:37 GMT
+  recorded_at: Thu, 28 May 2015 01:26:35 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:37 GMT
+      - Thu, 28 May 2015 01:26:35 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:37 GMT
+      - Thu, 28 May 2015 07:26:35 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:38 GMT
+  recorded_at: Thu, 28 May 2015 01:26:35 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/64%2F3b%2Fe4%2Fc7%2F643be4c7-68d4-48ec-8154-c7f2caadf08d
+    uri: http://localhost:3000/annotations/c3%2Fc7%2F45%2Fff%2Fc3c745ff-3070-46a4-9506-58d3c167c65d
     body:
       encoding: US-ASCII
       string: ''
@@ -2481,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - faf201eb-28e0-4b33-8ce9-581c71ed0f8f
+      - 14c145df-8e2b-4f60-8d33-9295e5975053
       X-Runtime:
-      - '0.290640'
+      - '0.241178'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:38 GMT
+      - Thu, 28 May 2015 01:26:35 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=dnAwOVlTamcwdy9WckcxNzBYclVGUmkxNGp3MFY1RFdkRnlIOWtPNjZQcmNoUHBkTXhPQ08zb2J5L1RyQmcrcG5LT2pkdVM3UW9jQ0Z1U3FDd2NaTUdVdTdxSUF1OFk3d1Y3QU1Fbk1kQTltcytKeDBXN3ZrUUp2UGZQaHhzcnJ0bkhZRkxVcnhsWHdBWVdna3dBcnc3OU5qVWZoaE9rM1UvKzREdm45ZU1aY2hkR1NKcVJRbUdEaVlNL0JJdHNCLS1OR1FjMHFpOU9RbFRQVU4xdVRNZzZ3PT0%3D--a302445bc48f16fa06e80578f8111dd13a6b591d;
+      - _internal_session=QjlrbTBKN0VwQldqcU1OUS9yUndtM3ZzQmpNT2x6bzZvVmpBNW5kYm1DOXo0dDFhamttdTFCeWR5UVBCQ0JaNzl0anlpS01nbVpsaEx3R3ZPdlgxcnlRNVQ2NkU2Q2dXS2txU0tWTHNvQzlsL3NJQno3eEVyMU42TzhGQyt0OVNySXJ1SFR3Rkh0TmlNd3ZMQ3k1RUxaTTJIQnJRWjFUQUIvalRUTjNCaW1DQmhpeWR6cmljU3d3UE5WdnIxN3ZZLS1hRlBKcnFyY3UrdjJlMnRmaitOTlBRPT0%3D--924c5b8ed017453ace327540b668148b0c16aa2b;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:38 GMT
+  recorded_at: Thu, 28 May 2015 01:26:35 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/requests_an_open_annotation_by_ID_with_content_type_application/rdf_n3_.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/requests_an_open_annotation_by_ID_with_content_type_application/rdf_n3_.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"4fa4a579fc6bc2e2b4c60d6d43f3b25e"
+      - W/"10d45180b6c1e604f84e8113318f1447"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - f18c9caf-98b4-44ab-b5d5-6a0c5ae8ca06
+      - 25670400-d948-4f46-a860-8c4af705b2ea
       X-Runtime:
-      - '1.637537'
+      - '2.200930'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:07:31 GMT
+      - Thu, 28 May 2015 01:27:35 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=YkJseDduL1pDcFpzRndZQ1MzWEk2ODRxaEJGZ1dPNWlidFRtakxTbC9kL0RGbHJKdEFBcGpKSFZubTdQYkJYZVJScVp0OFdMVmxyNFZTajNJaXl1NTlQcWwxc0dNdkhobVRPc05ONzFXUFFtT1lla0MrRWg2SjRPZldhSGJCRVJOUjFaQXFVR0NBOURSK2JnNjJpR0RsZFVwNXpGSUQ1TzVmS3RUczgrODhrN3poSXlTbHR4UDV1bUV6emxiL3M4alBwY2lZekR6QTFyblVoTjhZZ2NWTFZETTM4OU1hblcySFRUc3Avckc2MXlrZ0dTQ3dWeVJNODlpak9ZYktISi0tdW1IZnVYdnRVcTNrMmhLZWdvWHU1UT09--1f637183a9a1de30d8d8ce7618931817129537d9;
+      - _internal_session=OGduYXpBTTgraGR4Q2xyV2ltMGM0U3BhbUpiTHZNd3BJaS9CaGhtcFkyY0FVbWJvRUV4QnlYR0JzOHBtQ1plMW1JcUpkYWhWODM0RDFocVJ5OVU3dDJVVUxJU0h1eXVtSDVzYWdGT3F5UUQ0VENDV0hYNHp5YUhFY080R0Q1ZVVqR1FUWGFxRk1Vck0wY096T1FFMFVKL1YwUkY3TlMyU2xFMEVHdUxmdTh1VEdlT1UrSkNacmlMVy9IV2wrZlFJZ3R3ZC9PRDNhdEtlRTJRdUxtbVlmNzZTMzR2cUhBekNWWDFJWnZrblh5YmJhdjQ3QmlQbVpUekN1NlZBdXRWcS0tbi9jR2p5M0ZTb1owREpUazVSaXlkUT09--76eb98849c66715661fc514ab77919304fb3973c;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310878915400","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/5a/e7/89/56/5ae78956-6a8e-4c19-8f9c-c3a697386a56","@type":"oa:Annotation","hasBody":"_:g70310878915400","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942033844240","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/51/9e/b1/4b/519eb14b-8a9f-4b4e-b2e8-0515951494b5","@type":"oa:Annotation","hasBody":"_:g69942033844240","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:31 GMT
+  recorded_at: Thu, 28 May 2015 01:27:35 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:31 GMT
+      - Thu, 28 May 2015 01:27:35 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:31 GMT
+      - Thu, 28 May 2015 07:27:35 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:31 GMT
+  recorded_at: Thu, 28 May 2015 01:27:35 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:31 GMT
+      - Thu, 28 May 2015 01:27:35 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:31 GMT
+      - Thu, 28 May 2015 07:27:35 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:31 GMT
+  recorded_at: Thu, 28 May 2015 01:27:36 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:31 GMT
+      - Thu, 28 May 2015 01:27:36 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:31 GMT
+      - Thu, 28 May 2015 07:27:36 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:31 GMT
+  recorded_at: Thu, 28 May 2015 01:27:36 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:32 GMT
+      - Thu, 28 May 2015 01:27:36 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:32 GMT
+      - Thu, 28 May 2015 07:27:36 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:32 GMT
+  recorded_at: Thu, 28 May 2015 01:27:37 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/5a%2Fe7%2F89%2F56%2F5ae78956-6a8e-4c19-8f9c-c3a697386a56
+    uri: http://localhost:3000/annotations/51%2F9e%2Fb1%2F4b%2F519eb14b-8a9f-4b4e-b2e8-0515951494b5
     body:
       encoding: US-ASCII
       string: ''
@@ -2481,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 7fe68a16-af3d-4bd9-a75d-d0dd61747bbd
+      - 3ed6bcd3-793c-4191-9590-e6bff3867ebf
       X-Runtime:
-      - '0.216059'
+      - '0.217179'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:07:32 GMT
+      - Thu, 28 May 2015 01:27:37 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=QXVISUM1SkpZUUtGVHE2QnBhUE1hdnAxbFBJNTgwM2pqRGZEM2wyVXpiUDhhbVl5bW90cEwxZTNtb1ZQdnNFNXZzRHRkZ3BaRzNTTmxPdVpGaDNDZk95S1JzRy95T3gyOWFFSXpvczRTZjNIL25zaytPTjcyUDR1dVh6YU1sT0VkUGczT2RKajBTRkRuSm1KLzNSRDdpbUFwUHJsZmp6SVpDY21BQzNwanlkdUhqMnd1UnRGSkN3UWRyWW1NQmViLS0vam5ka0pYWlZiMkQvRER4WXo3bFBnPT0%3D--c81891ce72701aa3e8279af482e290ca56be7456;
+      - _internal_session=K0NuRWUzbWhwUVEvMG05cnRBWi9zSG90THpNK3ByRkRQM01pUlovMXAwclRUR01ERDluZHBmRnIzQ21lcWVVVWFTc2VhUDFmNW4vNU9DUEFUbU80cEt4SlZSZk9PeThSOGVrQzJQTFc2bzBLR1BnMnpYRUQ2ckRzWFdSWk1GK2R0Q01RQjFBbUNVMXVOdkE5UkVLVDE1Tm0zUWVHd3JQeHU4R3NBU0JWa0x2VEV1VExKNEV6YytCY1dLMFdWU0c3LS1scmFqVDFtb0IxWFN4YVVNajZ0WjN3PT0%3D--30b83a6816542f76886b50b0d29bb34c9528c958;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:32 GMT
+  recorded_at: Thu, 28 May 2015 01:27:37 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/requests_an_open_annotation_by_ID_with_content_type_application/rdf_xml_.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/requests_an_open_annotation_by_ID_with_content_type_application/rdf_xml_.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"ed26ec4295aaed3dc9e9bbf0cea69141"
+      - W/"13813ddfe76fc6881f6a0b281fa4fc2c"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 3b417bd2-6fc7-42a5-b9c0-429b2be4d6dd
+      - 52d55600-fc5b-46f9-91fd-679218f46425
       X-Runtime:
-      - '1.802578'
+      - '2.251990'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:44 GMT
+      - Thu, 28 May 2015 01:26:42 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=OFpjU2VhZGZTeHFxcTQyaXZWcGhENjBIVDhMVVZvT3ZuMnNhWjRTeWlDYmR0bGRNY3l5VGJJdUZUaU1seFByWWVsRGRtNjlkbWQ5Zy9QeGw1ZlU2U2hUY2NXRHdPOU95ZmFkVkxndW1sVTR1dlhxMFVGczI2Q2dTK1JJOUphSzRScVBUNTFWekZUVmNNUk5qUjQzdThXbU9oSmJncXZiQmFPMlpNZFhMRThIVHh4eFFXZkRYUC9qbXpvZ0Vvc0xBejlxZWUrSWFadDgrYW1ueXpnRVdYVnNtb0lHU1lmWG1BOTY5UUdIZk9VdzdFeE11am9XTWNkbnhjOFRTREovZy0tQnRSbTRkZFZVSk1IckNIWFF1TDJOdz09--1fdea5ff94327cd13cbb439c09caa1b447baa434;
+      - _internal_session=QmJOeWZ2ckdYSTZSLzFmbVhEeW90akEyTHRSdzl4NnB6RUE5aEhRemJJQjZDZHN1YmhzUUxHRlk3TU5YcUdKRWhkZUhYQjN4TEpodlI3NHRqQmFlZjVDeldIbHpPL3JuVnFIUWhBVG1pc216RlNQWWFBdEVUR0MydHYwazhhcWJkWG1kdnc0dU9JRzdLYmwvcGF6UkVEbWxDVFFpUUo2QkRoOWpTZHlBaGRKZkNqZ1dFcVJLN3RzYnFIR2pGSnNHT0lFTVY4dDJHWkF0Y001SUNjSFovNXdCTE9UK0JWVnplQXd4Mmx5MTUweHpGNXc2VXZSUktxZ2NXYWxXd2F0QS0tU3JxbytaZGY3ak9hNkluUTB5UUV4dz09--8fd750c54e98b72d92f8358df463ac89d9df0f3a;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310873662120","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/05/98/90/ab/059890ab-34c2-4161-9731-18668ce04bfe","@type":"oa:Annotation","hasBody":"_:g70310873662120","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942007118440","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/9e/07/e9/66/9e07e966-a7f6-4190-b90d-72b5d73c2150","@type":"oa:Annotation","hasBody":"_:g69942007118440","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:44 GMT
+  recorded_at: Thu, 28 May 2015 01:26:42 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:44 GMT
+      - Thu, 28 May 2015 01:26:42 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:44 GMT
+      - Thu, 28 May 2015 07:26:42 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:44 GMT
+  recorded_at: Thu, 28 May 2015 01:26:43 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:44 GMT
+      - Thu, 28 May 2015 01:26:43 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:44 GMT
+      - Thu, 28 May 2015 07:26:43 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:44 GMT
+  recorded_at: Thu, 28 May 2015 01:26:43 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:44 GMT
+      - Thu, 28 May 2015 01:26:43 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:44 GMT
+      - Thu, 28 May 2015 07:26:43 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:44 GMT
+  recorded_at: Thu, 28 May 2015 01:26:44 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:45 GMT
+      - Thu, 28 May 2015 01:26:44 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:45 GMT
+      - Thu, 28 May 2015 07:26:44 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:45 GMT
+  recorded_at: Thu, 28 May 2015 01:26:44 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/05%2F98%2F90%2Fab%2F059890ab-34c2-4161-9731-18668ce04bfe
+    uri: http://localhost:3000/annotations/9e%2F07%2Fe9%2F66%2F9e07e966-a7f6-4190-b90d-72b5d73c2150
     body:
       encoding: US-ASCII
       string: ''
@@ -2481,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 24c75953-012c-41c7-ba0c-35fdb0f52d3e
+      - 47c161ef-e052-432f-a351-706bc5cb0c02
       X-Runtime:
-      - '0.271825'
+      - '0.229859'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:45 GMT
+      - Thu, 28 May 2015 01:26:44 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=bzFueTFUaS9vVGl0VEZNZ1dYaWZTWVJyak5uaHMyR1REaytkSmFjUmZuWjNXYTd0ckI2RkJoRy9YWmRjM1gwNVMwUkJJTGF6K21IRHYwSFFZTDhuV1NKQzhGbitUQ0dlVHpOWWN4ajlKNkNUTlYrUXZNbHdzSkRwTzJBdndVQzZwdVBDMjRXK0NpdUpWRTNkRGFlWlk4THJjNHh5ZVJkZlhOMFkrZWoyNDJpTTlRM0ExenlIdHRzanAvMDBZZ25sLS0vQXFqQzBPUEk5MmJzS05UK2UzL1dBPT0%3D--80d176d4d3a88795db6f88bb3521bdf601637691;
+      - _internal_session=dGR6cTVFYzlnd0ZVVGVFLzd5VE90ZTdtc1pmbW5NNDdKZDJSS0ZoTTJ4MURyVmkzcGpLUGx6QllncmJobm5WR0k3MHc3aFpMNVVBRWZSbDhITUhkbCtvQ3VEUFdiVENqMW9uMG1KY1NFM1JsbFhWak83R1F2b3U2MFM5UERvV3lIaUNITkVqamU2TVpJRllobHJvdFdRemF5WjdxOVBCekVuOVdCZHdBMGN4TzdrUklCVW4rbFZvZU54Z0ZMa09nLS1kYWRlZmZxVlY3Qkt5SCtwakRhalZBPT0%3D--935487f561ecd5e1027efa0646d9c7ee47032156;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:45 GMT
+  recorded_at: Thu, 28 May 2015 01:26:44 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/requests_an_open_annotation_by_ID_with_content_type_application/trig_.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/requests_an_open_annotation_by_ID_with_content_type_application/trig_.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"7dcdf8a069e7f0ae7c34d5d001e17159"
+      - W/"7bc303bf6fd69afaeeb7349aebcf4d34"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 1c4e10c2-f37b-4842-9aac-4a3edc3069f2
+      - 3d0e3e4b-8180-4631-8d36-82a36435ca11
       X-Runtime:
-      - '1.752756'
+      - '2.940949'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:08:05 GMT
+      - Thu, 28 May 2015 01:28:23 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=cFJBRVFlZEo1WUcyN2t0Si9zcW1iVlBQeEUyQ2FCanFmSGhzUTF4SUdZZm95R2cvb3M1SGZnWitwVmRSNDZUMHRZSFFYcEN2ZC82ZWxlY1FwMHU0NlBLZy9aR1ZsbmhjQUp1Q2xVcVQxU01CVW9NYjd5aFBUUFozM1lCb3REdlVtOXpxVHkraFJEWndHWi9rcVMrSFpKWDVDc2k1akNnaW1BSFNkMXdWL2NFaWF3MUM5bEJGaVU2NTZqemQrWUdLb0o0NWczZzNlaTFlL1VZSnNtWWJ5ckVLcXBDMjloejZ3OFJ4TkRZU25PUnVrWkd1aWVpNUVkaTllbmlTRldKUS0tV2RTYzBudXZicXZGQ2s0ZWJFUkZBUT09--ac4b32152f5f7029504d883b5c7e7fa3252d5c60;
+      - _internal_session=WnJmcDg3b1dEWVJ4cHhoUFJRYWJOb1dPaEIyU3lWY3U0bVpsb0gwWUh5QmppLzhIVnQrckx3TVUyblpPdjkwYzdZN3RkMk05ZDlVL2l1Z2lTNk5uL0FSN0JwTHFvTks0UjlMeGljUFBCeVZxRWtvMWo0WEtGMkNqa3FSSyt0dVVQWkFPN0ExTUMrQmd6SStwb3VBN2xOdy93V0RCUXNwTUo0OWJVME9wOFMzNkFWYlJ1dTIxdkNnMm5JdUx2dDZWOXpueWtBTHR3K01VblhmZk8vVkFocjNTR0srcDlGZUdUY0h5REFmUHUxNk16TEpPQWx6ejlpWjQyeS9Ra0NscS0tRU1CSDBXaStYVkpXSjh5cWltZzN1Zz09--5c4bb9ae2365ca834d2b739306fa0eeef5ef8f95;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310878872960","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/3e/a6/bb/65/3ea6bb65-50c7-44b6-93d3-e7e9e0075fb9","@type":"oa:Annotation","hasBody":"_:g70310878872960","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942034462060","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/22/a5/e6/a0/22a5e6a0-c9e3-4761-8561-172577a0555c","@type":"oa:Annotation","hasBody":"_:g69942034462060","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:05 GMT
+  recorded_at: Thu, 28 May 2015 01:28:23 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:05 GMT
+      - Thu, 28 May 2015 01:28:23 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:05 GMT
+      - Thu, 28 May 2015 07:28:23 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:05 GMT
+  recorded_at: Thu, 28 May 2015 01:28:23 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:05 GMT
+      - Thu, 28 May 2015 01:29:24 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:05 GMT
+      - Thu, 28 May 2015 07:29:24 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:06 GMT
+  recorded_at: Thu, 28 May 2015 01:29:24 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:06 GMT
+      - Thu, 28 May 2015 01:29:24 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:06 GMT
+      - Thu, 28 May 2015 07:29:24 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:06 GMT
+  recorded_at: Thu, 28 May 2015 01:29:24 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:06 GMT
+      - Thu, 28 May 2015 01:29:24 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:06 GMT
+      - Thu, 28 May 2015 07:29:24 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:07 GMT
+  recorded_at: Thu, 28 May 2015 01:29:25 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/3e%2Fa6%2Fbb%2F65%2F3ea6bb65-50c7-44b6-93d3-e7e9e0075fb9
+    uri: http://localhost:3000/annotations/22%2Fa5%2Fe6%2Fa0%2F22a5e6a0-c9e3-4761-8561-172577a0555c
     body:
       encoding: US-ASCII
       string: ''
@@ -2481,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 62ca9f95-9a2d-45e5-b2e8-d5ba67cf75d8
+      - 512da6bc-9f32-4c8e-bd14-2f3fe5a05551
       X-Runtime:
-      - '0.248837'
+      - '0.167828'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:08:07 GMT
+      - Thu, 28 May 2015 01:29:25 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=aEFsd2tRcjF6MmVxeHlMQUVJVFhEcTBGbmhZdzhyTHFIQnI1SnA2NEpTM05sSk1OaVgzdTJLbjd5d0w1MnBtYjNESVYvSEx6d2FGSTByVGZEcVJjNFd3dk5jQkhEamNvMlA0UlpkQVdvbEZkRXBVcW9pOS9xTC8relBWSVduWDJhN09adndZWWNXK01GNU9YZmp1Q3A0QlFOSFZZVlQrVU1oN3FmMkx2OStvNmFpWmFxMk9GTzB3TzlsOENZVnY4LS1qT3A0SEI0R1U4M0d3MWFPczhwRmdBPT0%3D--348e36b40739c492ebdb0d9d3b4561c99ba1951a;
+      - _internal_session=UVg1ZnBIUXFWMEhqWVlCSlZWUjJLQ3kyOU9wMjd4eHpORHV6c1dvSnZFYnVkWnJyMWpIb2FWaWwrMkFhU2NuY0NRT20rdUVjcitQc0lKZFRtaVdDakZxTnkxTTFyLy90V3pPeC9aSnl0NzlVbHlqcHByRnFiV1VEczhaQUIwUzVpU1BBckVVcGdzenFKZlNBaUxwUTlZTjFORUIzaWxzYWxoNVVXS1FxUW1BL2tYZHE1eFU2UGxDZlNnOUc2ODNuLS00QWI1N21CSjZ6bGlSRWNWcFJweVFRPT0%3D--d1db387a3571b007479e5e0eac509d0629b976bb;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:07 GMT
+  recorded_at: Thu, 28 May 2015 01:29:25 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/requests_an_open_annotation_by_ID_with_content_type_application/trix_.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/requests_an_open_annotation_by_ID_with_content_type_application/trix_.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"1b7c1f0122283905d9e9125a689b616c"
+      - W/"80444ccdc2c2ff9f0194477b01481f90"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 2112e0fd-3ca4-49a8-a8dc-76d6b14c5e28
+      - ed0cb172-a800-4130-8013-106ee268b1d1
       X-Runtime:
-      - '1.784130'
+      - '2.129931'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:08:20 GMT
+      - Thu, 28 May 2015 01:29:40 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=WFRGVlZaeHVYS3VBY2xJWVZhcmpxU0dFV1FjclU4ZWtXZEYvREhGdkNhQ0l5em8zNDFYajdSVlFyS3d4a05yVkhmencvZTlWN0owcE56enBwUldKb1I5UC9QNFJCckdMR3V0VWo5MW9TRXFxQ0NUeEZEa1Z5bnMyalJPcnIvSitFdXZCQVJvL1ZiT2VkT3JRSXZtVWxDMytsckh6ZWhKT1NaWmZtSkhlWXl2dHdJUkhybDVTckw4WXJPK0FrQjBlV1JWaTFxNXhyRUxkSldJUXJ0M3pTWGsxay9yUkdSVXlEYmUyb0lTQ2RhQXd3dDdveDRxSlFEK2dpTWpSc1g2ZS0tMm53OXFOK2RrdGtYVVBLNitjYmI5Zz09--3431164672e3bc64f80716f79545beeeac5b5d27;
+      - _internal_session=TXgxWkZrWTJ5VUN1WGJVSmdibXRHdE8zeDNVWDFCVnhsWWZvbjRBaDZtaUNObzN6ay9lQU4xRzI5VDZVVDh5VDZzbzJ0SGlNbWs5MHJIbHdId3IyV2N2MFdtS3NoREZ4YU5xV0Nab1lmbkpjK0loaVlJNWtIMTJVRE9jSjR1RjQ0UWxHU25nZ3QrUEtRZUJLWkw2b0hoVElpaVVZL3pzSGRVbDVjZTc2UlJneUpXWDN3UDM4T1JEZzFyU1pLbkwyZEJJWjZtekNWSmRjb1g0ejRMdnYrUTU2VG1UbVlNR2FVVWI4dE1oS1lydEhVMGRsVXdiSUtQNGpRWHlYOStuYS0tNUtWaXdCWGJaNXZYS3dZNjQyc2pCUT09--c3463fbfbd77e28b454f5ad0f94eccedbbe2b053;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310882611640","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/e1/e6/d8/a1/e1e6d8a1-c539-467f-937b-6f12df465a47","@type":"oa:Annotation","hasBody":"_:g70310882611640","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942027242940","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/aa/33/78/4d/aa33784d-f44c-4412-9176-cd7f0b51648d","@type":"oa:Annotation","hasBody":"_:g69942027242940","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:20 GMT
+  recorded_at: Thu, 28 May 2015 01:29:40 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:20 GMT
+      - Thu, 28 May 2015 01:29:40 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:20 GMT
+      - Thu, 28 May 2015 07:29:40 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:20 GMT
+  recorded_at: Thu, 28 May 2015 01:29:40 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:20 GMT
+      - Thu, 28 May 2015 01:29:41 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:20 GMT
+      - Thu, 28 May 2015 07:29:41 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:20 GMT
+  recorded_at: Thu, 28 May 2015 01:29:41 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:20 GMT
+      - Thu, 28 May 2015 01:29:41 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:20 GMT
+      - Thu, 28 May 2015 07:29:41 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:20 GMT
+  recorded_at: Thu, 28 May 2015 01:29:41 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:21 GMT
+      - Thu, 28 May 2015 01:29:41 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:21 GMT
+      - Thu, 28 May 2015 07:29:41 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:21 GMT
+  recorded_at: Thu, 28 May 2015 01:29:42 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/e1%2Fe6%2Fd8%2Fa1%2Fe1e6d8a1-c539-467f-937b-6f12df465a47
+    uri: http://localhost:3000/annotations/aa%2F33%2F78%2F4d%2Faa33784d-f44c-4412-9176-cd7f0b51648d
     body:
       encoding: US-ASCII
       string: ''
@@ -2481,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - f2a80658-dc1b-4c35-80b5-cd90571381e9
+      - aa10ebb9-ac9f-45c7-a769-7a8cbd4de804
       X-Runtime:
-      - '0.235576'
+      - '0.179804'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:08:21 GMT
+      - Thu, 28 May 2015 01:29:42 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=V0hac0lJQlA4bTB1Uk9FT29OcHVDMXpmeE9KMEpiMlZQTXhvQVlhVHVOem1ZTXNFZG5ZdExqZUN4SXBGbE1aU0xoLy9QOTZUT0t3TnNpWjlXUHE5RHZtRi9Vb2dqZFlFSHdrYnptQ2dRSUJlbEN1bFc2NFJ2UkdXL1VhYndsN0hDcW51TVFKY2VvK1V5ZFNDc1EzbmUyZnA5ZjVjZzNYb21NY1RzL0ZKUGRhN0VaM0prdDJwb3U1b3lNNUtZSEJoLS1zQWdQanZpeWpsNWxQT1lwTEJsaWd3PT0%3D--39f209460e2e882ed12d5a3827bb8eb7728e158e;
+      - _internal_session=ZjAwQ3ozZVhJazYwMkwreE5mb2V2Mm1QMFhvL3JUdXozanBvKzBXZEllRTRWd0VrTFZzUnZNUzRwU0poMFpPWmhUeTl2MVVmOWExQ1FndHZ0S3FnODZ3eG9mNXUyTWFCWC9qZFVrNFRtTXV6cmcrM2NGd1J2ZCsxeFpteENKc2RiRzg0anV3RThicHIydGN4aTk4MXNpMkZtWmt5ZDgrY21GT1JMMXRVWWhJYXpiM0kzb0U3c2pZdnNLOWpQWnNoLS02Zk1NMGZkNnp2K01xYnJORnNJdVVBPT0%3D--f26d688542b6355f5a49948d71abfd0ac40562a4;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:21 GMT
+  recorded_at: Thu, 28 May 2015 01:29:42 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/requests_an_open_annotation_by_ID_with_content_type_application/turtle_.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/requests_an_open_annotation_by_ID_with_content_type_application/turtle_.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"6a76b93fd65b53a253564e0259d1d357"
+      - W/"252bcea18fa331f1a092c8d6525a04aa"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - acea1372-6478-4143-8aad-16292890eb94
+      - a1de8d72-a9fa-4dca-bbdb-bad1ce3af0b2
       X-Runtime:
-      - '1.771144'
+      - '2.249109'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:07:05 GMT
+      - Thu, 28 May 2015 01:27:08 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=RlBXS3FJZHQrK1QwTEFwdDBHR1p4ZlJHYjdqazBhaVRyeWZxYmU5d3pwb3VEYVpSSmY2dUtKMUsyVmJETEk3ckd0bTZwMzFUbmIySnp6Qk5CclJ5Ym9GVGtKeHBoSHB2YjZWeTc1SDIwcGtYZ3BGWkdUZXdVdjVyNW9uSjRack9Yc0Y2MTd5d3pWVlVQN2xTajVTcU10STNTS1BoZW5RN1VpdGNEekhjbVRqNWdiUWpuaEhINkYzL3dzSkJzL0x3V01hYmR5NUlkL3kxREpNSWsyMEt1aENZTUUrZkFPNmNPc1ExTkNxdkZTbUtvNjNVNGpLT2Z5UmxMY1lWY2VNVy0tUktmSDdPTkVHMjlxVU5pZHQxU1RBdz09--8eebc520d1575674560890f14e1906455c815c25;
+      - _internal_session=SXRtdGtZK0txTlIzYTQvTStkWkYzeHY4VUhuYVNjNVVlcTdIcWE0Smt6UVd1M2p0NlhwTTFveXJqVVI4cEpoN2pEcWFxRVc0VXZnVVdLa1ZEeU5aZld0TEFyeVFJK01vMER1RmRHYnJ3ZjlEVVlaMUttV2puSUZZMm9NL3NvV1h0WUVtNkcySXFhZmltTUdHRTFpejc4NEp5K2Z1TnBVUUdaMndnL0dXU08wdGplRDd4ZG9TVGhVcTNZcGc5RHdMOHpNazA0NURBVU5qTEFONjJ5ejBLbjY0U2FVRDBFaElMb0RyYTY4MHdiYjBjNVpQTUYyK2xCbDQ2dDEzSTA4TS0tb0hBcVZzQ2NCbVZoaXk4ek5HQm42UT09--cdc0e9d951939727c743cac76404544366a75d67;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310887745080","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/66/9a/b6/6c/669ab66c-72c1-4589-af16-b6cd3b78c666","@type":"oa:Annotation","hasBody":"_:g70310887745080","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942035990940","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/ce/bc/6b/57/cebc6b57-70ef-4bd4-81d3-5a5309f856a1","@type":"oa:Annotation","hasBody":"_:g69942035990940","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:05 GMT
+  recorded_at: Thu, 28 May 2015 01:27:08 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:05 GMT
+      - Thu, 28 May 2015 01:27:09 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:05 GMT
+      - Thu, 28 May 2015 07:27:09 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:05 GMT
+  recorded_at: Thu, 28 May 2015 01:27:09 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:06 GMT
+      - Thu, 28 May 2015 01:27:09 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:06 GMT
+      - Thu, 28 May 2015 07:27:09 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:06 GMT
+  recorded_at: Thu, 28 May 2015 01:27:09 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:06 GMT
+      - Thu, 28 May 2015 01:27:10 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:06 GMT
+      - Thu, 28 May 2015 07:27:10 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:06 GMT
+  recorded_at: Thu, 28 May 2015 01:27:10 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:06 GMT
+      - Thu, 28 May 2015 01:27:10 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:06 GMT
+      - Thu, 28 May 2015 07:27:10 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:07 GMT
+  recorded_at: Thu, 28 May 2015 01:27:10 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/66%2F9a%2Fb6%2F6c%2F669ab66c-72c1-4589-af16-b6cd3b78c666
+    uri: http://localhost:3000/annotations/ce%2Fbc%2F6b%2F57%2Fcebc6b57-70ef-4bd4-81d3-5a5309f856a1
     body:
       encoding: US-ASCII
       string: ''
@@ -2481,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - bfdeb434-a6bc-41f6-999d-7c47a7be52cd
+      - 855a7787-66b8-40fa-9e28-15e6e4123c0b
       X-Runtime:
-      - '0.249562'
+      - '0.233925'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:07:07 GMT
+      - Thu, 28 May 2015 01:27:11 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=QThLQ05zTTJJdVMxS1lzcWIyc1RrU2ZMbWlzeFhsNHp3Yi80T0ZaSm9RWXNCU3JENVc2aUxrTnRFaG91c2JKRmhidHV3dVF4eDdwMm9YbWkwRUNkSzZoYUxkRzJlWmdVSXdSeGhTS3F4UHE5cnY5QllEWk1kOXY3TlFBcGp3NnRrSzN0ZGQ1bExqK0tZZ2NpZGFiTm5nME5MN20zSnZXZ3JQaXBPc3d6L1VjTUo5bElkMFRZZDB6L2ZDRnF4NGdNLS1Fc3VsdldwMWRURmtvb01seE1CSWx3PT0%3D--a1c1925bbd76b0b68567ee92643d486c0186d33c;
+      - _internal_session=VlBuaVkySk9qUGlyZ3F5YlZoVXpiQ0JHcjl5TlBuL1h3Qy93bmY3Q25ad04zTGNFRFoyeUJ3S1AwM1hLdHlZTUhnSmw1MTBHTlhYTWQwb0FxV2gxdEJsY1NvNTlFZ2JYZXoreTFlRHlKMzJCL053bVpyRUtMSFBHYTVVaGtqbDhZa09ObXZxVXl3MzN4VFh6Zm5kcGFnaExpWFlXVUIyQWtpMVRxcCtrNE90S01BNVdxM1cxWHVMaVdDeUJEYXNXLS1kbDZsR0U5TGxJQWxLelVLSG05MzFBPT0%3D--f7b0062dbc52ccd6eacf7f56b4860fa633e0cb61;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:07 GMT
+  recorded_at: Thu, 28 May 2015 01:27:11 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/requests_an_open_annotation_by_ID_with_content_type_application/x-ld_json_.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/requests_an_open_annotation_by_ID_with_content_type_application/x-ld_json_.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"608d9b7a2e56f5f32413ae7f6cf2955b"
+      - W/"e3657822f77e830f9ae84e726ee3ff8d"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 2dfec735-eb0d-4847-bed2-41aeae282d74
+      - 798c181f-c1e1-470e-90a7-41ce420a387c
       X-Runtime:
-      - '1.664625'
+      - '2.349143'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:29 GMT
+      - Thu, 28 May 2015 01:26:25 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=VjV1bTRhdnJ2MHZwQWZYUzNyeFRteTcyTDZwK3ZXeVY3S0Q2RUIrTEZlTTB5eGlvbER5M0V6UzBHVWkxV0RLcnMzMmp6ajloZkFYRERYYjRoT0xiSHdqTVZxUExWVkVtRE5GZy9UYXdmT0w2WlJvNnVnbkZHZVN0MXZkb3FtdTgyQWhraHhZVUtBdFVrR0RmQURXeFMydStyRlphUXdjbjQ0S3NmYmt0c3JSM2tuQWtkU2NyejgwN24rL0RRNVBNMUFFK1kzYXVhNWZnNWgwSjFjRFIza1FoNEg2ZHJ1SGxrTGo5R0wvc1EvOEt6Y0sxS21PYmIwZitvWDllWmI5VS0tUitkYWltM3JqUEt1aVIyRGx4OEhGQT09--93b2991f3a58da66611ac32a396a99b9571c6a2f;
+      - _internal_session=OTY0MlBnUzZubFJUelNyajVWKzZDN2ZVQmxobllnWnN2Y1NyN2dFdUFUUU9lWEZQQnZ1OEZPRlFiMEh2MGo2NmZMV0N6WUUzckpTMkJCZ2o1QkQzRnZCMjJqZ0FIS1JaSGQ4Tk5QN2JHZDRlSVJ6azFqcUpLMU1VTi9RRGgzZzJkV3lGQXU1MlYyVGRBVndzcWdRaWpZaklaenpCL2RXS1ZKSDhhY282Z1hEanFLVjBOeXhsTnNmZG5zSUhKeEFOVzNuVDFEWnAzMTlsMG9qQjNNb2Jpdmt1SzJ1LzhuMnAzUVg4RDFyVE9NRDBMVFhtZWdkdW02WVRFUGNUV2dCdi0tazF5bWFUdDVoUWN3RndSczM4WXVmdz09--e707b491252911983e7fde645bba6b5b4e28faf1;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310858496280","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/5e/4d/b9/08/5e4db908-8e08-4477-b895-93a1d8929aec","@type":"oa:Annotation","hasBody":"_:g70310858496280","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942003514000","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/99/60/45/2c/9960452c-e355-412a-a96d-4fe7683a5a42","@type":"oa:Annotation","hasBody":"_:g69942003514000","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:29 GMT
+  recorded_at: Thu, 28 May 2015 01:26:25 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:29 GMT
+      - Thu, 28 May 2015 01:26:25 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:29 GMT
+      - Thu, 28 May 2015 07:26:25 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:29 GMT
+  recorded_at: Thu, 28 May 2015 01:26:25 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:29 GMT
+      - Thu, 28 May 2015 01:26:25 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:29 GMT
+      - Thu, 28 May 2015 07:26:25 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:30 GMT
+  recorded_at: Thu, 28 May 2015 01:26:26 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:30 GMT
+      - Thu, 28 May 2015 01:26:26 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:30 GMT
+      - Thu, 28 May 2015 07:26:26 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:30 GMT
+  recorded_at: Thu, 28 May 2015 01:26:26 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:30 GMT
+      - Thu, 28 May 2015 01:26:26 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:30 GMT
+      - Thu, 28 May 2015 07:26:26 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:30 GMT
+  recorded_at: Thu, 28 May 2015 01:26:26 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/5e%2F4d%2Fb9%2F08%2F5e4db908-8e08-4477-b895-93a1d8929aec
+    uri: http://localhost:3000/annotations/99%2F60%2F45%2F2c%2F9960452c-e355-412a-a96d-4fe7683a5a42
     body:
       encoding: US-ASCII
       string: ''
@@ -2481,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 4fbc7d78-ea4c-4cfd-8723-8a0589a9a4b3
+      - 692f0ac6-c6f4-48bb-a39c-4c8b8c2f8310
       X-Runtime:
-      - '0.293494'
+      - '0.210557'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:31 GMT
+      - Thu, 28 May 2015 01:26:27 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=NzZCU09wSFRNSjJNNXFiSzRueVJIQ1FUS1c0Znc0RFNXVjExVXlyRWswa2RVS1JuVjJQVE5lRjVmWmxXSStjOHNSWEt0UWgxcm0xMnVsVXk4MW9zaTNyaVNKMVlacUVVNmRxVVhTRVhQSG5aQktNSG1Qd0Z2U2ZRY0FOYTNkRWVvb2lkQjdRbHNBaGxHVzhRRjIzQmZxTEhadzQxQVJYcXcxZ2hPclFta0xZQmt5eEN5cVBPWjFNcTB2ZWJTSDBoLS1PWVUyTkV6Z2NuYTBGVjYrR1RaWGRBPT0%3D--20431a93df80fbae90b9ba4b5829e32ac836b9f9;
+      - _internal_session=OXg3Q2VweWs3SVBWYjVjcklmRC9VMjhYQlZJUXk2NXhYSGY5QmFDajlxWGhBY0JSVFpwd3hzdFJGMDVnNXpZU1UwRDdsSko1aCtDaHBsaG5Rd3Y3UE9CQ1hyN3NRaEtJenRDbzBsK2dZV2ZlRkFpZjNocGZBdUxUeFc2bVRBY3l6RVU1aGtiRWdtVGpxMGRwWS9leTNvYXVua0U1QXNUZWlMZlhSZDNzbko2UERQNk1LOExweTR5ZWZTbVlvNmF4LS1ZYmN6M2RWZGRkekZCTVNqc1VESDNBPT0%3D--98952f04ac14cd6c4c0fe121b4bac7d32684503a;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:31 GMT
+  recorded_at: Thu, 28 May 2015 01:26:27 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/requests_an_open_annotation_by_ID_with_content_type_application/x-trig_.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/requests_an_open_annotation_by_ID_with_content_type_application/x-trig_.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"8fc6a5aeb27a60d6870aea711c94edb1"
+      - W/"0156b063929c14d6526c2ddac5cedbad"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 8b0de1ed-f2dc-4bc2-8ba3-0663a51d3b71
+      - 46571957-530f-4ffb-837d-61147db29bf5
       X-Runtime:
-      - '1.734660'
+      - '2.081838'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:08:12 GMT
+      - Thu, 28 May 2015 01:29:31 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=RW10Z3d1Wnc2cVhWTjhWbk1GTENtZVdLdm1MUHB3cnlheFlCb21kRWRBY2FvWVhTdkNvRkVEV1Rsek1Tdm9UUkZxSElOMjVUSkl2amJNTGFaRVdDd2Q3OWkwT3hoS2tLY0dDQlpBK3RFajFHWkJ2TWVNbjRaVDI2d3cwL0ZVVGtBZDFwRUVyeTJhOEVtR2R4aEZQMHY5dUZyNnhCNEN2VGxBZ0Y4VGdvcVdUQkFIdjFSeG0xV1laT2k1NGJqYlJqZjdJNDIya1NFZHFOM1kvdU1oWERkRi93emROYkN0V1pHMlVvWWRWL0ozS3dxR1R1YzZBQjFrNWpqUUpGNUVRTi0tM0RpNGIyd3VOUFAzTVJsWm12RGo5UT09--ab1ee9767b96582dd7d947fec03fd1d7b796b58f;
+      - _internal_session=TWZkUDVPOU1hMEFnWTM3cHMrQnFmcXhGYTJyOVlvYWdUVjBNaUJ4QzBYT0I2QTh0MHBSbDNKSEFYVXlHWmlLdG9OcnlmZWRKYXBnTkY2dmpjdjhDTUZ2aEJpV0V1MEczTnBhUEJjSjBrbitYV2VSNWtEUjhraGZnTFVvU1dUNUhLUUl5VDdsMEMrT2trSWJrNjZsbmJHMVRkeUZSallKQUlXQmxJci95UzRQa3FCcXNkK0hHYzkvRVRMaFlFZUFkYi9WOVhpMEFhZkQvdFd5Tzg1ZVJRcHYvWFRBVzNxU01wYTU0V2Y3QWZCWlMxL01UaG12NUEwNjZ5M1RSU2UzbS0tejhqN0R6RlYzbW5rd0VFV2xMdnhidz09--ebc6c12882993b1954d945ba5a541170e80907b2;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310882605800","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/be/83/c3/35/be83c335-af5f-4c89-a498-95828f665f86","@type":"oa:Annotation","hasBody":"_:g70310882605800","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942004650540","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/12/62/aa/f3/1262aaf3-eb87-4618-8808-01b3229586dd","@type":"oa:Annotation","hasBody":"_:g69942004650540","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:12 GMT
+  recorded_at: Thu, 28 May 2015 01:29:31 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:13 GMT
+      - Thu, 28 May 2015 01:29:32 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:13 GMT
+      - Thu, 28 May 2015 07:29:32 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:13 GMT
+  recorded_at: Thu, 28 May 2015 01:29:32 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:13 GMT
+      - Thu, 28 May 2015 01:29:32 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:13 GMT
+      - Thu, 28 May 2015 07:29:32 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:13 GMT
+  recorded_at: Thu, 28 May 2015 01:29:32 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:13 GMT
+      - Thu, 28 May 2015 01:29:33 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:13 GMT
+      - Thu, 28 May 2015 07:29:33 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:13 GMT
+  recorded_at: Thu, 28 May 2015 01:29:33 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:13 GMT
+      - Thu, 28 May 2015 01:29:33 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:13 GMT
+      - Thu, 28 May 2015 07:29:33 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:14 GMT
+  recorded_at: Thu, 28 May 2015 01:29:33 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/be%2F83%2Fc3%2F35%2Fbe83c335-af5f-4c89-a498-95828f665f86
+    uri: http://localhost:3000/annotations/12%2F62%2Faa%2Ff3%2F1262aaf3-eb87-4618-8808-01b3229586dd
     body:
       encoding: US-ASCII
       string: ''
@@ -2481,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - fb680cc6-ebd8-461f-ac63-1ad815e8a550
+      - 71c22d5a-d1e8-4883-b21a-0c40847bde3c
       X-Runtime:
-      - '0.212396'
+      - '0.282009'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:08:14 GMT
+      - Thu, 28 May 2015 01:29:34 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=Njd5MXcvWkRFaTZhOVdrTkZhTnNxU21nR3lCOG1zOFRGWFdTS29rTXRtUEVaK2svOTd4OGt1Y3BESWFnOEZwUXpRRmNPd2Q3dFgwVVNncDliSDlzZ3ZxaGlFNlY2NUhNNVVUZXpCR0IrM0NteEN3TlFOMlRicVBCOGt3bFJsZ0tmb3NUeEtIZzhzdW85RTZLdzJhTzlqeGZLMmRVWGhTVWwydEhHcno3M005TDVYM2MzQ0RXNEtHejkvL2MyZHRhLS1ESzJCRWEvcndINklLbURVZWR5Wkt3PT0%3D--3c0bdd20b588ec8dd4896beaed3190a08067fc5b;
+      - _internal_session=YlE3M0pvTThhc1p2eXg1cDVPZi9KeFZNa2lnOFUwZ2NEV0xnOWt1a3puZ2dIUzhicVBBdkVxcWwva3RwTEdQRTMrcFFmL0FpZXdqUDRkWThqczdiOWtwMWVsTUlCUUp5Q3o3M3ZkdVBNZTEwcEZNU1lWdVN0WmZVNjI3dko0K3c2YStMZUNnb212QnlmRzBGQzRBVWhvbDhMUlh6aXU5MUUxbWIyZ25ic0h5aGxSRlM2b2U4a2Rkak1SWGxhaVhiLS1JejNmMk9lenZnTXZKK0x2NzE3RGhRPT0%3D--e5bae80fecb7f9177ca3787f84e33d52c26366eb;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:14 GMT
+  recorded_at: Thu, 28 May 2015 01:29:34 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/requests_an_open_annotation_by_ID_with_content_type_application/x-turtle_.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/requests_an_open_annotation_by_ID_with_content_type_application/x-turtle_.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"afe4ab560bc25b37a53ddd90e17084ed"
+      - W/"fdd697e059f5acb6a6e9169735462a1f"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 8fd33a32-6a84-408e-9d8b-f8458d260c0d
+      - caa19033-4db9-43fc-8ec1-298f78ca923a
       X-Runtime:
-      - '1.637634'
+      - '2.269571'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:07:12 GMT
+      - Thu, 28 May 2015 01:27:17 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=VTE5c2tjQXp6U2RpeEhWbnp2QTZaQ28vK0lWN1c2czNnQWpzU2oyS1EvWTlSSy9nU0Q2OStzVTUzdmFNazl6dUdoMVZ2bW16eTVzUXU2dE16Y1NaNU5JUllWTHFPWlZERTA2NDQ3NTEwQXM4YXpDeHQ4Nytwa0NKRkNpVnNwMkFKMzhlNmg1OU5hOVViQWJLTEhjL3NtVmlGcUpackJidXdwaVVETllqaW9qemNYWjZaRUxyWHZLMlNSSlFoU1NnVWcwTmhFNzNtb0dnTWU2ZkVhTnNZSUNFK1hvMkZBN2tUVGtZeVNydVJTUEMzZlA3cTUzZ3o3OWxRWWhWbTZrTC0tYlBIMXExZDhNRE54bGxoRHRyQTZsUT09--736683ea3730dd7422c0c73aac8dc3b05a2e2833;
+      - _internal_session=ZGtXWDlPL1JYQUhBSmpsTjl6MkoyaUpOVHZqdldMVm8vYXBwaWhQcWZIQnkxTXZGVHhXRmR1M2FpcmE1U29xd1RPY0R5UEJLNWRQdjcyc2dPb3hnb0RLWXFta0l2T2pUQUNadWlCaXlCcXhHRWFYbDM2Um4xRU5WYm9mR0JOTTBOZnBMSmM3ZnF1TkpjSjB4VE05dWdqWHRwWTk2T09CbGkvNXFLZTBHVjlQVUJxd202d0lzK3Zyb1hjVlV6WmJOdkpERlo3bjRoWm5JSC9mUE9nelYxLzBqSlZsWnZqQkh2UkdmaWRNRzlCUG9nRDc0Z3o5UXF3TElDU0hubVZ2Zy0tUis3VkNuemZFamRJVWFVTXlSbGxZZz09--b64d37ee875278907727ed0f9cd0a6a8c9ebb479;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310849963460","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/69/7b/85/ac/697b85ac-53b5-4f2f-963e-0e70fe43eccc","@type":"oa:Annotation","hasBody":"_:g70310849963460","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942006625000","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/0e/55/00/08/0e550008-3574-44b1-a3bb-dc18d87b0504","@type":"oa:Annotation","hasBody":"_:g69942006625000","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:12 GMT
+  recorded_at: Thu, 28 May 2015 01:27:17 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:12 GMT
+      - Thu, 28 May 2015 01:27:17 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:12 GMT
+      - Thu, 28 May 2015 07:27:17 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:12 GMT
+  recorded_at: Thu, 28 May 2015 01:27:18 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:12 GMT
+      - Thu, 28 May 2015 01:27:18 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:12 GMT
+      - Thu, 28 May 2015 07:27:18 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:13 GMT
+  recorded_at: Thu, 28 May 2015 01:27:18 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:13 GMT
+      - Thu, 28 May 2015 01:27:18 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:13 GMT
+      - Thu, 28 May 2015 07:27:18 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:13 GMT
+  recorded_at: Thu, 28 May 2015 01:27:18 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:13 GMT
+      - Thu, 28 May 2015 01:27:18 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:13 GMT
+      - Thu, 28 May 2015 07:27:18 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:13 GMT
+  recorded_at: Thu, 28 May 2015 01:27:19 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/69%2F7b%2F85%2Fac%2F697b85ac-53b5-4f2f-963e-0e70fe43eccc
+    uri: http://localhost:3000/annotations/0e%2F55%2F00%2F08%2F0e550008-3574-44b1-a3bb-dc18d87b0504
     body:
       encoding: US-ASCII
       string: ''
@@ -2481,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 712d39cd-899f-463e-bf41-5ed5a56da17f
+      - 4aa23347-dc8a-42cd-bab9-db72045b1971
       X-Runtime:
-      - '0.214719'
+      - '0.217761'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:07:14 GMT
+      - Thu, 28 May 2015 01:27:19 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=bVo2aUd1NXpNR000ZTd5NXcyUVVDbkR6c0FGZVlWUDhWYnE3WWRQVmQzWEFvZ21qa3dtY1hhNHRrNE9nK0ducXJyU3ZyS0pSbjZYYXVMeElBdHJjdXJGUGsvT3Q5cmdxNEdFVmJXODRVM1QvK0kxMkNCWWV5OFlLLytGVXBZWWxpR1RBVndlRnRjV3pjY3l6SmRFZWNrcUEvdVUvT3VjWGdtb2RJbW1DUG53WG8zYUpRRlIrdUxQYjVsSnJzOFU5LS1yMC9CODFtS3RJK05wTkxkV2VDTmVRPT0%3D--fea542f379974f62590b497edfe3713643672ec6;
+      - _internal_session=alhkV2lpeWNaUXYwaUVoZUF4cndqbDl2VnBlR2tad0taYUpKMGZWQWowVGhHNXNiait2WHJPUFF0Y0lRbndzclZNbzJjdHZFdjBZdFlPNFlqbUl2bzk4T0VtS1FoZWR3UWRkU0d6MGh2bnRmODF5eU4wT1Y2ZEJTUjlHSWt2b0dDa2NYMG5pcEdFUnk3d0dxVE44VnpsVEtiUnhYNVpiSTAyMUp0OFFaYVRYaVpDVnlVdEJFclVHcyt1RGZ6TmVsLS0rZTg4bHR1WnVQNWlWd1UxYW4rQlRBPT0%3D--bce2977864ea4af0ab5ca858864f667743aa574f;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:14 GMT
+  recorded_at: Thu, 28 May 2015 01:27:19 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/requests_an_open_annotation_by_ID_with_content_type_text/n3_.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/requests_an_open_annotation_by_ID_with_content_type_text/n3_.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"83bc5ac5a6fae7f7b5e08a7979c07312"
+      - W/"eaf324d8a23458250d95813a80c3a757"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - c496192a-efda-4d99-ad77-8654e11dcbea
+      - 81189d52-2523-4563-972f-b25e57f662d8
       X-Runtime:
-      - '1.626406'
+      - '1.999039'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:07:37 GMT
+      - Thu, 28 May 2015 01:27:44 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=aHZ6enppc2hoNGFZcndmNy9MVURkdy9FZE10QVdUaEc5M1QxeEUyd1pvSndPZnBJVS9ITXdRVUdjNVhMZnNWdG9yTG11aFM2M2p3enNiZGVzMFhjOEsveU5vbURNYXJBaVZGM3NlRG5BaUc2NUVWSC91NWdPT3lQek4rdlAxOFFiejhGRDdVSmNqZytCV1JhdnpOOC8rUi93QXhWU0paVHg2b1lqdERZZjQ3cnk1M01aM3dQSDV4dHJ2Q1FrTU93YWNPVXk0bDVtSGlvZmNHdkpqM0ZjSHRqS0VRNXlRa25CNE1JZVlmeXdJT1RCWTZIcDVwL2JCclNSdjdIdXhJMC0tTmdYSXN5VkFlNHJ3WmxrcWpWZ3E1dz09--376e20778a3f706520d96af361bc2d48617dfbe9;
+      - _internal_session=OGkrUlZFK0I3Y1U5WkM4cWljMEQ5ZzlkcGk0RlVzZlBsUnBMZkVjVG15SUV5aUMzZ2dRaUlQNE0wSTI3S1FheEMxbENOL3RGbUhWNHhEdlFSdTlYK1JqRjN3RnBIWitjeFdDSVhpTElhYmc2V1dJTElxcVh6UEZDei9IbFZEZUNWQUkxRGkxZEVQMVBSMi9PSEUyT1Z0cXNoSmhWQ0dpWktMUU1OMVhmYTlYTjB3UXc3aTNlUnF5NENpUm1IWCtlNmViQlRRcDNLQlphV1M4U1hqc0NJQVc2ZmVTaFBqWkp6ZEVXS2V6RkNsZGRaZ3NHRWxIRno0Y0tUWnZRYWJHci0tZkNjSWhSK044R0VrOE5nakZxMTUzQT09--cee0b1e565483d5431e775b9aaf9703154eee20e;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310881515320","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/f8/9e/be/74/f89ebe74-f820-424a-b246-525b3196749c","@type":"oa:Annotation","hasBody":"_:g70310881515320","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942006621520","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/e1/22/29/b0/e12229b0-f84a-4e42-9661-a36d82e6119c","@type":"oa:Annotation","hasBody":"_:g69942006621520","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:37 GMT
+  recorded_at: Thu, 28 May 2015 01:27:44 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:38 GMT
+      - Thu, 28 May 2015 01:27:44 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:38 GMT
+      - Thu, 28 May 2015 07:27:44 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:38 GMT
+  recorded_at: Thu, 28 May 2015 01:27:44 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:38 GMT
+      - Thu, 28 May 2015 01:27:44 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:38 GMT
+      - Thu, 28 May 2015 07:27:44 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:38 GMT
+  recorded_at: Thu, 28 May 2015 01:27:44 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:38 GMT
+      - Thu, 28 May 2015 01:27:45 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:38 GMT
+      - Thu, 28 May 2015 07:27:45 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:38 GMT
+  recorded_at: Thu, 28 May 2015 01:27:45 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:38 GMT
+      - Thu, 28 May 2015 01:27:45 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:38 GMT
+      - Thu, 28 May 2015 07:27:45 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:39 GMT
+  recorded_at: Thu, 28 May 2015 01:27:45 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/f8%2F9e%2Fbe%2F74%2Ff89ebe74-f820-424a-b246-525b3196749c
+    uri: http://localhost:3000/annotations/e1%2F22%2F29%2Fb0%2Fe12229b0-f84a-4e42-9661-a36d82e6119c
     body:
       encoding: US-ASCII
       string: ''
@@ -2481,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 5b0b43c1-4fa0-4ec7-abb0-40b704786223
+      - f96aa325-a1b0-4c25-bda2-e78dfa6179e2
       X-Runtime:
-      - '0.197600'
+      - '0.196532'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:07:39 GMT
+      - Thu, 28 May 2015 01:27:45 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=NUdkQzhGUFJTM2dIcUorQ2cvOW1BMEo4WVhoSlliMk5iSktVbk9SODZveEtEZ2JWUVBsekNmaTN3UmxJVlQ3cVdaNmgwUXMrMDBNbUlSU1djcisyQVNJdWFwTTNUL1gySSszQ0xHWlcwU0JObXRFMzNBWGdSUGJGZk8rb0U5TEZZakF5NFp2T2x5b2pIK2dTVURzdXc5U01GaDFlQkVjU1FVOXZwSzVnVXVCYXJ0eHM1eWp4SFE5bDlsQWFSNE5NLS1SMjU2U2dyY0h0N1BOVW15S1JXaXZnPT0%3D--6b181d23dbf7e447b5fe03a34d0873da8f27e524;
+      - _internal_session=ZzliSzJ5TWwvWHVjSFFCN3U3MWxWQUcxNFNXNnYvT0pvUGcwQysyWGtIQmhnWC9KbjZ0MHRKRHpQU0J6MFA0L2pXS09tUWZ5TEVIMm1rWkVJTnpybUd5dUdLbjZIbEZRSGFzRm5kVEEwOVRuaWhnRWFiL3FiWnUxTW9WdkdaeDBxU09oREswc0NxdU9yZzBsZFlOWENDS2M5TXRVNHZIazlWNVpSeVJob1A5Zk1nTUUzUzBOVVhMS2NxOHVLUkkyLS1ITXpNeVJkZmNjQ2hWeXIwMXV0bVp3PT0%3D--c3930de752f656d8934f05ed84223bab9973fa19;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:39 GMT
+  recorded_at: Thu, 28 May 2015 01:27:45 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/requests_an_open_annotation_by_ID_with_content_type_text/rdf_n3_.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/requests_an_open_annotation_by_ID_with_content_type_text/rdf_n3_.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"ea8d5c6d0f2abf5011b06131ed169e70"
+      - W/"7a3ecb210a53a9ba0235893bab8e71d0"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 7bfb72d5-f91c-421b-8513-4a40aaf4a961
+      - 6a06e289-c51a-482b-89fa-34a8be74de93
       X-Runtime:
-      - '1.627840'
+      - '2.571358'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:07:44 GMT
+      - Thu, 28 May 2015 01:27:53 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=MXJrRGZXbjRlSXVKSHdOYVB3UzBHUElUOTkzMGwwRlFaMkZBYXZOLzhtOFBCTjc3M09kcnJ1WkFlbmZoeDM1UmM5WUtLTjJFQVNoQWVOY2paUlNPZ1R4aFpYd0pSOFdVUGh5UXJJZHI0YXgyV3dIYVZSK0gwdkNDcDFPWGNRYkd0MjN1OXA3Vk0zZS8yeVFoUFVzclJSVVBEcEJubHpFNlpYZGdmZkxvVCtrRW91cVd4dG9CUWIzd1piTXJzcWZoMGFIaVJ0THNFdzArY2N0NzBrR25xSWFIbENrTElNOGVhZTBFeFFQL0dEQ056cVBhSmcxYkczUEdUZGlUbEJpRC0tZVJNQzg5NDEzSVI0K2cyZTBpOVpKUT09--e60bf8fc174f7ed836f427a20b783889080f3a3b;
+      - _internal_session=N3E4MXJqU3MrQ3dsOFM5WHhKemFjY3lMdFFxSWpXR2d5U1pSN0c1eVlnVWxDcTQ4dkp5Z1dEcDlrcnJaTlltMDFzMm1aZXJIcFhIc29COVg0QnJxd2FCQ2xMOC83b2dvREd5bk5wK2Z5TnRDb0NsZnNzcVdXdXF2b1M3bHJ3Z2VhTWNMWFRiYUxpTEJyaHVnTGlLSzRIdjJBVzA1UFh0ZktMTi9TdlgrbFQ4Q2x4bDR0aVZmWmNrd2pUaVJZS1B3aVpnT1pjNGxnb1NsY1N5RGFQQjZRUUYwRDd4U0U3NmhYZ3VUdWdDTGw2cFJwT3JnM2hLMDU3MCtDZGRyUEhhOS0tMEthQ2RjbTd3WTVLZHFteUhKeWh0Zz09--eed8509732f60ec3e62d3d9cd5ac3fc40e14998e;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310882017600","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/3d/78/bc/28/3d78bc28-abf2-4454-9ae5-e13d85e449cf","@type":"oa:Annotation","hasBody":"_:g70310882017600","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942028293540","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/4d/d3/81/fa/4dd381fa-8d15-4519-9b6e-e133231cd566","@type":"oa:Annotation","hasBody":"_:g69942028293540","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:44 GMT
+  recorded_at: Thu, 28 May 2015 01:27:53 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:44 GMT
+      - Thu, 28 May 2015 01:27:53 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:44 GMT
+      - Thu, 28 May 2015 07:27:53 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:44 GMT
+  recorded_at: Thu, 28 May 2015 01:27:53 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:45 GMT
+      - Thu, 28 May 2015 01:27:54 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:45 GMT
+      - Thu, 28 May 2015 07:27:54 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:45 GMT
+  recorded_at: Thu, 28 May 2015 01:27:54 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:45 GMT
+      - Thu, 28 May 2015 01:27:54 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:45 GMT
+      - Thu, 28 May 2015 07:27:54 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:45 GMT
+  recorded_at: Thu, 28 May 2015 01:27:54 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:45 GMT
+      - Thu, 28 May 2015 01:27:54 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:45 GMT
+      - Thu, 28 May 2015 07:27:54 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:46 GMT
+  recorded_at: Thu, 28 May 2015 01:27:55 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/3d%2F78%2Fbc%2F28%2F3d78bc28-abf2-4454-9ae5-e13d85e449cf
+    uri: http://localhost:3000/annotations/4d%2Fd3%2F81%2Ffa%2F4dd381fa-8d15-4519-9b6e-e133231cd566
     body:
       encoding: US-ASCII
       string: ''
@@ -2481,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - c626aaf1-65df-46e8-b9f7-7ed1d982d7cd
+      - a7d8aeee-2538-47fa-b4dc-52eaaf59eedc
       X-Runtime:
-      - '0.234534'
+      - '0.203885'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:07:46 GMT
+      - Thu, 28 May 2015 01:27:55 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=NkdYbXEyS0FrRTU3cEZjR0YwU3o1am9ZNysreFVmU3dpYitkeVMvQmovZjNRS210bmdsM3dNSDNOVWlzV0xZeFdnZFU1Y1JRaG82ZVoyK0o4SjZqcHdwb3F4bGM3OEJaQmxad05DWG9CRkZXTnpzang2cXZWVENINmxPTUpZOHFZY3UwUWlWUXNEOXBSVFQwelZ4MWdUOXZRenp3K0NjeGtsNUtzZ0ZpekdzZy9wOU5PYUk2czhNQmpVVXdwY3llLS1NbkFHclIreStid1RTQlF2OVpKOGl3PT0%3D--c8435120caa5a5d552df800b50c577dc1f9a7f82;
+      - _internal_session=OWRybXRvV2toUE5JdWc2amRKanVoeVdnRlZ2Wk10L1lPdXlRcXdFM2FyRlhMbjBscXQ2VWpmejdoT2UwcVdiaFo5UXhmNHg0dlZNcmRsaE1hM0U2Sk5ua0lnbUR2eENQWERGTzQwSDNOaFJSSW5IdStaNS9Wbi94blB3QUl2VzNWaWtibmgxSWVZVUR2MTJYRGsxamJHUksvSmt0Q1cvb1J6ZUQvTjRuaklVaGEzd1Y0V0Y5QlFwYjh0SVFsbC94LS02b0p4YlZEYktiWjFWMGtxYmJMeUNBPT0%3D--60cf19124f58ddcdca9c7b99042d72d8f1e1f842;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:46 GMT
+  recorded_at: Thu, 28 May 2015 01:27:55 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/requests_an_open_annotation_by_ID_with_content_type_text/rdf_turtle_.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/requests_an_open_annotation_by_ID_with_content_type_text/rdf_turtle_.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"16e7eef2a3d87ee8a54a40367e254607"
+      - W/"c2850eb72cd96285575d64ecb292a6c9"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - a4162165-c2e1-4a3c-909b-60f04486e887
+      - 1d58ee4c-95da-4101-b80f-996754c909d7
       X-Runtime:
-      - '1.634503'
+      - '2.194261'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:58 GMT
+      - Thu, 28 May 2015 01:27:00 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=d3dRQW81N1d5eUtBcThIaTNROUxWazhVZEJtMmdubXQ5RXUxU010NWNtVGlKWWFLU0ZpZ3NjTmIxNFFiQ2FEUXBzZjZPMFlHUTE4aU9wS0g5VVh3SzBUK3Y3NWFqVWZUSWxrNGRuaWk5R1hqU2hubjZwUDhkQUEvSm54UXlLZWdvdEZYWERRbDA5V2V5YVoyMzQvTHp6ZFdRMzduZC85WGdWenlyOHZNWWNtdW9zU2ttWk04NEpLVys5OThPV1QrRURmakZGbkN2eFYzQTd0RmUxU2NYbkdmbGIvVXhoTHByT3JHZSs4TEtFUHFYNEtEKzZhWnptRnh4OE1MTXNMRS0tSUI1cU9McmViNFR5elZaU0tiWFpUdz09--2b8a82e7cd5146dbd27f6892588725a6655c25c0;
+      - _internal_session=dEZEd3dSSzhHb0liOERhajdFN0IwZnFwSUhDV2l3YVNGd2VLcWhGTTVaMnl3T1JaR0srN29hYlMxdlpxUGJjQU9va0I2RzRmMUlkdUM0cmk3ZlpLTGpGdDZ3RDVKSlRTZklGTHdVRlFaSWdPdmU2Z0p2NU1LWnZKVElhMzQwWlpsajhGVkFlZHU2c0xVRWRtRVdtRFRyWllLWklNRjhPN2hESEQ0U1ZFMDZBYktJSmlXNm5CTG1jUVJicHVoUE9DYkxka0lGRHAyZUtEY1ZDcnUwK1NMRUhaSmNBeVpjaGlCTUorNHQyRWxWa2RWa0Nxb0g0eUlKK0dLSHB1ZSsvSS0tNHM5ckcyMHkwQXh5ek41QjNmSktXdz09--0b6e5bf2c2c002314dde053a0f1984c8010b950f;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310882327720","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/fd/ae/99/da/fdae99da-fb58-4eb0-96df-30d4b1b6f3cf","@type":"oa:Annotation","hasBody":"_:g70310882327720","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942001348100","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/ce/52/fc/13/ce52fc13-8fbd-4180-98ec-029fc1d4538c","@type":"oa:Annotation","hasBody":"_:g69942001348100","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:58 GMT
+  recorded_at: Thu, 28 May 2015 01:27:00 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:58 GMT
+      - Thu, 28 May 2015 01:27:00 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:58 GMT
+      - Thu, 28 May 2015 07:27:00 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:58 GMT
+  recorded_at: Thu, 28 May 2015 01:27:00 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:58 GMT
+      - Thu, 28 May 2015 01:27:00 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:58 GMT
+      - Thu, 28 May 2015 07:27:00 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:58 GMT
+  recorded_at: Thu, 28 May 2015 01:27:01 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:59 GMT
+      - Thu, 28 May 2015 01:27:01 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:59 GMT
+      - Thu, 28 May 2015 07:27:01 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:59 GMT
+  recorded_at: Thu, 28 May 2015 01:27:01 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:59 GMT
+      - Thu, 28 May 2015 01:27:01 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:59 GMT
+      - Thu, 28 May 2015 07:27:01 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:59 GMT
+  recorded_at: Thu, 28 May 2015 01:27:02 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/fd%2Fae%2F99%2Fda%2Ffdae99da-fb58-4eb0-96df-30d4b1b6f3cf
+    uri: http://localhost:3000/annotations/ce%2F52%2Ffc%2F13%2Fce52fc13-8fbd-4180-98ec-029fc1d4538c
     body:
       encoding: US-ASCII
       string: ''
@@ -2481,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 8e1917d1-4fa5-4d1c-a66d-cf0c065747f7
+      - 6f16a8d6-de71-4432-86ee-b952c74929d5
       X-Runtime:
-      - '0.245614'
+      - '0.200146'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:59 GMT
+      - Thu, 28 May 2015 01:27:02 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=OHFCOTF4Zll2T2NvQUpOSVhja09HcGVPRGNxVTYxSmJwOGhWS3pWK0FDMk5SWGp1dmt6dU16QmJWZTNjMEoxempLRmpPRmVpeTR3UEswcWY5V0U5L1M0aGhkUjdPK1JYUk5WZHJGa0VRV0FWZEhOTGlDZ2h3d1c2V3hzSGNUZmVnRXpBQW9TampXZUhPK2ExMVVuVFBSNEExN2JBaUZGbjJNTWd5RVhFbE5LejA4elJteFBPckJLTThKRDVkbC8zLS1oVHZsN3IrNk1rditlK2U3TEE3M1hRPT0%3D--d778cbc09582474d57f61c0e4b58dfb44ba63d57;
+      - _internal_session=M29DU1dLTkJFakM0eFhxU1pMcnJpazMwZm0vU01lWVUzSHNPTjllNE83aWpIMFQzSEJoVk9oL1lEUmFET3orTWJFR2Fod1RleG9jcGtQd0dLU1ZtZnVhZ0NabDJYeUJzR205NjVpV2s1UnpHSFRwejdUMGM5QWN1T0ZTTkFvWWllMmV4czN6SEV1Z2FqeFYrenNHRmYrWFBmUTUxbUh5VThsR1F6MzFIOXhBa0gyYllHOVFxd1EwMGU2c0p2WWc5LS1TWnppL1lEVkl3MWJkN2ROZXdOVzF3PT0%3D--a9782a8e41b7a9b392c4b307f5b966c205b04783;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:59 GMT
+  recorded_at: Thu, 28 May 2015 01:27:02 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/requests_an_open_annotation_by_ID_with_content_type_text/turtle_.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/requests_an_open_annotation_by_ID_with_content_type_text/turtle_.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"3f6438679a742c01c5086cbf78578336"
+      - W/"9f04e9e0613559fdddea9b2d9f08b50c"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - f405f3f4-f9b8-4025-b3e6-88831f1a4ac1
+      - 16960ac2-8e68-4f00-a637-70caec0c61fa
       X-Runtime:
-      - '1.837793'
+      - '2.208240'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:51 GMT
+      - Thu, 28 May 2015 01:26:51 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=YzhPWVM5ZU50Z2VqbzIvL0xGc20zZ0dqNTMwRENsZHJFR3Q3d3ROQXhpT2o2dDN2QkxRNUNSdG94SGx2MFFrc0NMYTFaQk9EWVZtTHl5bmVycWk0RWpyc2d6TU04dWg2SFZPSVNVdFRiY3FieU1OSW1lMHNVU3RRRE56RXVSUktlMXRSdWZBOWp2WnJOdkFFQlhnRy9zUjQ1N3ZidDVhaXQ0dkNIaHVQNkdpTkNUa0l2eG51SVUwNDdhSFRQanNHeXdBbW9LSHo3TnJqZ24zZGtyeHY3eHJCdTc4RVJEU0dRZ2FuMFdUUllmb1dqR2l0MTFHRUZ4TVQ1VGtvcmNQYi0tOVpiMWZXMzZXMWNUQjZ1OVZ0Nk13QT09--14b613c0a5dc804d9aea8be732af635f781a18a9;
+      - _internal_session=ZFBjZDl0OTdCT3RLSmdWMGpHU0VtNzBvS3BnV21Sei9zQWswSWY0MkJLaXNRS1FsMnRhSFROMGZScDlWa2x3c21KbityVUFrUTNkQkgwejBTNm5KT2tNNXNoV2xjcXIzQWErYzJhUXd1L3NBeDY0am00YnJPL3J0d3ZLZ2xSelFIY0ZBWmJ1dzVYbEpJcHFBYitEUEN2QzUwNklpdG4wSG8zQllTYUlLdFFMbW5PbmhZTXU2RFpzNDRYbE5zaFR4VDFBU1pVRnphRFVneFloZjMvWCtlYzRmbDFseitBS1FZTExtbFZIamJDZXNQV3hnQWxxYTM0RVlUc284Sko5dy0tSVF4SEdpKzJDMUJ0THBiWW5oVUxVZz09--ca3f772d4994c949c745e8bd45dad4dbfb69a5ae;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310849617280","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/2f/1f/a0/4c/2f1fa04c-6091-42b4-8efa-39885fdbffcc","@type":"oa:Annotation","hasBody":"_:g70310849617280","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942006955660","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/fe/dc/1c/d8/fedc1cd8-d47d-4e4a-8466-3d850b69b4e7","@type":"oa:Annotation","hasBody":"_:g69942006955660","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:51 GMT
+  recorded_at: Thu, 28 May 2015 01:26:51 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:51 GMT
+      - Thu, 28 May 2015 01:26:51 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:51 GMT
+      - Thu, 28 May 2015 07:26:51 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:51 GMT
+  recorded_at: Thu, 28 May 2015 01:26:51 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:51 GMT
+      - Thu, 28 May 2015 01:26:52 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:51 GMT
+      - Thu, 28 May 2015 07:26:52 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:51 GMT
+  recorded_at: Thu, 28 May 2015 01:26:52 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:51 GMT
+      - Thu, 28 May 2015 01:26:52 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:51 GMT
+      - Thu, 28 May 2015 07:26:52 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:51 GMT
+  recorded_at: Thu, 28 May 2015 01:26:52 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:52 GMT
+      - Thu, 28 May 2015 01:26:52 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:52 GMT
+      - Thu, 28 May 2015 07:26:52 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:52 GMT
+  recorded_at: Thu, 28 May 2015 01:26:53 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/2f%2F1f%2Fa0%2F4c%2F2f1fa04c-6091-42b4-8efa-39885fdbffcc
+    uri: http://localhost:3000/annotations/fe%2Fdc%2F1c%2Fd8%2Ffedc1cd8-d47d-4e4a-8466-3d850b69b4e7
     body:
       encoding: US-ASCII
       string: ''
@@ -2481,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 9f85acaf-2bb3-4fc1-8a8a-62b85ec5cf93
+      - 6ffbae04-af1c-433f-8b11-8823120d6e75
       X-Runtime:
-      - '0.256618'
+      - '0.167397'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:53 GMT
+      - Thu, 28 May 2015 01:26:53 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=RUFGbFM5eU9PZ3pPaUg4bSs5VG5Nd1ZsZ0Q5Mit4ZGUwRFM5Y0NVRkdlTEovZllRK2R6NHpQWENKTjA4YkdjR2t1RE1TMWFXZjh6dk1PYS9HVjI0bVBMS1FOdXN2LytyMUtXZFUvY1BXbmtDUytGTG16YVF2N2k3amJiNTZlanV6UXl2RnFjbGNvVkUzRXgvOHh0TkxjTGpMKzgxOHNSZWk0QWVFM3JTcExhMnY2RTJkMm1PR1ZIc0RRZ1BIeXI3LS1DZmE5Tm5nUkJkbkhUaUFYd2pYNmpnPT0%3D--e557ee1b771219df7387bfb02a0eba44b62158dc;
+      - _internal_session=QkFKd2xsNWh2Qm5Ud040eU9EVFM5NEtiQnJFT2d6dUhiS0pMY05EMDhJYlp0N1JZWFprZlg2T2dVa1VJMDExRWdIN1lRVmtCN3VHWmlVbW1taEhZZWF0b29MY2VCNXZiT2tDcHpmeHlhVnNmWUdUSk12RDhYcFNYOG1ZcVlWcEJ1cTJDNVY3b1lTMHpwVG9LTWM2OVJxOERPdUl2YWhENkJOc3ExcTVqS0F6ejZlUFcxdk1MSWU1bk5ZQ0Q4SW1MLS1KZVhvQ3dsVnBmMnlJZ0RDMHVsYkR3PT0%3D--83ffe52fef71851f2a216e6d70ebd68ee774bd70;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:53 GMT
+  recorded_at: Thu, 28 May 2015 01:26:53 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/requests_an_open_annotation_by_ID_with_content_type_text/x-nquads_.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/with_content_type/requests_an_open_annotation_by_ID_with_content_type_text/x-nquads_.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"7c26d14e64d5be990900ff05e066ae2b"
+      - W/"011bb6089a719519f4a1d3c87da2bd91"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 9a3307c2-2741-463b-bca1-e6fc815f4b20
+      - d545a816-ec6e-4a3c-a3dc-7fe9ea1a515d
       X-Runtime:
-      - '1.672883'
+      - '2.340207'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:07:58 GMT
+      - Thu, 28 May 2015 01:28:13 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=Rks5UXQrQkpWM2plejhBWTQrblppcWNOSXFWQy9tdTluZG9xL1ZuQnVpUDlBTktjd3JCaHgySDFwaGU4azkzNGpvWnRsOHp0cldwaU5PSTF1RVNzcHp3WWtqbThqcmU3cUhZRkYvc1hVSnRDUEhKNjk2QmZiV1V1K0QzY1dUV1pTNVFqSE9JNEZPWDhoSVhFQ1NiMGRjeDhaV3BRN2hwbUdiLzgvVS91RkF1Wk5HSkQ5VEZYMTl4dVBIcm1aaEpmUlc5NGxvU2NvWkIrdmFPNTlheTRBeGh5YzF1S3RpTkJlanQzYkMxczVMYkR3djZzMVZobDBqemNIS3ZTN2k5VS0tK0paVjJZZzJtMXlhU1N4YThZVjJxUT09--13d0df6c6c439f93dab52b3ed1672fe4d5418ee4;
+      - _internal_session=ZFhmNS9MU3c2Y05XWEtGM1Z1bFBvazNmd1NIMzRrWithM3ExRjFhQzNXOTBLUkZPOGJFbS8xRUw0WjRsaTBMdi9ZZ2ZvcWVkNVJZbkJvWUYzVE42b0ZQZ3o1aXNyK2pkUE9lN2pETkdmOVpPWmFPcnJTTjZXcnJ4YU5RWDI1dDBnKzE3ckRRZTFOeUphU0cxUkZEQ3BObW1FK1BHSjB1cm9YalVKcnorVWFlbm11YiswVEJSbGlRbk44NEwvUHRkdWJPalZLNVNscm9wOFpVMkRIVG5kV24wbnFiOE5OQ2pyVWdoNkMvaVlCODBLRGlxMnNra01XT0dqOTVrdkNRcS0tVS9jWkF3NGw2akFRZzBDK1B5aHZWUT09--0356bfb785f57b331126c4e1f012c18deee87953;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310884132240","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/eb/f4/a7/c7/ebf4a7c7-589f-4649-9e05-34b070d81d72","@type":"oa:Annotation","hasBody":"_:g70310884132240","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942024045280","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/22/ed/8d/3d/22ed8d3d-7144-4f63-b8de-72696ed3d649","@type":"oa:Annotation","hasBody":"_:g69942024045280","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:58 GMT
+  recorded_at: Thu, 28 May 2015 01:28:13 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:58 GMT
+      - Thu, 28 May 2015 01:28:13 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:58 GMT
+      - Thu, 28 May 2015 07:28:13 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:58 GMT
+  recorded_at: Thu, 28 May 2015 01:28:13 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:58 GMT
+      - Thu, 28 May 2015 01:28:13 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:58 GMT
+      - Thu, 28 May 2015 07:28:13 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:59 GMT
+  recorded_at: Thu, 28 May 2015 01:28:14 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:59 GMT
+      - Thu, 28 May 2015 01:28:14 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:59 GMT
+      - Thu, 28 May 2015 07:28:14 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:59 GMT
+  recorded_at: Thu, 28 May 2015 01:28:14 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:07:59 GMT
+      - Thu, 28 May 2015 01:28:14 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:07:59 GMT
+      - Thu, 28 May 2015 07:28:14 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:07:59 GMT
+  recorded_at: Thu, 28 May 2015 01:28:15 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/eb%2Ff4%2Fa7%2Fc7%2Febf4a7c7-589f-4649-9e05-34b070d81d72
+    uri: http://localhost:3000/annotations/22%2Fed%2F8d%2F3d%2F22ed8d3d-7144-4f63-b8de-72696ed3d649
     body:
       encoding: US-ASCII
       string: ''
@@ -2481,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 644383b9-dc6c-4648-b36c-9a00d77cfeac
+      - e1b94580-87d3-4160-b128-d9ed3b934fd0
       X-Runtime:
-      - '0.179508'
+      - '0.197610'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:08:00 GMT
+      - Thu, 28 May 2015 01:28:15 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=WjFJbDB4UDdOT2lTbUhDWHkyVlFpTUV5QmsrZFlOTUxWZk8zNnhjU3ZsWVBYcUd6VlVTSUkybGVudkZ1OElXL28rSGlmZXpFdm00L0ZFY0Y2TVlTcVVQRmUyVGtFcm5FNmxxVHhpK3hJYVVRaDY5cU9WamxBY1ZwN0NNOXg1RDFjSElZcDlUcDhlOFc1YUI0a1ZLVGVGL2dERTdiNlNqYzg5a1dsMWxzS3Y1djlwUG51aTFJV09TU2V2SUg4bWN1LS0vRzJnOWhSODYvc0hqSUFtQS9SQmhnPT0%3D--5ff5a227d935b3f6df1057d576ceb9023f08872a;
+      - _internal_session=YVRpQzdmY1NCRHV6UkFMSGJpL281TmFCUXRVUXFkN0JpQUVUM2x1c2ExQmtTOWZXc1VkeU1JcmxBUkMyMkpOVWkrYUg2QUR0N3F1aURXUDJlakJTaFdxVFZSUEZSQnBWNlcveXB0N1F3VWl2T3F3MkIyeGh1U21YTmVlSWg3aXVnZm5keHNCQis4a1grRGtSVFpjWWo3MlFtdE5hYXRLdkRWK2RmSk1jbWpWb2pKeWtnM0JZZEJiRGRkMnRyeld0LS1KMGJxWWQwY1RCMWVHM0EwaUtBWGZnPT0%3D--2a4cfb4f04020e205ba566764217dd1b2fbfab2c;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:00 GMT
+  recorded_at: Thu, 28 May 2015 01:28:15 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/without_content_type/checks_the_annotation_ID.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/without_content_type/checks_the_annotation_ID.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"ed53c954929112a620834a1820e30598"
+      - W/"e8a3a66c5ce9493aae3c1e02a93c148e"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 3d9f1752-0b8f-499f-981f-df3d98b7a96f
+      - 7c2ba3ac-aaa4-494b-958a-d029404302f4
       X-Runtime:
-      - '1.623929'
+      - '2.245361'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:08:30 GMT
+      - Thu, 28 May 2015 01:29:53 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=SHAwZU5HQUxiQUNoUkZWZVhBUStFWCsraElWYmpJWkQ2K2VFQUJjU3gzYUlyL2dValZIMWVHL09jWExQQjMxZlhxMVZuUytXNjJnOWN3YUh2MlJmdG1MZzFTMXkxTThaQnVYeFhvRDkwUzJXT3ozWWJscSs2VEJ0cEE4aUFzejAzT1dFMm03OUkzR0ZXaFZCRW5RRWRtVlZCQm9LR1B3L0d0UmE1NU15WUhJS3FyU0FpbjQrWUs4YUFjaTlwQTZ1ZXhkbngrZFVsMXVLTDU4NEJVbDdLTUQzbW0vWUVEMjdtb21SbVpEL3BFODFKNS9BcU94dHlBWlI3cmJMTU5KMC0tNEZXR3NoQ0lZdWVhSHBuWUY0SG83UT09--068f8736e5897b4781bdc433c7c32c64e1b42dd7;
+      - _internal_session=MVdPcnFKY2FrUitBOWlrNGNEUjJPTWs1RG1FeXJKcUxydndDL3Q3ZFFoZDRhKzFFYU1md3B4RXVpTmFmWXlhVGQ5UTk1dlBtYUhBRGQzWHkwL0RESmJQd0JLdk5ZTEFCbEliNFpvWW82ejJ0WG1IS2hKK3pFZXhOUWM0VHp4ZlV0ZXpKY2wrVW1zTXRlY3RiQXQzWmt3K2xpRXR0S2t6VHBqSTQ4V1Rodm81d3N6d1Fpc05CcU9RTFBXcnplVWlRcy94LzZYbWFKMi8wOE9JRlYzWUdFUGZRZ0JWTFJGY2JrbnozbjRoRnpFOG1zTVJ0K2lkdHdPR3IzREZnT0Yvdi0tcVlaMSttNms3UzFMUlJtVUgzTGJIdz09--115537ec433962a45a0e0f527f59e691f82d5495;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310859125340","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/16/a3/cf/e8/16a3cfe8-f1b6-4b98-ac60-4d0fdb857a66","@type":"oa:Annotation","hasBody":"_:g70310859125340","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942002477580","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/88/27/92/6c/8827926c-9c4c-4976-ba69-d13ebbb7672a","@type":"oa:Annotation","hasBody":"_:g69942002477580","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:30 GMT
+  recorded_at: Thu, 28 May 2015 01:29:53 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:30 GMT
+      - Thu, 28 May 2015 01:29:53 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:30 GMT
+      - Thu, 28 May 2015 07:29:53 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:30 GMT
+  recorded_at: Thu, 28 May 2015 01:29:53 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:30 GMT
+      - Thu, 28 May 2015 01:29:53 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:30 GMT
+      - Thu, 28 May 2015 07:29:53 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:31 GMT
+  recorded_at: Thu, 28 May 2015 01:29:54 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:31 GMT
+      - Thu, 28 May 2015 01:29:54 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:31 GMT
+      - Thu, 28 May 2015 07:29:54 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:31 GMT
+  recorded_at: Thu, 28 May 2015 01:29:54 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:31 GMT
+      - Thu, 28 May 2015 01:29:54 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:31 GMT
+      - Thu, 28 May 2015 07:29:54 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:31 GMT
+  recorded_at: Thu, 28 May 2015 01:29:55 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/16%2Fa3%2Fcf%2Fe8%2F16a3cfe8-f1b6-4b98-ac60-4d0fdb857a66
+    uri: http://localhost:3000/annotations/88%2F27%2F92%2F6c%2F8827926c-9c4c-4976-ba69-d13ebbb7672a
     body:
       encoding: US-ASCII
       string: ''
@@ -2481,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - be0d9215-ecdc-4dac-a39f-d60e9b46da81
+      - e2e66cb9-5929-4b0a-b0d3-1e025fc41565
       X-Runtime:
-      - '0.238257'
+      - '0.184384'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:08:31 GMT
+      - Thu, 28 May 2015 01:29:55 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=ZUVTM0xyVm9qRThGeE5HNUtQdXN3QWViRGZhMmQvUkQ4OWphZ08wbjBTZU96U1BRRVJ0ZFJXb0tRNlY3aUFKWHY5LzBvSStTblJneHpLMmxFUjJyeDd1T1J1dElKTFBIbnRTQWNIeHNmQUVxWlQ0VUtaYWh3cjB3UVZLa2dzdWtBT2JvcjliTnFGVElSVHpoNlA2eDF1UFRNbGxHQVd6U0VORnE3dEp1aGlyWDNrMllDVWdoQ2ZiZmdHVUltSkdTLS01MUZiZzMrZitHYTcyMHM0VFh3cXNnPT0%3D--a25b1e7deaf9a6f0327988513ef0b31dcf601a84;
+      - _internal_session=eGVoK3RVM1RPRlEzaWhkY3htWkh2Sjc4Y0FqY0c3UUFJa3hjekw2NWliTVFvWEdJVm1SdllaMDJRaW1OZitENG40ZTNyTHNhckFPLzQ0OENyTmZjQlRpYlUvSExzbDhGZ2hScklxZjdrSW1CbStQYmpzRzFrdGxpYzV4cVpQNU9xREs0OVhZVHoxdys4VGpyZE5VbE9KWHNyQ1lISjNpOFRvWFJuNnN5ZVVzcldzRTVDL3YraHdwVGhTdThyNVRRLS1NazBvMldvM01qejNMWEVKRThUQmp3PT0%3D--8a5eb0eb4f2cc8a160a64edd6fa99ba3172377a3;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:31 GMT
+  recorded_at: Thu, 28 May 2015 01:29:55 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/without_content_type/logs_exceptions.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/without_content_type/logs_exceptions.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"14bb5ce40e11541ca0c331bc84b51bf8"
+      - W/"c7dd359a6f3e225ba152b611843b4dab"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - c2ef969e-acda-465c-9cdc-0bce30f65fdd
+      - a039bb2d-b718-4174-a1b7-05e34211f295
       X-Runtime:
-      - '1.732281'
+      - '2.005802'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:08:55 GMT
+      - Thu, 28 May 2015 01:30:25 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=QUwvbWhKZGlwdUtMeDhTZjJncTFyODYxOWtocGFUUUo5VzVBOTk2L081UHhMR0FueUxMR3lMVHBFa1VHYXhqWGNmSDd4aGJPbHpLZlhKdW9rMkw0a0dZTTNVNUx2dmlpNTVUN1E2WFc1Nk1WSkhldWNaTWF3T1JRZm5acjdMQ1lSM21MdGhBVkQ5RE1rZlJUN0ZzeGw2Z2pPK0JoYU5XUVBwSlBkR1JSNTM0YUZ3bEs4TGtlOXE2V2RtcjJibGxJL2NMSW5XQ045RFdESFVaVWFDa0E0K2V0UTYxM0M0SlVwV2JaWEhxNzAwQW8vQWU5eDN1Y3Z1MTR5MjBnNnNtLy0tSnBka2xNYXozT3lZRDNTWDlSTkhWZz09--236ba8d17883e23613fcbe0e02433e912ccbcec0;
+      - _internal_session=VExibmNtRVlPelMyRGtTODh3eVMrUXROQ3JoUFVsRUJaYVQ3V3hIcE1taGlJeTcvMGxkZlcvZ3pubEg2WkpKdkd1NGxqUDd1eWk2bFlVY3RBd0hKWWN0Q3I3RC9NWmkzQUd4NVBwNllaZXI2YVpSWW51UFpVN0VBeWZaN20yQ0VoTjZqRWFhSXhXWE1oK0pOd2l1MWR3VksyZ005QktGcmRReXpnNDZOVFpNeVR2T0NWTlFjcGNJNFNDOU1ET2lMdkYxenlWdTR0QWJYYXU1RDk0TFQvS0NyQ0c4K2xXdGFMVEY5Mi9oWXRNV3l1T0l6Zk1neTJaNHB1WU1mQVhPRi0tNkZyWk5NbC9rQkZISFF3V2c5V1hwUT09--03da4523987785aa9845d8ce10bb70a3ddce10d8;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310858147740","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/4e/52/bc/20/4e52bc20-d3d4-4f47-a5ad-e23d28d2e7cd","@type":"oa:Annotation","hasBody":"_:g70310858147740","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69941861485340","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/22/d0/3e/59/22d03e59-263a-480c-b041-41acc67ecfa9","@type":"oa:Annotation","hasBody":"_:g69941861485340","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:55 GMT
+  recorded_at: Thu, 28 May 2015 01:30:25 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:55 GMT
+      - Thu, 28 May 2015 01:30:26 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:55 GMT
+      - Thu, 28 May 2015 07:30:26 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:55 GMT
+  recorded_at: Thu, 28 May 2015 01:30:26 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:55 GMT
+      - Thu, 28 May 2015 01:30:26 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:55 GMT
+      - Thu, 28 May 2015 07:30:26 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:56 GMT
+  recorded_at: Thu, 28 May 2015 01:30:27 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:56 GMT
+      - Thu, 28 May 2015 01:30:27 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:56 GMT
+      - Thu, 28 May 2015 07:30:27 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:56 GMT
+  recorded_at: Thu, 28 May 2015 01:30:27 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:56 GMT
+      - Thu, 28 May 2015 01:30:27 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:56 GMT
+      - Thu, 28 May 2015 07:30:27 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:56 GMT
+  recorded_at: Thu, 28 May 2015 01:30:27 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/4e%2F52%2Fbc%2F20%2F4e52bc20-d3d4-4f47-a5ad-e23d28d2e7cd
+    uri: http://localhost:3000/annotations/22%2Fd0%2F3e%2F59%2F22d03e59-263a-480c-b041-41acc67ecfa9
     body:
       encoding: US-ASCII
       string: ''
@@ -2481,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 772c987d-f7df-4bcd-9201-b6b7ed317256
+      - d8896372-b451-4e6a-9aa9-1c4a9fa1ee89
       X-Runtime:
-      - '0.187622'
+      - '0.242178'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:08:57 GMT
+      - Thu, 28 May 2015 01:30:28 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=cjlia3Q3cFBJZWR6dTZoSGI2YzVTL1dVSHVWQ3A4N01Kb29nZEwybldyRHRNZHJxMWExYW0walJVZ2lkdVMxODYwSCsyUEVhY0NIOVJJNlZDT2tUclVCTU9QTlVrOFJudkdFVWl3em1LUjJoejlHbEtxaU1YL2oxZFYvTmkybGtIaHczVThJZG1pUlRIZUplTnRqNm9DaTBZdDRwdUxveVBUQ0pocC84NThiT2kvUW5WWkJCdFZHd2VxNVRIelczLS1uY013Y1VwUVpNOUxXcnh3WUFTaE1RPT0%3D--eba459b722a475e145686007c10243d6fa3370f9;
+      - _internal_session=Q2pQUzh3dDNSQmJ1RUdyUFllQkIvdDdRTTVSdFpaeEdFVldOcHlPTFFJeHBIc0ZKSFh6elU0L3ArY3FOOWJQNFAyMGFwOUx4bVF4TCtFL3pHYUhaeFRwM1IvK3NoUlF5MWxNMkhvR2ZJVktuNjFnNnpsODBXOWZiZGdMVGdST2FuZlVaUFpzRUZ2RFBkMGxRM1FqMFQ1R29sRmlqcFBBNlBuT1grVWhxaHVQdVFEcHhKcDB4Q0JTVkFMNjNvKy94LS15S3ZLZU1FZzlSbERxaUlnNzlpNUdRPT0%3D--89c8a552f98d2e2c62640a09f7f2541a6392ffe2;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:57 GMT
+  recorded_at: Thu, 28 May 2015 01:30:28 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/without_content_type/raises_an_argument_error_with_a_nil_ID.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/without_content_type/raises_an_argument_error_with_a_nil_ID.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"cbf64771f83c64befd9a279a33078758"
+      - W/"743a63a0d71885d01ecf803ff46af3ed"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - b1258a19-6e81-4fdb-9579-9a3ba2b366c2
+      - b3a4302b-23f9-4402-ae35-dcdfcf27ebd7
       X-Runtime:
-      - '1.762966'
+      - '2.307416'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:08:33 GMT
+      - Thu, 28 May 2015 01:29:57 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=bzkzZ2VWQ2hOL3FwT1A4WmFYN2U2QnoyUTBXOEpYeVI3NTNaUEtzTTUxVm5QYXNtTUE4R2MrRVJSMW1hZkYxQWRjSE1OVUNKOW4zcitjUmt0ajZFbFhncEQwOWM5bThROHcvM0NvL1JQVVBnRUpWSUs1cVdveVMweXNMYmlxSkJ2TUpMWW5Pb1NURmU1T3pFTllPU3oyTk9HZlZYMUNZU1p5OXUzeGdPckZmWlJocjhLcENGS3RRaDRCQ0ZGKzhHWUJqVUFTd1N0SzlXOW4xUVo1TWgzalNNOWMvWG15c0dsb2lOTE1QMExOSG5zUW1aQmpCMERaeGUwOENTRk1yTy0tMDlqWWZ0SmlORHdLNVJ1V0tlM25ZZz09--e59147fdd0842f293b7374334cb863a340c3c564;
+      - _internal_session=NHdrQ1o5bkVMVjN0N1BybENSVnRyRHFIeTZGK3ZrWDVsME1USUlNS25pbHgvc3JKVmpFb1h6RnFZZGNDMlN2T0NwK0RCS0ZRaWp4UDZqT21hOWxMdjIya1NrWVBnUHZzWVFpY2Y1bHdudCtXbjVPdDBUQUtlZTR4S1E2ZTVNdmhyQjBsdGtIOWZuejlBUExwOXBDNC9OdEFFT2xIRXVQcGJDR2QySmRxMGVoUldKeFJWbHhZSHBOOE9OdGQzc1BmR3ozdW1GNWRrbytCeDBncDNmQXl1NitUbmdjSWgyTm1SUnI0aVRrVzcxK200TlliVzF2OFpacnJmRG9RU2poVS0tc3ZXeU53UGFLRTF4UVFFSFgrTE0xUT09--fa82dcf76ad450fe7dbebd6713cbf30218f84d1e;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310885229380","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/20/6d/03/a2/206d03a2-8b7b-4dac-a2c3-85af31a3223b","@type":"oa:Annotation","hasBody":"_:g70310885229380","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942008860620","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/6d/ab/c5/cd/6dabc5cd-c647-4959-ac3d-dc71f39945e1","@type":"oa:Annotation","hasBody":"_:g69942008860620","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:33 GMT
+  recorded_at: Thu, 28 May 2015 01:29:57 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:33 GMT
+      - Thu, 28 May 2015 01:29:57 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:33 GMT
+      - Thu, 28 May 2015 07:29:57 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:33 GMT
+  recorded_at: Thu, 28 May 2015 01:29:57 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:34 GMT
+      - Thu, 28 May 2015 01:29:57 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:34 GMT
+      - Thu, 28 May 2015 07:29:57 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:34 GMT
+  recorded_at: Thu, 28 May 2015 01:29:58 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:34 GMT
+      - Thu, 28 May 2015 01:29:58 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:34 GMT
+      - Thu, 28 May 2015 07:29:58 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:34 GMT
+  recorded_at: Thu, 28 May 2015 01:29:58 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:34 GMT
+      - Thu, 28 May 2015 01:29:58 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:34 GMT
+      - Thu, 28 May 2015 07:29:58 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:35 GMT
+  recorded_at: Thu, 28 May 2015 01:29:59 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/20%2F6d%2F03%2Fa2%2F206d03a2-8b7b-4dac-a2c3-85af31a3223b
+    uri: http://localhost:3000/annotations/6d%2Fab%2Fc5%2Fcd%2F6dabc5cd-c647-4959-ac3d-dc71f39945e1
     body:
       encoding: US-ASCII
       string: ''
@@ -2481,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 47a3352f-e1bc-421e-81b8-4884678d4e5e
+      - 99b7f185-0bae-4d5f-bc87-fd2a41501a82
       X-Runtime:
-      - '0.209510'
+      - '0.209763'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:08:35 GMT
+      - Thu, 28 May 2015 01:29:59 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=SHA0aTRmZkpRakRCWkFrYWNKMSttODdMRnlUNFhmeVdrQ0g2aDhLVFNTd0t5SFI0dXJSZTdGYmpsVWlTQUJKOUJlenhUWFd6eVBmSGhzempoME9EQ1RlNk5ERCtDTEtaVk5xWEQ0QnByaDhxTU9sWGpzNEJZb0xSQmw1OExJT2tzRWJMRStIN1JIS3NiSEl2Z3ZBZjAxZGphL0hrVTAvd3FucXlucUQrbnZzTU9MeTQzSHZXRVhVbDVlejVzeVBBLS1ZTlM1cHV1MEREMDcxWFZJU2tDVmZRPT0%3D--534f079783b679903ae456a9d0f53dee68a067e1;
+      - _internal_session=T2xHT1h4anlnekFQMnV6dHI3WmR5UnBobGxxRjBlSHhJajJuSlMzb0VOUnBUdkd3YzZBV3ZKaUhOK2djSVZsNTdTT0xhTlNZNVExTkF5bkE0TUN4RWJjaGFFR0JUS2Fkei9vY1VYYVlNRWNoMTB3czBON082YW1aMVgrQzlzaHdWbXp0anZoNkwwdkR0b1RWbGMzL1p2M3ZVM3JLWVhKdVNtaE95NitIbEo5SlVjTDZDTjZTdGE5cURxZm91bU9xLS1sektKM2NPMFJ5YkFiRzI0a1RmeGRnPT0%3D--cd1c9bfc6f5f5e1852ad07dea457e3b2368c8d84;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:35 GMT
+  recorded_at: Thu, 28 May 2015 01:29:59 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/without_content_type/raises_an_argument_error_with_an_empty_string_ID.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/without_content_type/raises_an_argument_error_with_an_empty_string_ID.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"1163480d56fd5cf9fec01801e83b12b4"
+      - W/"daad664503f3dcc9078321c20dbed651"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 0963b00e-e123-4fea-8871-81053048fd91
+      - e118bff7-f662-4dc2-b68c-ce58c93cf34f
       X-Runtime:
-      - '1.682352'
+      - '2.181370'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:08:40 GMT
+      - Thu, 28 May 2015 01:30:05 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=MDYxSnlVRmFjdXNYdjBFbTBHVUVxWC8rVVRQaU1raGRWbGlJdWFSdjFsdHQ2MlNvRDg3ZFVjbUJHbXJnbHM3T0VFWWd2dTVOcTBJMTc3TGI4S0Z0SE5XWXEzZmZ2MFhkUFkwREJjc0duRkJJSkxzRFF5Rlh6ZGdsOHNqMjZKQlR5RWNqWUtSVjBPRXpWelRTM2pBQk9PdkRSamFUY1N0OVFSNmZ6OG9UcXZDYVNoZlVlbU04SVFtbmtGN3B2Znd0UW91clBNMks5THErZ0FkOHY1R05FOGFpRjBBUGpRY1NyTm9kRWU1QnAyNytXWXJXM0w4UnVnc0JVaEl0dGdUYy0tMFNzSnhzNnRvT0JVMzBCWWc4OEM0UT09--445cb0d3dd19fce5256b5ea845bffa926670ebf3;
+      - _internal_session=TXNIOUdyMGljbkNZOGttNlhXOUNxYXlhQVVDVzY5cUVFZUIybFFtVldIYTFPZ08vc3FSSkFyRUhVcmRyMXJmbkVjV1ZxZGdzSDE5RVhmc3oxbVZzN1hDQkZYeXJFWERYOENXUE1MdVZIbkNvZWRQbzBuZS95VjdqSjJPK3FxbEFqUDFFRTIweTJJMDRWeVZyQnk5aVpCbmQrTXFLZ3o0dTY3VmxCbEdCQnhiSTE5cnpCSUk3QS8rYTRrTVljL1YrcW5KVTIydndURFdtUW8wM1VvalRzOVM2TzVURkxMNCtWdE5IMERsdWJBY3BOV2FlMmp3K3FTeVhLdEcxcmJpMS0tRVBrRk12WXd1SzZkdm5zc2kyT1lZZz09--bf924b4fb1e8f0610fc6a79b743420b1d433f4a6;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310887105780","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/94/94/72/ee/949472ee-d00a-460d-bb73-656ec32a2bdf","@type":"oa:Annotation","hasBody":"_:g70310887105780","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69941853424080","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/4f/09/ab/0e/4f09ab0e-80ad-437c-ac84-34d045d60da7","@type":"oa:Annotation","hasBody":"_:g69941853424080","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:40 GMT
+  recorded_at: Thu, 28 May 2015 01:30:05 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:40 GMT
+      - Thu, 28 May 2015 01:30:06 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:40 GMT
+      - Thu, 28 May 2015 07:30:06 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:40 GMT
+  recorded_at: Thu, 28 May 2015 01:30:06 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:40 GMT
+      - Thu, 28 May 2015 01:30:06 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:40 GMT
+      - Thu, 28 May 2015 07:30:06 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:40 GMT
+  recorded_at: Thu, 28 May 2015 01:30:06 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:41 GMT
+      - Thu, 28 May 2015 01:30:06 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:41 GMT
+      - Thu, 28 May 2015 07:30:06 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:41 GMT
+  recorded_at: Thu, 28 May 2015 01:30:07 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:41 GMT
+      - Thu, 28 May 2015 01:30:07 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:41 GMT
+      - Thu, 28 May 2015 07:30:07 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:41 GMT
+  recorded_at: Thu, 28 May 2015 01:30:07 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/94%2F94%2F72%2Fee%2F949472ee-d00a-460d-bb73-656ec32a2bdf
+    uri: http://localhost:3000/annotations/4f%2F09%2Fab%2F0e%2F4f09ab0e-80ad-437c-ac84-34d045d60da7
     body:
       encoding: US-ASCII
       string: ''
@@ -2481,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - c9cbb180-5c0b-4ee9-9102-e30da22d141f
+      - 730d3fe0-6480-4b7b-b878-02e354a95e56
       X-Runtime:
-      - '0.201419'
+      - '0.342428'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:08:41 GMT
+      - Thu, 28 May 2015 01:30:07 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=Vnl3MUYvRFlwbVNzQ29oN3VwK1hyaFY5VGhobFM1NTdZVWtCQ3BjRnFIdW5HaURLdzRiUlU1dE9RY3orL2JBZmU2VnJXbWVwZ2dyUm81T0JyTGF3cUE2MjJPOUkrMmpRK2J0V3QzSTgyWXJzb0hRd0RQV3p4Sml1RXV5dklLQ1htRkdaZkltaTIrcTQyY2FzcGQ4Y3BEQ1FqTGYyMjFKZElwckRJVFgybjJmVlk3VGpMOWdabnZZRVhDK3V4SytVLS1YRVFKdERTZEtPbGMzQkxtNXN5RmhRPT0%3D--b7413f6a3255a3d84a718fac1aa2b8d5b591c504;
+      - _internal_session=cFplVTBUeDNXTENweHV1OG1PbTFwN25wSnpyUFoySFNCSGs3WkxrTkhWbEljYmJwQUw0cjFNOWJXeE03Q3BFZ1hTamtHU3pvdGp2SlJFdS9ST0VET044bm1VU2cyMXdRZXl1NFVUNk1RNGswVkVjOXBWVjdJWWJmMjNNNEY3czlYTmRLeHN0TVNvbnc4RFRQVFljRGZxU0dnaEZuSDFxQzg2bU1IWjVUSGRGQll0RDB4MDEvUDRBWEpKYjRnVCtuLS1HeFBZUElVKyt2aEozMjhkYUM0RERBPT0%3D--5f3b1353f514a9950951b9f4ecfc601e21d53cfb;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:41 GMT
+  recorded_at: Thu, 28 May 2015 01:30:07 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/without_content_type/raises_an_argument_error_with_an_integer_ID.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/without_content_type/raises_an_argument_error_with_an_integer_ID.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"5bacd03a8af0b97ec900e162bf379698"
+      - W/"ba35aaa8ea9884f687ccc6db41d8a449"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 4fde2adb-6a28-4f63-ba5f-f1b78edf454f
+      - 22afbf64-2b26-46b1-86fc-6705b9d626f9
       X-Runtime:
-      - '1.646171'
+      - '2.248953'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:08:36 GMT
+      - Thu, 28 May 2015 01:30:01 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=NXI2YzdJSlhldERlNzdRUWN3RnVZZjZmSkxTK3NLVW5qZ1RvSFJvb2V3Q3VZT3FuSmVhY1d5YUdRbzZWaWYzVzZTZldLSTJmeURwbEduNkFuQjcvdUlmK3ErVFl5SndWZkY1dzNRY0lhR0hwYjNhT1dRU255bjU1anpObDN0bFVCUWxZT1k4T3pmZjlobFlaUkVtYTY5bk43QlpHU01HbU4rdVg3UzRzd2tyTk9UcElvNFQ2NTRyR1V0Y1Z5cjE1U3h0TVAvcy9nalNYSXpqb1ZUdk1rUXV1YzY1cmtTcGxPdmxlVjlFZFFNQ0xDd1dnR1FDWXpTK2Y3UHY0Skp0eC0tU05OOXNRc1loci91THFSYVpzZ2xhQT09--7faa4ebcc3f20aed1bdebef3625f043c31906bee;
+      - _internal_session=N2dVbkw0OXhTV2VrQ3ROdVlYN285Z2xrUDlqQitpa29EU2ppdmtEVFpEQm5ETmI0UUMyWUV3ZkorM3Y2a2V2YU5xVTFIeXpiL0lqQ3NkT09oajhFaHBPZkpoVVRPSi94V2lyMzhNWGZsNUJLV1JqRUl3Z3ZLcXhoUmhEUEZ2NWlHLzNuNzlGRUlMTDEyY2RiaE5kRFoyVFBPckIyZXM2TmMxMEFRSFJPY0RQeFhVUTJqUWdYYStoVVhOMkNkMkJzTjhQaWpVdE9naVllMGNVaEJCL0NhMksxTVRvZCtERFBxSlg1Rldkc0h4VStrTUd2Q2RlUFdHTEZBbXNGZ085SC0tUVUxMzA1SzJNaE9GZXRwZk1uVUlSUT09--bf013a6b1c576aca1cc493953dfa102af0e90607;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310851299500","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/7c/51/e3/90/7c51e390-22e6-4ce9-a516-a61111662960","@type":"oa:Annotation","hasBody":"_:g70310851299500","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942027223120","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/56/e2/cc/51/56e2cc51-794c-44ce-badb-963eecd23eca","@type":"oa:Annotation","hasBody":"_:g69942027223120","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:36 GMT
+  recorded_at: Thu, 28 May 2015 01:30:01 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:37 GMT
+      - Thu, 28 May 2015 01:30:01 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:37 GMT
+      - Thu, 28 May 2015 07:30:01 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:37 GMT
+  recorded_at: Thu, 28 May 2015 01:30:02 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:37 GMT
+      - Thu, 28 May 2015 01:30:02 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:37 GMT
+      - Thu, 28 May 2015 07:30:02 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:37 GMT
+  recorded_at: Thu, 28 May 2015 01:30:02 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:37 GMT
+      - Thu, 28 May 2015 01:30:02 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:37 GMT
+      - Thu, 28 May 2015 07:30:02 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:37 GMT
+  recorded_at: Thu, 28 May 2015 01:30:02 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:37 GMT
+      - Thu, 28 May 2015 01:30:03 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:37 GMT
+      - Thu, 28 May 2015 07:30:03 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:38 GMT
+  recorded_at: Thu, 28 May 2015 01:30:03 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/7c%2F51%2Fe3%2F90%2F7c51e390-22e6-4ce9-a516-a61111662960
+    uri: http://localhost:3000/annotations/56%2Fe2%2Fcc%2F51%2F56e2cc51-794c-44ce-badb-963eecd23eca
     body:
       encoding: US-ASCII
       string: ''
@@ -2481,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - c663da6a-3f7d-4fe2-a06b-4782aad756d6
+      - aa8c479b-ce4d-4506-85ac-db882d19a610
       X-Runtime:
-      - '0.199476'
+      - '0.197880'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:08:38 GMT
+      - Thu, 28 May 2015 01:30:03 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=Y2lLRVlkb20renFKUVJ6bW1KdXdkN2NsdkhUVVJ1NVM3L0ZxZU1DcE9mQnZDaDExL0xWL1M5TmFuOFdoVm4wZXlXNC9oYmZwU1NWZWJUNlpQTkd3R09PUjVzL3A2TEhGcE5RWHFSVk93RlJvUklQK2FKdTZWeEVnTEwrNC9lOGlvOGNqVS9mWVRuSlVFYXFxdjdVKzE5UEFRWGU0RDNEVVBZdXFiZXNIMU55RitjRlBpZnpYQ3dZVy8xZkN3dVJRLS04ckxFYVBVdGw1M3lENkhOZEx2ZW93PT0%3D--48f9925debb90a580410ef37049654e81faf2089;
+      - _internal_session=R2tOdzJRTnpGWm8yc29rVEF5SGJ6RFluK2Ztb0NvTmtxcGZTNmFoWmFKMkVyV2NSeW5pbzVESy9NSmJIL0Flcm1ORWc0cDRGb2g5SGhyWm1JSFgyOWdkYkRLZjBVaGtJUVEzaC9ZanlmMnE1bEtXU0MrYVRFaVpYejlib3oxMzF5OWc5Z3pvY3V3WXYvRDRrdVZhYTFUUFU5VjUrdXBDcWc4cmtlRWhFVWJuQXNtdE1XcjFWUGIrS3FLVHFRNlVaLS1IYytrUzlrdUZoZ3ZOSHQxRmVFQkNRPT0%3D--413b961f7f257d6c13b0e37bb8be01023e19a4ad;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:38 GMT
+  recorded_at: Thu, 28 May 2015 01:30:03 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/without_content_type/requests_an_open_annotation_by_ID_accepting_a_default_JSON-LD_content.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/without_content_type/requests_an_open_annotation_by_ID_accepting_a_default_JSON-LD_content.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"9006d859837bbbf9a744e4fa19407c40"
+      - W/"22eb3848c5e2c1822e359696d2de0d93"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 2055f13c-b6f9-496f-8b6b-316b122fed66
+      - c54c13cf-4e61-4626-a27c-c3e1ca77c1a0
       X-Runtime:
-      - '2.028142'
+      - '2.250605'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:08:27 GMT
+      - Thu, 28 May 2015 01:29:49 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=c1VpcURBV3VKRkt0OTRmNmxwSDd2N1dNbXIzWnJmaVJGelN2a1ljSGpORGlPYVNMbEVOaTM2bVZtVzI1Z3lyUHZIRERLSWZDZlJvdURrdnR5YWN1RG1Ib2k1QThYdlBES0ZXNmVERVU3SVhRY3RscVd6bjQwaEpQa1RqV0o3UStrdmFaVTBxb1FxMjBQTmdRa0Q1eklKS3ZNQW91Q3kwTmU4cmFKRHlCSmVzODBxNDV5SjlvQzAzWXQvZFFSRm10b2tBZVVMRERQbFFkc3ZvYVlsNHA3dkdhKzVlVmhHU250cW1BU1pjNXVRSFJ1SGx5ZUNVdTlEa0dEWDhkcDc1RS0tZmIwNnFkVzFSMDZXM0lVdW4yODJwdz09--cd9e44cfa47122a16fb8aba6918e8ede0e8b692a;
+      - _internal_session=Tkc5bSszVEdWZDl0MFBZRi9EOGlwaGZJamJWMDd0NDMxeGFEMG5NUlZ0eW52T0M1c2JUWTVMcElRUFhlNVkrektoNjRZazdDWHZ4RXpPYlEyMlZQclk4emtibnlxb3pqRzJHNitYM01zMXZyRXRtdUZha1VXRGNJZ3FMdzhCZFZxRlEyK241MFFWa1RhTHgySVZTeFJOeHV5dDd2V3pmcGRzZGJobkd5VVhtSTFiNE1ZUk5aeFplODN3S3BKbEQ1VkEvOGZYdWcxZU0rVG92Y01RSTJ3bDdMY1l2R1NtRkZraG15eHB2c05PLzdpcUhXZ1JiVVV3ZmxqcStINEREWi0tNlJ2TTVvY1U0NjNHTFJsSnd6UmF6UT09--1c0de24b8688dae66668fd7b655a2faa3dc11eeb;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310883476240","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/49/48/a8/95/4948a895-1b34-4303-b68b-6706ae42e2b7","@type":"oa:Annotation","hasBody":"_:g70310883476240","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942035583700","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/a1/8b/b7/a6/a18bb7a6-9b6b-439e-9882-1fb700540b7a","@type":"oa:Annotation","hasBody":"_:g69942035583700","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:27 GMT
+  recorded_at: Thu, 28 May 2015 01:29:49 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:27 GMT
+      - Thu, 28 May 2015 01:29:49 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:27 GMT
+      - Thu, 28 May 2015 07:29:49 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:27 GMT
+  recorded_at: Thu, 28 May 2015 01:29:49 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:27 GMT
+      - Thu, 28 May 2015 01:29:49 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:27 GMT
+      - Thu, 28 May 2015 07:29:49 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:27 GMT
+  recorded_at: Thu, 28 May 2015 01:29:49 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:28 GMT
+      - Thu, 28 May 2015 01:29:50 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:28 GMT
+      - Thu, 28 May 2015 07:29:50 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:28 GMT
+  recorded_at: Thu, 28 May 2015 01:29:50 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:28 GMT
+      - Thu, 28 May 2015 01:29:50 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:28 GMT
+      - Thu, 28 May 2015 07:29:50 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:28 GMT
+  recorded_at: Thu, 28 May 2015 01:29:50 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/49%2F48%2Fa8%2F95%2F4948a895-1b34-4303-b68b-6706ae42e2b7
+    uri: http://localhost:3000/annotations/a1%2F8b%2Fb7%2Fa6%2Fa18bb7a6-9b6b-439e-9882-1fb700540b7a
     body:
       encoding: US-ASCII
       string: ''
@@ -2481,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 2de19fac-b118-4ad6-b20f-116f1f44b558
+      - 72914a67-e181-47ba-9702-138b64fa7f99
       X-Runtime:
-      - '0.214643'
+      - '0.213211'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:08:28 GMT
+      - Thu, 28 May 2015 01:29:51 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=STVDK0lnUTRlV2FadDVXKzJ3WlRxT2g2YlQvV0NIbWFyMGl0SFZiYVQ5dlJlQWpHVkgybDd0dStVWXFLLzR4M0pWSDY0U2NZOFdYYUdEY0UzNThNdFB5UDdWbllBU0JrMk03YVBYVFdxeElWc0hvalY0c0p2eVBMcHJlYUlDV2htZ0s4TUQ3c3R6aWgrLzdRZEdTeWt1MVYrajhDM1ZTaUhoWlV5T3VweGpaSTI4a3hoOXJ3enk5QU1ZZjhNSERoLS1YNWY5Zng3SkpDenlQdVNtYjM5UVVBPT0%3D--b762fb142a52fc4e4433ae8a51161adec6c3a945;
+      - _internal_session=TE1OajhmY1VIcmxSNnh1OGFPbk84ODVhczhmM2dWcTFud1hDUHFqTnJPNzRUaGI3elRJSHRQdi9IWGRvZzFwZkd2TkZqSzNZR2p3NUhBc3BiY1VBNWxGU0JkNmZzb2RWYXpzNXVFeURGWTQ2RUJ6MGJZeHdLOVNkQlhHNGp3dTd2eVRCN0NiWXdtWDg3c24wUkFXbmxhaE9PKzNXUGZPMlVlWkJ3R0dqRWx6KzZtVjBwY29ZaGFmeTgvRGl5eGRLLS0wZVZ6VFRvTnVVT0VLSG16ZGVjaXNnPT0%3D--fd91c36d9d377c0d5308ea2f5e164556ffbdb78b;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:28 GMT
+  recorded_at: Thu, 28 May 2015 01:29:51 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/without_content_type/returns_an_EMPTY_RDF_graph_for_a_500_server_response.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/without_content_type/returns_an_EMPTY_RDF_graph_for_a_500_server_response.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"df07f5d1aadd2ba06122ab2a601ee14a"
+      - W/"8a7d57b4f7264c45346753056fa185e8"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - de768aee-8ce9-4e1c-a5b7-5e791321a17f
+      - d4e88f44-2097-4536-a4d6-af62cede9bf6
       X-Runtime:
-      - '1.621330'
+      - '2.223635'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:08:52 GMT
+      - Thu, 28 May 2015 01:30:21 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=bStwck1VODJjK0kvT2pJRHFJcTluOW9tWkxPZ08xY2h5Z01aakRwK282RlEwWmU5ckNiRU85WUM2TTc0RjNGTUE1UFBZZkx0cE9HNDNTcld1dzVLSmVOT0dMTGY0K1ZxQktMV0QwZjNEL1VSa2x1bG8wLzJTNGdROTBYZUZsMFcxRVQzU2NSVU5HQmw1ZGoyU1VSRGw2ZWJRa3lXd0VpKzd6SDNSejVWSXFPK1Y0TDBJalgwOHdNNUl0U0hhQlhBM0NDcG9laFZJdkt2QlZ2M2FhZ21TbUdLdEZSMitTb1QydmJwSWcxSzZsQURObm95Y2Naem9jbnA1ZjFBS05xVS0tNXRNOW5KRnRkc3hNZURqSFF0L0pIdz09--a741e7733fe364d1818a5f93ff201559b250ce0c;
+      - _internal_session=VDZLT3liU2xXeG5CcWdvNTI3bS8yUkx3Vy9ZZmZOTTJQbVhXaytHZW5Xa0lQV1BZUWc3aEMyMnBuNzBUV3IzbG9iQ29wYUhtc1JTRFhLWERJdmhHanRrei9XSkZ5U2tiNTZPZXZRMU5ncHY4YnA5L1QwL2lVOWdpSTlRVDZ2UHk0WGlnb0FXYVl5SWV6eEpObENBcGlzL0Z3UDNSWUoxQlEwZzRmMzd0Lzk4VmppN1l5NExwZmh4RkRLR2hGelNFN29jdlJoZ2pjNlRGa3FYaCt2SU1pZjhUQkw1dlFBYjFlK3BselFRMStxR0ZzRFA4ZWFKRXBWNnFCU1A4QlpaRS0tTjZVM2pBdzd3R3VRejl2bTlqa2l6dz09--84ce3fa6490ca4497ae2221463d354e8b98baee5;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310886274700","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/c5/11/7e/7a/c5117e7a-25e9-43cf-ad51-e9e5469c4004","@type":"oa:Annotation","hasBody":"_:g70310886274700","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942031311520","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/c5/a1/53/c3/c5a153c3-11f8-48d1-9b41-e6b3b037c97b","@type":"oa:Annotation","hasBody":"_:g69942031311520","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:52 GMT
+  recorded_at: Thu, 28 May 2015 01:30:21 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:52 GMT
+      - Thu, 28 May 2015 01:30:21 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:52 GMT
+      - Thu, 28 May 2015 07:30:21 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:52 GMT
+  recorded_at: Thu, 28 May 2015 01:30:21 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:52 GMT
+      - Thu, 28 May 2015 01:30:22 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:52 GMT
+      - Thu, 28 May 2015 07:30:22 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:52 GMT
+  recorded_at: Thu, 28 May 2015 01:30:22 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:52 GMT
+      - Thu, 28 May 2015 01:30:22 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:52 GMT
+      - Thu, 28 May 2015 07:30:22 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:52 GMT
+  recorded_at: Thu, 28 May 2015 01:30:22 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:53 GMT
+      - Thu, 28 May 2015 01:30:22 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:53 GMT
+      - Thu, 28 May 2015 07:30:22 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:53 GMT
+  recorded_at: Thu, 28 May 2015 01:30:23 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/c5%2F11%2F7e%2F7a%2Fc5117e7a-25e9-43cf-ad51-e9e5469c4004
+    uri: http://localhost:3000/annotations/c5%2Fa1%2F53%2Fc3%2Fc5a153c3-11f8-48d1-9b41-e6b3b037c97b
     body:
       encoding: US-ASCII
       string: ''
@@ -2481,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 52ae00d8-2680-43d2-84f5-b526d37d2ba1
+      - eddcf606-7d89-42ab-a811-d3db14b85b06
       X-Runtime:
-      - '0.219275'
+      - '0.178218'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:08:53 GMT
+      - Thu, 28 May 2015 01:30:23 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=K2xPVnYwaGtwdUF6ZHNmMXQyVjdabFUzczh4bjBzVkVVVDdIM2xyajFQR3JuNTRyaXVhRHdKdllFWm1UVnBtOXZXS0ovN3ZQczRoN1hCS2tQcjRpa3ZpendwK3ZMdFFoN1F6MTJkTk56WElMYmtxNnNDeXJMbjRNNkk5M0xCNm14aFI0QXYralpwRlY2WFh4WmFIQy91Znh5NXVMdW43U0lZRVFnTnlhUXcycy9wREVkR0hTM1A0dGpEM3JoMUljLS1XVU1Hc0pFV3pMT0QxM2JMYUtuMHZnPT0%3D--677ea3394aa60d351bc7431182101c0ca62d0251;
+      - _internal_session=Z1dFV0RSeEVaMmhoSVNaSHYvc2lDKzM3Q1BjYUJKT1RRQmU0Sm5EUVNTOFluMmdMRndGT1NER0pMRjZ6QkgrN0grcWZxVk1IRHlyenVuZnRlbklsMjNpV0s2QThXZFFEblNuZnB4K3JRdHM0OG1SM09EQ3VLbHlYR2R2NittMlpsWFZSSE5wOFFPcWtFYmxENU5ZMlBoQzJDL0RmaU80WGNvVzZ1cWRhYWRwUnF1Y0dPU0JPMXFBS2d3ZHFvbE9JLS13Y0dVelRHbTJnVDMxQUZab1NIbzVnPT0%3D--6126b8dd2e96abef205b886784104dadc4ae401d;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:53 GMT
+  recorded_at: Thu, 28 May 2015 01:30:23 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/without_content_type/returns_an_EMPTY_RDF_graph_with_a_valid_ID_for_NO_annotation_on_the_server.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/without_content_type/returns_an_EMPTY_RDF_graph_with_a_valid_ID_for_NO_annotation_on_the_server.yml
@@ -2735,4 +2735,63 @@ http_interactions:
         \                                               \n<br/>                                                \n\n</body>\n</html>\n"
     http_version: 
   recorded_at: Wed, 27 May 2015 23:18:08 GMT
+- request:
+    method: get
+    uri: http://localhost:3000/annotations/3c1d8024-57f7-4ebd-a6b0-ccd362faae1b
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/ld+json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: 'Not Found '
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - text/html; charset=utf-8
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 732b4271-e718-4816-91d2-6816d5476982
+      X-Runtime:
+      - '0.027380'
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
+      Date:
+      - Thu, 28 May 2015 01:02:35 GMT
+      Content-Length:
+      - '1486'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: "<h2>error getting 3c1d8024-57f7-4ebd-a6b0-ccd362faae1b from LDP</h2><html>\n<head>\n<meta
+        http-equiv=\"Content-Type\" content=\"text/html; charset=ISO-8859-1\"/>\n<title>Error
+        404 Not Found</title>\n</head>\n<body><h2>HTTP ERROR 404</h2>\n<p>Problem
+        accessing /fedora/rest/anno/3c1d8024-57f7-4ebd-a6b0-ccd362faae1b. Reason:\n<pre>
+        \   Not Found</pre></p><hr /><i><small>Powered by Jetty://</small></i><br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n\n</body>\n</html>\n"
+    http_version: 
+  recorded_at: Thu, 28 May 2015 01:02:35 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/without_content_type/returns_an_EMPTY_RDF_graph_with_a_valid_ID_for_NO_annotation_on_the_server.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/without_content_type/returns_an_EMPTY_RDF_graph_with_a_valid_ID_for_NO_annotation_on_the_server.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"a276b286141bdc1b86ee14ef120fef38"
+      - W/"ef1ae2f4af85c3aba1428dfa3b3e9443"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 0dfa7212-8223-4e71-a588-0379ff82c76e
+      - 5e4fc341-8624-4eca-87bd-a1d4372b2385
       X-Runtime:
-      - '1.634746'
+      - '2.290801'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:08:48 GMT
+      - Thu, 28 May 2015 01:30:17 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=K0ZrWTF3MERqZkFTMDdPangrelNDbFA4Z05MbzhHa2J0bHl0eUFmVmV5ei94MWxaZWM0YzNRU0FNYlF6VVFiOWpOVnpBNkZMbXlzcHp3M1RWaDFVUVRZQllQWmFiL1dHdHhMb3FiYTI3dC9lMkNaWDhvTSt1M0lFbVdMWjlvSnFtdkJRTkwvWHNYOUFKbkxCV0ZSR0tFdUJGNWtNQXBLdGtCemRtUW93Uis5WUwwMnhqM0Y3YjloUjdIbVZraFhRelp6NDNGT0l6dzJkV0pYL2RhZGdJS1BkNElnRHFCQ0g1a1FEbkFOOHhlSVE0MENjZ2UyZWcwM0p5TC9uZndWMi0tMm9OL2pkV2ZRQmdVT0lPR2pWai9TUT09--a7aa36801200aa17a47c73a53673cd82c3acc0fe;
+      - _internal_session=RWFXWHpnTlFZWnhCN3NTV09wcHU2dkxVaXRPTVR1aVE4UVdQMVRQc205TFlrbGRYbG1zVjRsSUZuT0lwbC9IdWlCQUY3RmJSSXZEWENZUFV6ODZhT0h1ZXMreFIwSHlNNnRLQlNaQUoxWHBWUWN6MEFNUzVENXpLMGRaS2xIRUw1WWhyUXlKWDNtSTB1TEZUYS9GQXA3QkRkZ2JNN0hnNExQL2JMMm9JbW9wVlhwRm9sekxIV0dZdTREL0EyUWtLRWczbE5OY01JOXc3c0N6WnYrRDJuOFdDYUNGWHlpeFJlTllxL3RlL0R6UVRhRHE1cVFDTjE2YWpMekYwOHROci0tQlM1RDl3ZTkwSzlyUkl2Q0VnV3pzQT09--7c500e99dcb2b0d3ab6451e5ba960470f9fa0df1;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310860274000","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/52/5f/e3/85/525fe385-f54a-4c4e-9f71-5730ca559c75","@type":"oa:Annotation","hasBody":"_:g70310860274000","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942033337960","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/69/2b/04/92/692b0492-d5c6-42c4-a76b-3593229e580e","@type":"oa:Annotation","hasBody":"_:g69942033337960","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:48 GMT
+  recorded_at: Thu, 28 May 2015 01:30:17 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:48 GMT
+      - Thu, 28 May 2015 01:30:17 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:48 GMT
+      - Thu, 28 May 2015 07:30:17 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:49 GMT
+  recorded_at: Thu, 28 May 2015 01:30:17 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:49 GMT
+      - Thu, 28 May 2015 01:30:17 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:49 GMT
+      - Thu, 28 May 2015 07:30:17 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:49 GMT
+  recorded_at: Thu, 28 May 2015 01:30:18 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:49 GMT
+      - Thu, 28 May 2015 01:30:18 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:49 GMT
+      - Thu, 28 May 2015 07:30:18 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:49 GMT
+  recorded_at: Thu, 28 May 2015 01:30:18 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:49 GMT
+      - Thu, 28 May 2015 01:30:18 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:49 GMT
+      - Thu, 28 May 2015 07:30:18 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:50 GMT
+  recorded_at: Thu, 28 May 2015 01:30:19 GMT
 - request:
     method: get
-    uri: http://localhost:3000/annotations/6214ad9d-cb6d-465a-af75-3095ce9c9185
+    uri: http://localhost:3000/annotations/66d1ef89-beb9-43e1-aed7-20917817660f
     body:
       encoding: US-ASCII
       string: ''
@@ -2481,23 +2481,23 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - bcfa2c6d-dfb1-4df6-97f7-96af369d560e
+      - 214e214c-6eae-4c18-80d4-682f50866471
       X-Runtime:
-      - '0.018253'
+      - '0.018874'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:08:50 GMT
+      - Thu, 28 May 2015 01:30:19 GMT
       Content-Length:
       - '1486'
       Connection:
       - Keep-Alive
     body:
       encoding: UTF-8
-      string: "<h2>error getting 6214ad9d-cb6d-465a-af75-3095ce9c9185 from LDP</h2><html>\n<head>\n<meta
+      string: "<h2>error getting 66d1ef89-beb9-43e1-aed7-20917817660f from LDP</h2><html>\n<head>\n<meta
         http-equiv=\"Content-Type\" content=\"text/html; charset=ISO-8859-1\"/>\n<title>Error
         404 Not Found</title>\n</head>\n<body><h2>HTTP ERROR 404</h2>\n<p>Problem
-        accessing /fedora/rest/anno/6214ad9d-cb6d-465a-af75-3095ce9c9185. Reason:\n<pre>
+        accessing /fedora/rest/anno/66d1ef89-beb9-43e1-aed7-20917817660f. Reason:\n<pre>
         \   Not Found</pre></p><hr /><i><small>Powered by Jetty://</small></i><br/>
         \                                               \n<br/>                                                \n<br/>
         \                                               \n<br/>                                                \n<br/>
@@ -2510,10 +2510,10 @@ http_interactions:
         \                                               \n<br/>                                                \n<br/>
         \                                               \n<br/>                                                \n\n</body>\n</html>\n"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:50 GMT
+  recorded_at: Thu, 28 May 2015 01:30:19 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/52%2F5f%2Fe3%2F85%2F525fe385-f54a-4c4e-9f71-5730ca559c75
+    uri: http://localhost:3000/annotations/69%2F2b%2F04%2F92%2F692b0492-d5c6-42c4-a76b-3593229e580e
     body:
       encoding: US-ASCII
       string: ''
@@ -2540,258 +2540,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - dc79a40f-e875-4c2a-8478-fc4f665ebd52
+      - 51ec5ec0-83f8-4cea-acfb-3ea605d86286
       X-Runtime:
-      - '0.201602'
+      - '0.274115'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:08:50 GMT
+      - Thu, 28 May 2015 01:30:19 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=eWV1Y0dwcngwT2VTdnErN3hKY0ljYVRlUGlFZFZWazM5SDBZWURMSGhoZ1hMWXJkbnk5d1ZkOERMSnZ5Q0dwS2VtYW5mdEloeDN0eW9pa3h6OThsUlVraEp4OUtSWnRMNWE3K000d3dMRHllSlhCcll3NzZrVnliaEhscVdMMlZxS3RuaVJyMDlweS9wK3VKb1FuNUV1N3Y5R1N0ZDNmaU5jMk1sT0o4TERBUDJUSGVBdndBSi9SNFIvT3VDUXZmLS1RTDV4dkRJUG52YU9JTTR0RTJTYWRnPT0%3D--ed2ddddad750485fd0aa023f0ae155fe60ae973e;
+      - _internal_session=SHhVVUprRWlJa1grUEQ3TFBPNTh6b3JQNmNRTEN0VWoyeHFLa0llMHJleE5uTE1uSkFBM1ZRY0xOMHdMcTdQWFROb25GeCtyYWhLUDZaTml6eVFRbm5KK3R0TWNMZmFMZWFORWJKV1ZwdFdZR1VkNC96UlBWVWxCbEhUWDhFOFlKa05YT1VabWUvZnpaTHJRVnp6eVhvd21DSXBMaFhTWWlHSEZIWWpDQ3RsWVMvVWFkeHRya2s5YmZYb2xmVzNTLS1UQ3Q2V1VCOGtORUhpVnQwNEdERUZBPT0%3D--61a553a866274ee9cb8eb06eee106b0323e069e7;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:50 GMT
-- request:
-    method: get
-    uri: http://localhost:3000/annotations/5d734f85-1021-4e2c-8741-12078844321a
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/ld+json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: 'Not Found '
-    headers:
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      Content-Type:
-      - text/html; charset=utf-8
-      Cache-Control:
-      - no-cache
-      X-Request-Id:
-      - 8806df22-8c39-4b50-b838-73fb5c7f74b2
-      X-Runtime:
-      - '0.046614'
-      Server:
-      - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
-      Date:
-      - Mon, 18 May 2015 20:25:48 GMT
-      Content-Length:
-      - '1486'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: UTF-8
-      string: "<h2>error getting 5d734f85-1021-4e2c-8741-12078844321a from LDP</h2><html>\n<head>\n<meta
-        http-equiv=\"Content-Type\" content=\"text/html; charset=ISO-8859-1\"/>\n<title>Error
-        404 Not Found</title>\n</head>\n<body><h2>HTTP ERROR 404</h2>\n<p>Problem
-        accessing /fedora/rest/anno/5d734f85-1021-4e2c-8741-12078844321a. Reason:\n<pre>
-        \   Not Found</pre></p><hr /><i><small>Powered by Jetty://</small></i><br/>
-        \                                               \n<br/>                                                \n<br/>
-        \                                               \n<br/>                                                \n<br/>
-        \                                               \n<br/>                                                \n<br/>
-        \                                               \n<br/>                                                \n<br/>
-        \                                               \n<br/>                                                \n<br/>
-        \                                               \n<br/>                                                \n<br/>
-        \                                               \n<br/>                                                \n<br/>
-        \                                               \n<br/>                                                \n<br/>
-        \                                               \n<br/>                                                \n<br/>
-        \                                               \n<br/>                                                \n\n</body>\n</html>\n"
-    http_version: 
-  recorded_at: Mon, 18 May 2015 20:25:48 GMT
-- request:
-    method: get
-    uri: http://localhost:3000/annotations/ccd58cc7-2381-4532-9b58-7bf8d8ee80c0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/ld+json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: 'Not Found '
-    headers:
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      Content-Type:
-      - text/html; charset=utf-8
-      Cache-Control:
-      - no-cache
-      X-Request-Id:
-      - 6f3e1a8f-52c6-46b9-8c5c-6e5805700380
-      X-Runtime:
-      - '0.047557'
-      Server:
-      - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
-      Date:
-      - Mon, 18 May 2015 20:30:55 GMT
-      Content-Length:
-      - '1486'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: UTF-8
-      string: "<h2>error getting ccd58cc7-2381-4532-9b58-7bf8d8ee80c0 from LDP</h2><html>\n<head>\n<meta
-        http-equiv=\"Content-Type\" content=\"text/html; charset=ISO-8859-1\"/>\n<title>Error
-        404 Not Found</title>\n</head>\n<body><h2>HTTP ERROR 404</h2>\n<p>Problem
-        accessing /fedora/rest/anno/ccd58cc7-2381-4532-9b58-7bf8d8ee80c0. Reason:\n<pre>
-        \   Not Found</pre></p><hr /><i><small>Powered by Jetty://</small></i><br/>
-        \                                               \n<br/>                                                \n<br/>
-        \                                               \n<br/>                                                \n<br/>
-        \                                               \n<br/>                                                \n<br/>
-        \                                               \n<br/>                                                \n<br/>
-        \                                               \n<br/>                                                \n<br/>
-        \                                               \n<br/>                                                \n<br/>
-        \                                               \n<br/>                                                \n<br/>
-        \                                               \n<br/>                                                \n<br/>
-        \                                               \n<br/>                                                \n<br/>
-        \                                               \n<br/>                                                \n\n</body>\n</html>\n"
-    http_version: 
-  recorded_at: Mon, 18 May 2015 20:30:55 GMT
-- request:
-    method: get
-    uri: http://localhost:3000/annotations/d3a46cd4-514d-4ee2-931b-2e81c0282bd4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/ld+json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: 'Not Found '
-    headers:
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      Content-Type:
-      - text/html; charset=utf-8
-      Cache-Control:
-      - no-cache
-      X-Request-Id:
-      - 8139caca-67c3-4c66-8ef1-8de15bb9cbbf
-      X-Runtime:
-      - '0.035534'
-      Server:
-      - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
-      Date:
-      - Wed, 27 May 2015 23:18:08 GMT
-      Content-Length:
-      - '1486'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: UTF-8
-      string: "<h2>error getting d3a46cd4-514d-4ee2-931b-2e81c0282bd4 from LDP</h2><html>\n<head>\n<meta
-        http-equiv=\"Content-Type\" content=\"text/html; charset=ISO-8859-1\"/>\n<title>Error
-        404 Not Found</title>\n</head>\n<body><h2>HTTP ERROR 404</h2>\n<p>Problem
-        accessing /fedora/rest/anno/d3a46cd4-514d-4ee2-931b-2e81c0282bd4. Reason:\n<pre>
-        \   Not Found</pre></p><hr /><i><small>Powered by Jetty://</small></i><br/>
-        \                                               \n<br/>                                                \n<br/>
-        \                                               \n<br/>                                                \n<br/>
-        \                                               \n<br/>                                                \n<br/>
-        \                                               \n<br/>                                                \n<br/>
-        \                                               \n<br/>                                                \n<br/>
-        \                                               \n<br/>                                                \n<br/>
-        \                                               \n<br/>                                                \n<br/>
-        \                                               \n<br/>                                                \n<br/>
-        \                                               \n<br/>                                                \n<br/>
-        \                                               \n<br/>                                                \n\n</body>\n</html>\n"
-    http_version: 
-  recorded_at: Wed, 27 May 2015 23:18:08 GMT
-- request:
-    method: get
-    uri: http://localhost:3000/annotations/3c1d8024-57f7-4ebd-a6b0-ccd362faae1b
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/ld+json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: 'Not Found '
-    headers:
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      Content-Type:
-      - text/html; charset=utf-8
-      Cache-Control:
-      - no-cache
-      X-Request-Id:
-      - 732b4271-e718-4816-91d2-6816d5476982
-      X-Runtime:
-      - '0.027380'
-      Server:
-      - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
-      Date:
-      - Thu, 28 May 2015 01:02:35 GMT
-      Content-Length:
-      - '1486'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: UTF-8
-      string: "<h2>error getting 3c1d8024-57f7-4ebd-a6b0-ccd362faae1b from LDP</h2><html>\n<head>\n<meta
-        http-equiv=\"Content-Type\" content=\"text/html; charset=ISO-8859-1\"/>\n<title>Error
-        404 Not Found</title>\n</head>\n<body><h2>HTTP ERROR 404</h2>\n<p>Problem
-        accessing /fedora/rest/anno/3c1d8024-57f7-4ebd-a6b0-ccd362faae1b. Reason:\n<pre>
-        \   Not Found</pre></p><hr /><i><small>Powered by Jetty://</small></i><br/>
-        \                                               \n<br/>                                                \n<br/>
-        \                                               \n<br/>                                                \n<br/>
-        \                                               \n<br/>                                                \n<br/>
-        \                                               \n<br/>                                                \n<br/>
-        \                                               \n<br/>                                                \n<br/>
-        \                                               \n<br/>                                                \n<br/>
-        \                                               \n<br/>                                                \n<br/>
-        \                                               \n<br/>                                                \n<br/>
-        \                                               \n<br/>                                                \n<br/>
-        \                                               \n<br/>                                                \n\n</body>\n</html>\n"
-    http_version: 
-  recorded_at: Thu, 28 May 2015 01:02:35 GMT
+  recorded_at: Thu, 28 May 2015 01:30:19 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/without_content_type/returns_an_EMPTY_RDF_graph_with_a_valid_ID_for_NO_annotation_on_the_server.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/without_content_type/returns_an_EMPTY_RDF_graph_with_a_valid_ID_for_NO_annotation_on_the_server.yml
@@ -2676,4 +2676,63 @@ http_interactions:
         \                                               \n<br/>                                                \n\n</body>\n</html>\n"
     http_version: 
   recorded_at: Mon, 18 May 2015 20:30:55 GMT
+- request:
+    method: get
+    uri: http://localhost:3000/annotations/d3a46cd4-514d-4ee2-931b-2e81c0282bd4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/ld+json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: 'Not Found '
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - text/html; charset=utf-8
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 8139caca-67c3-4c66-8ef1-8de15bb9cbbf
+      X-Runtime:
+      - '0.035534'
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
+      Date:
+      - Wed, 27 May 2015 23:18:08 GMT
+      Content-Length:
+      - '1486'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: "<h2>error getting d3a46cd4-514d-4ee2-931b-2e81c0282bd4 from LDP</h2><html>\n<head>\n<meta
+        http-equiv=\"Content-Type\" content=\"text/html; charset=ISO-8859-1\"/>\n<title>Error
+        404 Not Found</title>\n</head>\n<body><h2>HTTP ERROR 404</h2>\n<p>Problem
+        accessing /fedora/rest/anno/d3a46cd4-514d-4ee2-931b-2e81c0282bd4. Reason:\n<pre>
+        \   Not Found</pre></p><hr /><i><small>Powered by Jetty://</small></i><br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n<br/>
+        \                                               \n<br/>                                                \n\n</body>\n</html>\n"
+    http_version: 
+  recorded_at: Wed, 27 May 2015 23:18:08 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/without_content_type/returns_an_RDF_graph_with_a_valid_ID_for_an_annotation_on_the_server.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_annotation/without_content_type/returns_an_RDF_graph_with_a_valid_ID_for_an_annotation_on_the_server.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"19a0121e959606d0a2ad964ff0cfa8c5"
+      - W/"63dbcd15f322448b9eb8fcf38383c542"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 541366b8-7b93-4dd4-a324-9fd3d50f464a
+      - 45770ff3-907a-437c-98d9-18f992b2e920
       X-Runtime:
-      - '1.653046'
+      - '2.327613'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:08:43 GMT
+      - Thu, 28 May 2015 01:30:10 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=Z29SbC8wSEtnelpwMkRSQlZhem9BME1DM0h0SUt3OCszdENnMk9ubnp3RVZlTUlKMzdXVmhxbnJnb2RhQzRCNUNEdTNvUmI4OU5YTzYvMW5POGF6dlBoMFJZOWkwMS9qME4zS29BZHMxNWt0Z1NqV2VaSmlvWktqRmIvN3ppL05TTXNUdVF0RmJTcCtsdXFHbmhaWjdLQk04dXAycjYxQ25kZEJCNTFzTllFU2Znbk5lTEllWXdGd3pPVXYreTRtQlVBQXc2dVRja3ExamRwZFFyVXM2bDJOUHI3R3FkeHowbDhkcDJUaitQSUxraEYzMUZGQUZ4dHVvNkk4eW1WdC0tdzVrUEJaZ1lHZll3YVlTdVJKU092Zz09--d48ae0b663d4fd43f3c403f17b9a937bd8ff1524;
+      - _internal_session=L1o2TnVZeGpPQk5sUzJ2MDM3VlZWM3l6VnF2eWdjL0VyOFpYb3N2aW43b2VreHVJOWlHQ3djZndUZU5tUWZ6eVNNR3U2V20yN2tuekdKUktVdjVxUEtmUXNzV2cvdGNxWWJ6SGhhQ3ZocisxanZlSnF5eURTMFRFVjVhTmVzOGx1bkxkWnlLMENWdy82OC9EcGJORzdvN3RXSFhXNGdhNmc5b0hrL2RxY2NCN2h2QUU0bWlWQ0FSK2dWSU85NW9WYVNUMCtZVG1VYk1Ga2lreFJsTm5pV0twazEwdURMMFpyaXAxOFpOSUZ2ZDlrb1plWDk0WVlwQ2ZQZHpKNzNFOC0tamV3bWFGQ0VqeXFKSlJkZTlhOWdyUT09--93a420e2fc8dd1453ea7dda08e70985534d84ed2;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310873487960","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/78/59/ba/42/7859ba42-ba03-4449-9253-f695edd6496f","@type":"oa:Annotation","hasBody":"_:g70310873487960","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69941859067900","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/75/03/8e/80/75038e80-eb5c-4281-bff5-ae3281c77e8c","@type":"oa:Annotation","hasBody":"_:g69941859067900","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:43 GMT
+  recorded_at: Thu, 28 May 2015 01:30:10 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:43 GMT
+      - Thu, 28 May 2015 01:30:10 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:43 GMT
+      - Thu, 28 May 2015 07:30:10 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:43 GMT
+  recorded_at: Thu, 28 May 2015 01:30:10 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:43 GMT
+      - Thu, 28 May 2015 01:30:10 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:43 GMT
+      - Thu, 28 May 2015 07:30:10 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:44 GMT
+  recorded_at: Thu, 28 May 2015 01:30:11 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:44 GMT
+      - Thu, 28 May 2015 01:30:11 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:44 GMT
+      - Thu, 28 May 2015 07:30:11 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:44 GMT
+  recorded_at: Thu, 28 May 2015 01:30:11 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:44 GMT
+      - Thu, 28 May 2015 01:30:11 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:44 GMT
+      - Thu, 28 May 2015 07:30:11 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:44 GMT
+  recorded_at: Thu, 28 May 2015 01:30:12 GMT
 - request:
     method: get
-    uri: http://localhost:3000/annotations/78%2F59%2Fba%2F42%2F7859ba42-ba03-4449-9253-f695edd6496f
+    uri: http://localhost:3000/annotations/75%2F03%2F8e%2F80%2F75038e80-eb5c-4281-bff5-ae3281c77e8c
     body:
       encoding: US-ASCII
       string: ''
@@ -2479,27 +2479,27 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"1b5f2dabb9d21d35c4522d66b8e46986"
+      - W/"0e8ef4a9d23d8a7307308980ae7c1085"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 01d1f55b-7b48-4e39-b8f0-134265439856
+      - 205ca886-8d5d-43fc-a565-48735c479c6a
       X-Runtime:
-      - '0.809589'
+      - '0.971544'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:08:45 GMT
+      - Thu, 28 May 2015 01:30:13 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310860311840","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/78/59/ba/42/7859ba42-ba03-4449-9253-f695edd6496f","@type":"oa:Annotation","hasBody":"_:g70310860311840","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942024123540","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/75/03/8e/80/75038e80-eb5c-4281-bff5-ae3281c77e8c","@type":"oa:Annotation","hasBody":"_:g69942024123540","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:45 GMT
+  recorded_at: Thu, 28 May 2015 01:30:13 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -2519,7 +2519,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:45 GMT
+      - Thu, 28 May 2015 01:30:13 GMT
       Server:
       - Apache/2
       Location:
@@ -2527,7 +2527,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:45 GMT
+      - Thu, 28 May 2015 07:30:13 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -2543,7 +2543,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:45 GMT
+  recorded_at: Thu, 28 May 2015 01:30:13 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -2565,7 +2565,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:45 GMT
+      - Thu, 28 May 2015 01:30:13 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -2579,7 +2579,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:45 GMT
+      - Thu, 28 May 2015 07:30:13 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -3697,7 +3697,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:46 GMT
+  recorded_at: Thu, 28 May 2015 01:30:13 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -3717,7 +3717,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:46 GMT
+      - Thu, 28 May 2015 01:30:14 GMT
       Server:
       - Apache/2
       Location:
@@ -3725,7 +3725,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:46 GMT
+      - Thu, 28 May 2015 07:30:14 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -3741,7 +3741,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:46 GMT
+  recorded_at: Thu, 28 May 2015 01:30:14 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -3763,7 +3763,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:46 GMT
+      - Thu, 28 May 2015 01:30:14 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -3777,7 +3777,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:46 GMT
+      - Thu, 28 May 2015 07:30:14 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -4895,10 +4895,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:46 GMT
+  recorded_at: Thu, 28 May 2015 01:30:14 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/78%2F59%2Fba%2F42%2F7859ba42-ba03-4449-9253-f695edd6496f
+    uri: http://localhost:3000/annotations/75%2F03%2F8e%2F80%2F75038e80-eb5c-4281-bff5-ae3281c77e8c
     body:
       encoding: US-ASCII
       string: ''
@@ -4925,22 +4925,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - acec9551-aedb-4d82-bec0-431f9ccdd9a6
+      - 603d0c30-0e0d-4c68-8df3-8c1b1f2301fd
       X-Runtime:
-      - '0.266124'
+      - '0.195405'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:08:47 GMT
+      - Thu, 28 May 2015 01:30:15 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=MmRQazAwUTZaL1ZwSWR3bExBQzdkbSt4ZlBOMWFyVHVvZk9YL3ZwWWdNMkFVMmNRWWRucUtlOGJwbDRhenR6QVV6ZjJ3ekZrTmE0ZWppNHFPOVUyMzF4Y25LbkQvMDdzNU9sYUtaZlJhb0ZjVVBPNHpjaVpyVUpKbVlYTFZkWjRZanhsQ3RpWm9VNEhCYjMrQm1KbmxpSU9ZSTJXdFZ1WW9lWEkveVF6UDlUVzdpeWsyTCtEUFZmTUhyK2JyYVJ3LS1VMjQyb2xXK0x0cVYyYTRtd0lFWkpBPT0%3D--8b2902e822961cd5ee9ce37991d3801b0c82dee4;
+      - _internal_session=ZFA4b3NueFlJZFVTdXdTaXZ3ZzVRWmd6OW9rN2J0cGVKYnU5NHkyU0JzeHEwQXczc0RXTnVkR0ZMYW9pZWxuQXNnbzBnQVJQVTZENS9jdDJUYXE3NlBDTjhQVXlnd2dveTZUTTYxUnBEVTM0VkpDZmtTTnVGR3czYllWck1WcjdqSkttczBaZllyelVLMmNGSG04NGNvQnpPd0VCQitQUGVqR0NSTGhCa3IrYkhXTVZpSGpNMVFrL0RrUjFLQ25YLS1ITkpUb3ZkS2s0RlRKZ2dqZjYrb3l3PT0%3D--4e0ff34eabe12fc0c167a7da29c66c545f1bfdd2;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:47 GMT
+  recorded_at: Thu, 28 May 2015 01:30:15 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_iiif_annotation/requests_an_open_annotation_by_ID_using_a_IIIF_profile.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_iiif_annotation/requests_an_open_annotation_by_ID_using_a_IIIF_profile.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"d32779462ac1d4ba61ceb2af5a33f22c"
+      - W/"b39655b8e82fdd1b7a32e49e7efe0428"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - c1a0a2f7-b116-4556-8666-feb2344cf9bc
+      - a3aa2ab8-36a9-4d06-8343-aeef88b90f92
       X-Runtime:
-      - '1.646155'
+      - '1.990758'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:08:58 GMT
+      - Thu, 28 May 2015 01:30:30 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=alRva0NMZzVYdHpLRWIwWjFZVHRJT2Y1YjJqYldQNVlDaVpaMU14aGNnSGVZd0FxQmRLcmRrRFkxZ3M3WGxEeXJINlNnR2VCcmJWRDZ6ZVRxRnUwQkgyQnhKdUFjaStjQWRmajRFYk1iQXdOSmVpejdzSElacWErS0ZBak9kbHRoczNUS1NsWFZsajBTbVhEbzFlb21OZ05ZNjFybDN2K3FMY2IySnpkdzJSLzVkY0IxVVo5RjVSMVcwVXFTd0FhK083aVZockxzeHMvRG92d3djNDNURFNmN0praWExNWh6Ym8rR1JjOHJ2QnRTUVFRSyt6RnpveDh5VGs1WnY4bS0tSU53Ny9HNm5OS1hpRlZWYTE4TUVjdz09--fe28237c6f617f2aa32165869198fc8d8a4846bd;
+      - _internal_session=MnhXQTJrcURpMEM5Wm1ZTWkzOFhoeWo2UWdqZmdnME1jR0UzYUpVQllDTVlpakJxUkp3cVpjSVBYMWtoblphMmhEYnY4a0lQRVBwalliOXR4anRXVGVleTd0S3U4L1owTUhuQjlrYk5rRDNjMFNDWkhBczJ0YUlJc3UrSEQxVGJRNlFtNjdLYzdJY0FhT3Vuck9icmlsdGVuM2toWkpPMDBKSmovZVVxSzZNT1RsendHL09FRjYvaERSdDdOcklUK1Bva2o2ajRod1phcU5iOXNiRWRadXVwR2tiNHBPU3RhN0NZVllrWDJZRktsQndqMnNrWUd3TGF0Mm9oZnZoSS0tcFhKaDBBZ2VyT0JhNThLaUpta1k0dz09--dff6233db97221d58c93f0e394c68d9579981d76;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310887427240","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/97/a1/cf/da/97a1cfda-c0b1-4509-bb3f-d18597d0a95b","@type":"oa:Annotation","hasBody":"_:g70310887427240","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69941861609940","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/52/af/93/ed/52af93ed-6bab-4d93-8b11-9fb3680f3fd8","@type":"oa:Annotation","hasBody":"_:g69941861609940","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:58 GMT
+  recorded_at: Thu, 28 May 2015 01:30:30 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:58 GMT
+      - Thu, 28 May 2015 01:30:30 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:58 GMT
+      - Thu, 28 May 2015 07:30:30 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:58 GMT
+  recorded_at: Thu, 28 May 2015 01:30:30 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:59 GMT
+      - Thu, 28 May 2015 01:30:30 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:59 GMT
+      - Thu, 28 May 2015 07:30:30 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:59 GMT
+  recorded_at: Thu, 28 May 2015 01:30:31 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:59 GMT
+      - Thu, 28 May 2015 01:30:31 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:59 GMT
+      - Thu, 28 May 2015 07:30:31 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:08:59 GMT
+  recorded_at: Thu, 28 May 2015 01:30:31 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:08:59 GMT
+      - Thu, 28 May 2015 01:30:31 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:08:59 GMT
+      - Thu, 28 May 2015 07:30:31 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:00 GMT
+  recorded_at: Thu, 28 May 2015 01:30:31 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/97%2Fa1%2Fcf%2Fda%2F97a1cfda-c0b1-4509-bb3f-d18597d0a95b
+    uri: http://localhost:3000/annotations/52%2Faf%2F93%2Fed%2F52af93ed-6bab-4d93-8b11-9fb3680f3fd8
     body:
       encoding: US-ASCII
       string: ''
@@ -2481,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 97615c8a-918f-4b89-9854-6a713a384205
+      - f6297600-d2a3-40fe-8ef8-d9f5efbccf8e
       X-Runtime:
-      - '0.282327'
+      - '0.412759'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:09:00 GMT
+      - Thu, 28 May 2015 01:30:32 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=dlcvR2t3ekZ5M3lFTmU3d0xrbXRiNUFHVEc2OHhQbGIrSlJ1YmFTSmpwRUcvVy9naWJIUVdSb3NSM2RrNWc1eTI1QkFLUTRCTzJGM1R3dHM0VnBjNktMYnlYdHErMVFRUkwwM1BTWkE1cUhsRS8vdE0wQnhXbG50cmtGQnJ1TU5PYzZrT2VVS2lya2RuVmFCUnBjTnIwMlJMeHZJUkNzQnlWUEEyUEdseTdiY05jWTg5ZjE2czd5ZVg5UENBc3BhLS1SbWFrMGg4dDlldExPTlZWZjRrTldRPT0%3D--c59ff4b3b8bcf99ba99ca94f590ae47dde65888b;
+      - _internal_session=WE5zdkgzYjJuZExaczhyRmRGNnNVQmVMM2M2RHdmNFRaL3B5cklGM3JRR2Rvd1hWZENoWi9iZ0RwNldXMyt2SkJhZFRobXhmZUp5RnZYZkFwZ050Y2prV3dGdXVtR252b0Zib3c5RTBLT1ZrZE1veldwRVcvRU96aTM4czRCbXZRb1I2MmVKZlhZeDFGMHF1SXB2Vzkvd0FpTGQ5eHEwdXVIV09rc3Fwa3BOMzU1RGZUMWtPd1hLc3RXZmc3MWdyLS1DMTg4WFdpZEFjYytLdEs2U1NDSlVnPT0%3D--42474f83ae8a5b98b51823d6d98f05b047c48e37;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:00 GMT
+  recorded_at: Thu, 28 May 2015 01:30:32 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_iiif_annotation/returns_an_RDF_Graph_of_an_open_annotation.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_iiif_annotation/returns_an_RDF_Graph_of_an_open_annotation.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"2d5371680258642578ab10f4961f22da"
+      - W/"0cf7742a77620fcd4b0e192dfaf0ca61"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 2d79de4e-8078-4c35-9c6d-9ea6e6f5b9d6
+      - 009bc3ea-9e28-44da-93f5-cadde5da26c0
       X-Runtime:
-      - '1.724068'
+      - '2.070807'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:09:02 GMT
+      - Thu, 28 May 2015 01:30:34 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=SWhNN3NUT2hxVHNlUUpZaUIrMzRGT0VGU1JuOXNlZitLVjJlMVZUdTFEYlltYnVpVGFZK2d0M0RmOS9MbTJkb2R5MENkVC9BNTNjV0g5M3FzS0hOdHhvUkM2b05FbGJMOGRmd0M4NVY0WWpUaTdnTml6TkhMTDJReFp4bVo3ektrei9WYjU3c3AyYXVleE5qclFuV2pYd0RZV1MxUEdGMnVnMjRnMUx2SE5KQS9nV0VBckZQV2tSTWs1TU1abUtjaUQ1bUhCWGZ2NlAwV2tMUjhETVZYTG05b3R4ZnM0VFk4RTFaNjMyRU1zZVAxRXBwTkE5NHMvYXVUVFFJUThBOC0tY0VndXhHSDRYK1pNNVNBZ0FyZnl1Zz09--a32d22e380809bc7bd0b56cfe3dbe9d674b40d5e;
+      - _internal_session=OUs0UVMwYzN3NTV4NTVJU2ZzZ3NDdHlBcTEyRDdiNnFaT0Z1ZmEwQ0RDRE9EN2NPL1JLQXVjd0hYbGoyV1Q0cnpOaFZwVndpMEEvaFhObHljMzVaMFkrb3d4Ymdkcmp3aldlYTM5eVVJQlFDd3RQMWxNZDZrbVM0V25sb3BXc05Zbit1S0UvYjZ6bVMzcVBBUC9JSE1vdGplUE5WTmNtczhaeU9nYXlTWmdRb3haRG9zTmhyOEYzdkVab2RSZkRWc1JWL2gxRU11QnZ1Q053TXF3WUsvMmlBNjRxVWIwSnBLanp2UGNsTGNIUFF5NkdKNFM3aUhKVTc4NFhWZE9QTi0tL1B5Ry9Kckk1SzFWUnlUcVBwWklPdz09--60b4c3ff8370996c72a554340f13828c5b5d3930;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310874307140","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/66/ce/62/2e/66ce622e-627b-4302-a647-e8ce5a6e5fac","@type":"oa:Annotation","hasBody":"_:g70310874307140","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942005805080","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/ec/b5/68/69/ecb56869-b375-4e52-88b6-40e3152e0a51","@type":"oa:Annotation","hasBody":"_:g69942005805080","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:02 GMT
+  recorded_at: Thu, 28 May 2015 01:30:34 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:02 GMT
+      - Thu, 28 May 2015 01:30:34 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:02 GMT
+      - Thu, 28 May 2015 07:30:34 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:02 GMT
+  recorded_at: Thu, 28 May 2015 01:30:34 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:02 GMT
+      - Thu, 28 May 2015 01:30:34 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:02 GMT
+      - Thu, 28 May 2015 07:30:34 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:02 GMT
+  recorded_at: Thu, 28 May 2015 01:30:35 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:03 GMT
+      - Thu, 28 May 2015 01:30:35 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:03 GMT
+      - Thu, 28 May 2015 07:30:35 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:03 GMT
+  recorded_at: Thu, 28 May 2015 01:30:35 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:03 GMT
+      - Thu, 28 May 2015 01:30:35 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:03 GMT
+      - Thu, 28 May 2015 07:30:35 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:03 GMT
+  recorded_at: Thu, 28 May 2015 01:30:36 GMT
 - request:
     method: get
-    uri: http://localhost:3000/annotations/66%2Fce%2F62%2F2e%2F66ce622e-627b-4302-a647-e8ce5a6e5fac
+    uri: http://localhost:3000/annotations/ec%2Fb5%2F68%2F69%2Fecb56869-b375-4e52-88b6-40e3152e0a51
     body:
       encoding: US-ASCII
       string: ''
@@ -2479,27 +2479,27 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"027fab91b04730ea5b3ce479d27369d1"
+      - W/"2220727adc9400149f7d90fa5be67986"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 84ea5acc-bfb7-4970-be43-113d6782198f
+      - b331ac30-f122-4078-b3ed-c334449faa23
       X-Runtime:
-      - '0.162402'
+      - '0.149888'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:09:03 GMT
+      - Thu, 28 May 2015 01:30:36 GMT
       Content-Length:
       - '437'
       Connection:
       - Keep-Alive
     body:
       encoding: UTF-8
-      string: '{"@context":"http://iiif.io/api/presentation/2/context.json","@graph":[{"@id":"_:g70310880866060","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/66/ce/62/2e/66ce622e-627b-4302-a647-e8ce5a6e5fac","@type":"oa:Annotation","motivation":"oa:commenting","on":"http://purl.stanford.edu/kq131cs7229","resource":"_:g70310880866060"}]}'
+      string: '{"@context":"http://iiif.io/api/presentation/2/context.json","@graph":[{"@id":"_:g69941860827920","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/ec/b5/68/69/ecb56869-b375-4e52-88b6-40e3152e0a51","@type":"oa:Annotation","motivation":"oa:commenting","on":"http://purl.stanford.edu/kq131cs7229","resource":"_:g69941860827920"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:03 GMT
+  recorded_at: Thu, 28 May 2015 01:30:36 GMT
 - request:
     method: get
     uri: http://iiif.io/api/presentation/2/context.json
@@ -2519,7 +2519,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:11:52 GMT
+      - Thu, 28 May 2015 01:33:38 GMT
       Server:
       - Apache/2.2.15 (Red Hat)
       Last-Modified:
@@ -2531,7 +2531,7 @@ http_interactions:
       Cache-Control:
       - max-age=86400
       Expires:
-      - Tue, 19 May 2015 20:11:52 GMT
+      - Fri, 29 May 2015 01:33:38 GMT
       Content-Type:
       - application/ld+json
       Access-Control-Allow-Origin:
@@ -2597,7 +2597,7 @@ http_interactions:
         \   \"language\":    {\"@id\": \"dc:language\"},\n\t\t    \"value\":       {\"@id\":
         \"rdf:value\"},\n\t\t    \"label\":       {\"@id\": \"rdfs:label\"}\n\t\t}\n\t]\n}"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:03 GMT
+  recorded_at: Thu, 28 May 2015 01:30:36 GMT
 - request:
     method: get
     uri: http://iiif.io/api/presentation/2/context.json
@@ -2617,7 +2617,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:11:52 GMT
+      - Thu, 28 May 2015 01:33:38 GMT
       Server:
       - Apache/2.2.15 (Red Hat)
       Last-Modified:
@@ -2629,7 +2629,7 @@ http_interactions:
       Cache-Control:
       - max-age=86400
       Expires:
-      - Tue, 19 May 2015 20:11:52 GMT
+      - Fri, 29 May 2015 01:33:38 GMT
       Content-Type:
       - application/ld+json
       Access-Control-Allow-Origin:
@@ -2695,10 +2695,10 @@ http_interactions:
         \   \"language\":    {\"@id\": \"dc:language\"},\n\t\t    \"value\":       {\"@id\":
         \"rdf:value\"},\n\t\t    \"label\":       {\"@id\": \"rdfs:label\"}\n\t\t}\n\t]\n}"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:03 GMT
+  recorded_at: Thu, 28 May 2015 01:30:36 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/66%2Fce%2F62%2F2e%2F66ce622e-627b-4302-a647-e8ce5a6e5fac
+    uri: http://localhost:3000/annotations/ec%2Fb5%2F68%2F69%2Fecb56869-b375-4e52-88b6-40e3152e0a51
     body:
       encoding: US-ASCII
       string: ''
@@ -2725,22 +2725,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 4c88fe85-79c2-483d-aa35-9c8801e4c6d5
+      - fe28687a-f71e-4f77-a151-9e0da5413884
       X-Runtime:
-      - '0.189083'
+      - '0.204654'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:09:04 GMT
+      - Thu, 28 May 2015 01:30:37 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=WlYxZmU1QnpyQWVRRWZ6RWFHRUhVdFhiTVVSS0FjQ3l2R1VacXVoQUpkeGw5cjVjWEd6SzdkbEwrOEZSMVlPUldxWGE2NWtuOHBHVDhNUjh2SEgzQkpGd2JuOTI1K3pxRXdGRlUvZWdadE0xMldsM1BxVHl4akNaMjZLTm1CbTE2TnpnUEJnQkpVdDRmNG12dlBnRndQVjcwZ1VQZXpkd1Q0aVptR0NXOWhCdmZ6UHpseGJtTG03NThXODNPWmVoLS1rRlhyWUF1dklyNHJ0anIyV2hoL2x3PT0%3D--5763c0bf16cf892a101b59d6ad374a9109865a74;
+      - _internal_session=THhTczVkSG1RMXNMUVNaQlVwZkpkM2w2MjFDQXg3b284WjM3SXM1RXZvekJxSFBZdUlOem5IckVqSXZaMk9nRWFNbStpenJ6dTJyaGhtUStyaEszZXdGMTBJUnhySWFDRWFhRnNjMDE2N3ZkLzBuYzF2bzY0ZXZuTCtOUTVYYkIvVWdlekVUUEtCN0RqSWFveDdMZ1lkemMwZ2VVVjFMZEFLaHhYYSs1clBBSFZBZ251cmxWUzB6Q25UTXNVVUZaLS1zaEsycGF2MkhVdTcwdFFkN3BLRmJ3PT0%3D--7f3ce03d68894368bfa578414eee70ee10f40b1d;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:04 GMT
+  recorded_at: Thu, 28 May 2015 01:30:37 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_oa_annotation/requests_an_open_annotation_by_ID_using_an_OA_profile.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_oa_annotation/requests_an_open_annotation_by_ID_using_an_OA_profile.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"76f2da2a3c8e749412dc607c1fd9cb51"
+      - W/"2ee583efdb8cd65da3f6155aeb7f843b"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - f43656dd-e65b-43f4-8a66-1663d112bc43
+      - 450d1b95-5312-4c51-8e23-48ea08cd5871
       X-Runtime:
-      - '1.625895'
+      - '2.056970'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:09:05 GMT
+      - Thu, 28 May 2015 01:30:39 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=Y0Zsd1QxUGorNXFnV2xrZjUyVXQxemF4U3pUTXdRVjdyUlpFdkFRWEZVUHlCTm9DWXcrc0xqcHJUaEJSaXQrVHJMcjNaRC9lQ1AzYkx5VUIwa05RbW5rdVZQMU91NmxxcUJuVG1XWXRBR1F3THFBdDBOQVpabER6clZwSmNUc2lGUXNTV3lDMzhKUG1KaXJ2SzVGUnd0L0hNUjYrRXgzOS9lNjJFOVlYWXBnc1VKSFdjZjcwMDVCbkMxaXorTTJvbkErRVpkS1Zkbm1Pb1F1UWNhYVhxaDlkaXAxeGM4ZmpqSk00NCt1dTBNQkJDeEZvblBCS1pIQzNxM09qRHpOQi0tVFdoZ1VoZ2IwRlkyS0NCTXhnRzVhdz09--6197d6c920defcb8b8cdbb095f54016383c5dcbe;
+      - _internal_session=N3dEdENDQ1hXOVNoTjZMVUFpZmJwOFRoNkViUCswSjE1L0MzL1lINUZJSkdoQzFmVnhBbXZTNHRnQjlXdVREcHVGaFVyRyt0OTRLcHJBWE5HbXd4ajVSbHhVckdQOUErcVVySDBxTVlxc0EwSEN4ekIrbXhoVmZHWjNnVUw3djNXMnI3SlRsbkpxSi9jb3UxbEZRTEkwR1U4NndlUWNzc0dVR1pnWUtNUy94QTJLRG5nYWpudGNvbUZNcENiV3c5bysxemlHN0crRS9xS1NYUGU2UmZLZ2wvN2dMUFU4Tjh3T2ZLZitWZ01vN2Jid1VJVzk4a21jTm9FRCt2Wk9Zdi0tMExtNFZ0ajcyaW02YzNTTUd6VHR6QT09--eb97e6f9c3728a939808eed46f8abf6c473cb7e7;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310872635640","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/0b/d0/30/41/0bd03041-8282-438b-b341-80f6da248694","@type":"oa:Annotation","hasBody":"_:g70310872635640","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942008292440","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/0a/11/9e/70/0a119e70-4807-4eb9-b531-5b5def545178","@type":"oa:Annotation","hasBody":"_:g69942008292440","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:05 GMT
+  recorded_at: Thu, 28 May 2015 01:30:39 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:05 GMT
+      - Thu, 28 May 2015 01:30:39 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:05 GMT
+      - Thu, 28 May 2015 07:30:39 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:05 GMT
+  recorded_at: Thu, 28 May 2015 01:30:39 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:06 GMT
+      - Thu, 28 May 2015 01:30:39 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:06 GMT
+      - Thu, 28 May 2015 07:30:39 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:06 GMT
+  recorded_at: Thu, 28 May 2015 01:30:40 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:06 GMT
+      - Thu, 28 May 2015 01:30:40 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:06 GMT
+      - Thu, 28 May 2015 07:30:40 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:06 GMT
+  recorded_at: Thu, 28 May 2015 01:30:40 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:06 GMT
+      - Thu, 28 May 2015 01:30:40 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:06 GMT
+      - Thu, 28 May 2015 07:30:40 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:07 GMT
+  recorded_at: Thu, 28 May 2015 01:30:40 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/0b%2Fd0%2F30%2F41%2F0bd03041-8282-438b-b341-80f6da248694
+    uri: http://localhost:3000/annotations/0a%2F11%2F9e%2F70%2F0a119e70-4807-4eb9-b531-5b5def545178
     body:
       encoding: US-ASCII
       string: ''
@@ -2481,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 3315f0b2-a02d-4111-86f9-886428bca527
+      - 9684099e-7879-4d78-9d1a-0ede43e7ab2f
       X-Runtime:
-      - '0.241122'
+      - '0.247538'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:09:07 GMT
+      - Thu, 28 May 2015 01:30:41 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=RGV3N3R6UVo1UmZJNkNxMnhlcHJMbkdvdFQ1QVAvNXlBRUhlQXduOGorWHZVUHFPZWxrK0NqOXRtTWQ4Q0pHMDZISWNELzRBSFVxRk0yUXNUeVlIMG5IYkNMOU1wOEJnSWNEd2h4djZaazhGNndrRkFOcFd2OVNyRE00dmlCdEE1bmJSZy9xb0FieEljRWtvd2xGT245V3RCaktycUwzYUJPbHlUQ1dXczRkd1JVVEl3L3RzVEt4RE5qOGxEVGFRLS13cEZrd1JhZFJOYlg3eHNUcUxuNE1BPT0%3D--e755d1a7b718198ef6968dc1d0452c7a4d4eafb7;
+      - _internal_session=TmNqSS82Q044MU45TzNaZjhUOE9ZN2tHQURycG9ZOFZlek9qV3VEbjhST1dFck5LTVNrQnBTeHdaUXZoY3FwbENERzdsS0o3eTVJRXRRRWlkUmZ6WlN0dlhUeDlkdEdCemhVUE1lNG1MRENUbStINHRVYmhidSs5WEhuUkkxNHlFeHEvaHlhVENKTUxITWZKazFXSEJNSmtsSkVrNmdialhkYkJMZG1WZEwzZ1AvL2s3MFFvZHVVMnNwVjNCdTc5LS16dDA5NWdTTDJJMWdRQ0JrZCtDMWFnPT0%3D--ab962d1598ec479c058f1da52ec3ff55e8b245f2;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:07 GMT
+  recorded_at: Thu, 28 May 2015 01:30:41 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_oa_annotation/returns_an_RDF_Graph_of_an_open_annotation.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/GET_annotation_by_ID_/_get_oa_annotation/returns_an_RDF_Graph_of_an_open_annotation.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"5677c0a3b1295acf1e19c96372ba4a20"
+      - W/"b58108426f199c2c7f99bd12ea223aa7"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - a46f01bd-5005-4994-b227-38230f4e01b0
+      - 17319770-cbe0-4037-8d2e-51c5c77c1a7a
       X-Runtime:
-      - '1.864126'
+      - '2.057698'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:09:09 GMT
+      - Thu, 28 May 2015 01:30:43 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=SzdsMDRRdSt2Sm5uSXZCS2d1dG16cUlqWXpLUkc4ZldoWituUDdHU3grTjVtWjlVUGJ5ZG5CT2VvMTN4cGd1dWVPdHFKUlZhNVl4ZC9aRFhMQ1RDV1ptVmhzVjJuVVU2MGRNQVMzRTRtZzkzY205OW9NVjhtb2dNdmxRSjN2K0VhWUgxeVB6NmdDd2Z0NmhrQ0JGWDhSRFJmZU9pTGdFQ3QvZVpQSnVGS2NDYlN3RzhLcXc1cVN4ZmNmaERqUFBieTl1SzExMm1uTFZib0lxYW14SWg5eDJTdlNxaFltbWhRc2ZxZGM4MEVkTVNaSjc5K2tScitaRS9IWURucjJ0bS0tQWxBSzM5WndXTS9JSisvdjNFR0pLZz09--e395a872689415f91d00ecf081a95c5c70b5aa60;
+      - _internal_session=dW55bndUTDV4cUtQNDhGNW53c0VZZmpRN1BQcFNuQS95SWRIbTZWN3NEL2NlMElleS9IMGJzNFFRQWRVTWw0S1Jld0hUUmphRTY3ZFZOYm5qUnJwc1labDVndUo5bnFxSTNPTHc1TUh5aUNQaVM1STJzS1VkZjkwdDR5VEJkeUpuSysyK3BVcVpxc3ZUdXlxbndiaDFmTHcrUFJMOXMwcVdvd1c0Y1c2TVlJTVd6aW12d3JkMlZ3c3gwU0IxUmpHUnZvT212YUFyT2dDbzBmeWxkZjNYWm1kSFh1bElvZXVGd2xuUkZraHZKVVNiNVlNTTVDZk1Ca3d1Q0UxSjdVNi0tVHdBZjBUTGt3YjRFZnlNTDh3RGZjUT09--a2359aef431bc5454d5eab6b9b80441a09d33b33;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310849936620","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/08/a8/0c/56/08a80c56-c685-4919-9943-93b3c5978e2c","@type":"oa:Annotation","hasBody":"_:g70310849936620","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942038176220","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/51/a4/c0/49/51a4c049-b1ab-4c04-bd27-efbbe3be2958","@type":"oa:Annotation","hasBody":"_:g69942038176220","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:09 GMT
+  recorded_at: Thu, 28 May 2015 01:30:43 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:09 GMT
+      - Thu, 28 May 2015 01:30:43 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:09 GMT
+      - Thu, 28 May 2015 07:30:43 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:09 GMT
+  recorded_at: Thu, 28 May 2015 01:30:43 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:09 GMT
+      - Thu, 28 May 2015 01:30:43 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:09 GMT
+      - Thu, 28 May 2015 07:30:43 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:09 GMT
+  recorded_at: Thu, 28 May 2015 01:30:44 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:10 GMT
+      - Thu, 28 May 2015 01:30:44 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:10 GMT
+      - Thu, 28 May 2015 07:30:44 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:10 GMT
+  recorded_at: Thu, 28 May 2015 01:30:44 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:10 GMT
+      - Thu, 28 May 2015 01:30:44 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:10 GMT
+      - Thu, 28 May 2015 07:30:44 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:10 GMT
+  recorded_at: Thu, 28 May 2015 01:30:45 GMT
 - request:
     method: get
-    uri: http://localhost:3000/annotations/08%2Fa8%2F0c%2F56%2F08a80c56-c685-4919-9943-93b3c5978e2c
+    uri: http://localhost:3000/annotations/51%2Fa4%2Fc0%2F49%2F51a4c049-b1ab-4c04-bd27-efbbe3be2958
     body:
       encoding: US-ASCII
       string: ''
@@ -2479,27 +2479,27 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"853eff8543e794eb707584e2075864d3"
+      - W/"8cc4c450bc33c77905f47918f9b12bb1"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 8481e130-f7df-4990-9fbe-339384970089
+      - 7f501a76-3ba0-4731-bb76-d8999d1c69cd
       X-Runtime:
-      - '0.796758'
+      - '0.966188'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:09:11 GMT
+      - Thu, 28 May 2015 01:30:46 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310857871240","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/08/a8/0c/56/08a80c56-c685-4919-9943-93b3c5978e2c","@type":"oa:Annotation","hasBody":"_:g70310857871240","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69941859412960","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/51/a4/c0/49/51a4c049-b1ab-4c04-bd27-efbbe3be2958","@type":"oa:Annotation","hasBody":"_:g69941859412960","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:11 GMT
+  recorded_at: Thu, 28 May 2015 01:30:46 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -2519,7 +2519,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:11 GMT
+      - Thu, 28 May 2015 01:30:46 GMT
       Server:
       - Apache/2
       Location:
@@ -2527,7 +2527,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:11 GMT
+      - Thu, 28 May 2015 07:30:46 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -2543,7 +2543,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:11 GMT
+  recorded_at: Thu, 28 May 2015 01:30:46 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -2565,7 +2565,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:11 GMT
+      - Thu, 28 May 2015 01:30:46 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -2579,7 +2579,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:11 GMT
+      - Thu, 28 May 2015 07:30:46 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -3697,7 +3697,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:12 GMT
+  recorded_at: Thu, 28 May 2015 01:30:46 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -3717,7 +3717,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:12 GMT
+      - Thu, 28 May 2015 01:30:47 GMT
       Server:
       - Apache/2
       Location:
@@ -3725,7 +3725,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:12 GMT
+      - Thu, 28 May 2015 07:30:47 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -3741,7 +3741,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:12 GMT
+  recorded_at: Thu, 28 May 2015 01:30:47 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -3763,7 +3763,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:12 GMT
+      - Thu, 28 May 2015 01:30:47 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -3777,7 +3777,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:12 GMT
+      - Thu, 28 May 2015 07:30:47 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -4895,10 +4895,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:12 GMT
+  recorded_at: Thu, 28 May 2015 01:30:47 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/08%2Fa8%2F0c%2F56%2F08a80c56-c685-4919-9943-93b3c5978e2c
+    uri: http://localhost:3000/annotations/51%2Fa4%2Fc0%2F49%2F51a4c049-b1ab-4c04-bd27-efbbe3be2958
     body:
       encoding: US-ASCII
       string: ''
@@ -4925,22 +4925,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - d3f275e5-2b69-4270-9ae9-2e4a78009004
+      - 1ae853df-72be-4fd3-8031-4aebca75c6ce
       X-Runtime:
-      - '0.195893'
+      - '0.176327'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:09:12 GMT
+      - Thu, 28 May 2015 01:30:48 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=TGczN2NHV0k5UmEvamhTT2Y3Z1VqNWJocXl4dy9ybXdRUVA2ZG51MDBQTkFIRnk0Mis4YVpSV0xONklXTmI2RnREOFp6VWJxUzlEVmtUejBabmpNV3YvOC90NGFyM210dEh2Z2ZzVTVFUEJ0WHFKSGtudzNVcXFjRVlkb2Z1OHhXVmNyNExRNWVaTDVaRkgrdmd0WHpHcWpnRk8yckFrV3JqNFAva3pkRU0rQ3J4dE5ONW9XUzdYQjVzemI5ekxtLS1iWjhlWWJRU3I1Mnh0YlNSZE93U3l3PT0%3D--23a54e3761be98e9e2305a9d945f44ad807f9598;
+      - _internal_session=N3RxR04wZlBwYkFlMGNtQmFiSmhPSjNSL0dXeE1NYmYzNkVPNVphbnJRaGRxaE5td2o1WlNMeGU2SUsrRlFaMFlkdWwycGtDcVV5czdMaVdoTEU2b1hBUCt0RFVEYk5MLzJ6SlBORzBWOWNuUldBZkNHL0ZZUjArTFpUK3JtVXo3L2pvU1ptd0kvVWFhd0ZQVUE2aEFHYldwRitQK29ZT0NLMjBSZ0YvS09XN0hBZ0E4RGZtRXdDZ3ZNQzhHdTNuLS1SZzdERnV0ZENCdTZPUFVYQkhkNnZnPT0%3D--ea33542f6b031b8984b5e5af80abd81fd1cee0db;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:12 GMT
+  recorded_at: Thu, 28 May 2015 01:30:48 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/_delete_annotation/does_not_log_exceptions_for_missing_annotations_404_responses_.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/_delete_annotation/does_not_log_exceptions_for_missing_annotations_404_responses_.yml
@@ -29,13 +29,13 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 6742b091-a4da-4763-a9f9-d851ebde083c
+      - 112a2743-8e85-49ef-a8ae-326d61b47318
       X-Runtime:
-      - '0.027674'
+      - '0.025649'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:13 GMT
+      - Thu, 28 May 2015 01:25:55 GMT
       Content-Length:
       - '1482'
       Connection:
@@ -60,5 +60,5 @@ http_interactions:
         \                                               \n<br/>                                                \n<br/>
         \                                               \n<br/>                                                \n\n</body>\n</html>\n"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:13 GMT
+  recorded_at: Thu, 28 May 2015 01:25:55 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/_delete_annotation/does_not_log_exceptions_for_missing_annotations_410_responses_.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/_delete_annotation/does_not_log_exceptions_for_missing_annotations_410_responses_.yml
@@ -29,13 +29,13 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 9eb688c7-4ee2-4e7d-b6b0-57acc93c26c3
+      - 12cf6efd-5715-4545-b50e-668871e4cfe8
       X-Runtime:
-      - '0.036648'
+      - '0.041693'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:13 GMT
+      - Thu, 28 May 2015 01:25:55 GMT
       Content-Length:
       - '1482'
       Connection:
@@ -60,5 +60,5 @@ http_interactions:
         \                                               \n<br/>                                                \n<br/>
         \                                               \n<br/>                                                \n\n</body>\n</html>\n"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:13 GMT
+  recorded_at: Thu, 28 May 2015 01:25:55 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/_delete_annotation/logs_exceptions.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/_delete_annotation/logs_exceptions.yml
@@ -29,13 +29,13 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 85b336c0-e659-4a2f-b775-93b3e968a74c
+      - 86b40ac7-a0fd-41d2-8e93-8ac6f968c271
       X-Runtime:
-      - '0.030391'
+      - '0.024923'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:13 GMT
+      - Thu, 28 May 2015 01:25:55 GMT
       Content-Length:
       - '1458'
       Connection:
@@ -60,5 +60,5 @@ http_interactions:
         \                                               \n<br/>                                                \n<br/>
         \                                               \n\n</body>\n</html>\n"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:13 GMT
+  recorded_at: Thu, 28 May 2015 01:25:55 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/_delete_annotation/returns_FALSE_for_a_500_response_to_a_DELETE_request.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/_delete_annotation/returns_FALSE_for_a_500_response_to_a_DELETE_request.yml
@@ -29,13 +29,13 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 8b274e2e-d4ab-41b8-aa99-f8aa73deb743
+      - 36f304bf-6417-4077-9ee8-e2950f5d55a7
       X-Runtime:
-      - '0.061279'
+      - '0.026028'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:07 GMT
+      - Thu, 28 May 2015 01:25:48 GMT
       Content-Length:
       - '1438'
       Connection:
@@ -59,5 +59,5 @@ http_interactions:
         \                                               \n<br/>                                                \n<br/>
         \                                               \n<br/>                                                \n\n</body>\n</html>\n"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:07 GMT
+  recorded_at: Thu, 28 May 2015 01:25:48 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/_delete_annotation/returns_TRUE_for_a_200_response_to_a_DELETE_request.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/_delete_annotation/returns_TRUE_for_a_200_response_to_a_DELETE_request.yml
@@ -29,13 +29,13 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 2bcce904-f0f7-4634-843d-cd076b912505
+      - c2cabf12-4434-4264-bcca-216a48cec05d
       X-Runtime:
-      - '0.031818'
+      - '0.026852'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:07 GMT
+      - Thu, 28 May 2015 01:25:48 GMT
       Content-Length:
       - '1436'
       Connection:
@@ -59,5 +59,5 @@ http_interactions:
         \                                               \n<br/>                                                \n<br/>
         \                                               \n<br/>                                                \n\n</body>\n</html>\n"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:07 GMT
+  recorded_at: Thu, 28 May 2015 01:25:48 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/_delete_annotation/returns_TRUE_for_a_202_response_to_a_DELETE_request.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/_delete_annotation/returns_TRUE_for_a_202_response_to_a_DELETE_request.yml
@@ -29,13 +29,13 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 14210990-38b2-4f3c-812e-188da313dba7
+      - 15899861-9b95-434b-82a1-f05b9694880c
       X-Runtime:
-      - '0.037773'
+      - '0.030239'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:07 GMT
+      - Thu, 28 May 2015 01:25:48 GMT
       Content-Length:
       - '1436'
       Connection:
@@ -59,5 +59,5 @@ http_interactions:
         \                                               \n<br/>                                                \n<br/>
         \                                               \n<br/>                                                \n\n</body>\n</html>\n"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:07 GMT
+  recorded_at: Thu, 28 May 2015 01:25:48 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/_delete_annotation/returns_TRUE_for_a_204_response_to_a_DELETE_request.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/_delete_annotation/returns_TRUE_for_a_204_response_to_a_DELETE_request.yml
@@ -29,13 +29,13 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - d4e0c39a-06d8-4333-a0c9-06714ad40033
+      - a5ade10c-9878-44c3-a706-6e2068052105
       X-Runtime:
-      - '0.038353'
+      - '0.031102'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:07 GMT
+      - Thu, 28 May 2015 01:25:48 GMT
       Content-Length:
       - '1436'
       Connection:
@@ -59,5 +59,5 @@ http_interactions:
         \                                               \n<br/>                                                \n<br/>
         \                                               \n<br/>                                                \n\n</body>\n</html>\n"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:07 GMT
+  recorded_at: Thu, 28 May 2015 01:25:48 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/_delete_annotation/returns_TRUE_for_a_404_response_to_a_DELETE_request.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/_delete_annotation/returns_TRUE_for_a_404_response_to_a_DELETE_request.yml
@@ -29,13 +29,13 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - c764a882-4b9a-466c-96d1-9e8af31e4646
+      - f8fa5ae0-4c61-4de0-84e2-aabae994cba8
       X-Runtime:
-      - '0.047105'
+      - '0.026153'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:07 GMT
+      - Thu, 28 May 2015 01:25:49 GMT
       Content-Length:
       - '1436'
       Connection:
@@ -59,5 +59,5 @@ http_interactions:
         \                                               \n<br/>                                                \n<br/>
         \                                               \n<br/>                                                \n\n</body>\n</html>\n"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:07 GMT
+  recorded_at: Thu, 28 May 2015 01:25:49 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/_delete_annotation/returns_TRUE_for_a_410_response_to_a_DELETE_request.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/_delete_annotation/returns_TRUE_for_a_410_response_to_a_DELETE_request.yml
@@ -29,13 +29,13 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 02a168a2-061a-4560-9168-25b6aaeb07d2
+      - 732478a3-f3d1-4f66-a80c-194a9928b9d0
       X-Runtime:
-      - '0.031490'
+      - '0.026571'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:07 GMT
+      - Thu, 28 May 2015 01:25:49 GMT
       Content-Length:
       - '1436'
       Connection:
@@ -59,5 +59,5 @@ http_interactions:
         \                                               \n<br/>                                                \n<br/>
         \                                               \n<br/>                                                \n\n</body>\n</html>\n"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:07 GMT
+  recorded_at: Thu, 28 May 2015 01:25:49 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/_delete_annotation/returns_TRUE_when_deleting_an_open_annotation_that_does_NOT_exist.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/_delete_annotation/returns_TRUE_when_deleting_an_open_annotation_that_does_NOT_exist.yml
@@ -29,13 +29,13 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - f8942ff0-133d-4b9a-a28d-46215c478919
+      - c478a0ce-5598-4ead-b4fe-e6df9b3d27f6
       X-Runtime:
-      - '0.034329'
+      - '0.020269'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:13 GMT
+      - Thu, 28 May 2015 01:25:55 GMT
       Content-Length:
       - '1452'
       Connection:
@@ -58,7 +58,7 @@ http_interactions:
         \                                               \n<br/>                                                \n<br/>
         \                                               \n\n</body>\n</html>\n"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:13 GMT
+  recorded_at: Thu, 28 May 2015 01:25:55 GMT
 - request:
     method: delete
     uri: http://localhost:3000/annotations/anno_does_not_exist
@@ -88,13 +88,13 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 474661ad-5d46-463d-a50b-950d513a3917
+      - f3123b3e-0907-415b-aefd-cbe869987f7d
       X-Runtime:
-      - '0.031949'
+      - '0.024601'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:13 GMT
+      - Thu, 28 May 2015 01:25:55 GMT
       Content-Length:
       - '1452'
       Connection:
@@ -119,5 +119,5 @@ http_interactions:
         \                                               \n<br/>                                                \n<br/>
         \                                               \n\n</body>\n</html>\n"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:13 GMT
+  recorded_at: Thu, 28 May 2015 01:25:55 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/_delete_annotation/returns_TRUE_when_deleting_an_open_annotation_that_exists.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/_delete_annotation/returns_TRUE_when_deleting_an_open_annotation_that_exists.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"2a598aae0675fc385f7e9e1181e4927c"
+      - W/"0a3e493737d5eea54dab6bb5313c5ebf"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 673d1f7f-582e-46ef-bce0-222546c45ff6
+      - e902c4fe-5d9d-49c6-b71f-ce67f5a67783
       X-Runtime:
-      - '4.062571'
+      - '3.867981'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:12 GMT
+      - Thu, 28 May 2015 01:25:52 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=Njg1YnVNdXBuSHNOdjZSYU1YZi9US1hld3BsU0xnLzJCYmsxSkJNYTVRWXJ4dlNSYjZodU9hZWRkSGkyYmU2VUZhdlBTVERzTFpGSFYzVnlqTmdINXp4aThPdFR4TlQzQVVFVlFEODBEeE1DVzFNWExhRjMvVjVDK0I4YzlpMVFnTDYvQnR6OWFCTmxJc2U2QWRyZHVmQWVqdG4wZmZ1Rk5zbms3NTZ2VG9NdjJxRVdZRGw2L21XNkdDMGRTeUZNOHNsWHJhUVdOVTRvMld3c1l1VTRNU2VzdEFhV0laSkJ4R3p5VUhhVlBsVk5nNWJseGZKYjI4b1FaWnU5Q3huby0tZzI3a1dNekNTeThXUHR1K1Brd3duZz09--5a2619e4276d033a144981026cfae7fe785a3179;
+      - _internal_session=VkJ1Yi9nN2ZCbzBrQnBMUDJ2NFlpSUxYMHhUcEZGeVdlek84YjB2c1FYaVNxLy9XMGp0SFh4VThvdHFyMTJWUmVuYXZSZE1pMnQxdHU5ZGw0RTl2RS95SHBTT3hwenExVzc3SVdCMHVqUXFmQTQzRFB3eWdUbHJuQkt6UWtWUWR4akloVnc4NlRjYmhxc21TNEd5ak1NeW1qbytJMHpNbW9RdEEvZUZqU1JHRW5XZ0xmUEIrSDlNNG1XVGhCQmxPbW4yMWJMYTNKL3gwYnduU0IycHhDVWdZaUN3eUxXN2ZuWDZTOHVFTStlWUlQL1loS0gvMnlUWjlWRnltQ1dpVC0teFJHeG5tNWVkTjBHMEdMYUxsdHdmZz09--2cdfe6035a311b71a7613d5c669a3587a1566de9;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310850717480","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/b5/85/9d/a3/b5859da3-768d-4607-b3bd-23379e589d5f","@type":"oa:Annotation","hasBody":"_:g70310850717480","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942037337960","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/3e/9a/61/ee/3e9a61ee-b125-4169-9dd4-2f5defb21142","@type":"oa:Annotation","hasBody":"_:g69942037337960","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:12 GMT
+  recorded_at: Thu, 28 May 2015 01:25:52 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:12 GMT
+      - Thu, 28 May 2015 01:25:53 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:12 GMT
+      - Thu, 28 May 2015 07:25:53 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:12 GMT
+  recorded_at: Thu, 28 May 2015 01:25:53 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:12 GMT
+      - Thu, 28 May 2015 01:25:53 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:12 GMT
+      - Thu, 28 May 2015 07:25:53 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:12 GMT
+  recorded_at: Thu, 28 May 2015 01:25:53 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:12 GMT
+      - Thu, 28 May 2015 01:25:53 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:12 GMT
+      - Thu, 28 May 2015 07:25:53 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:12 GMT
+  recorded_at: Thu, 28 May 2015 01:25:54 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:13 GMT
+      - Thu, 28 May 2015 01:25:54 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:13 GMT
+      - Thu, 28 May 2015 07:25:54 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:13 GMT
+  recorded_at: Thu, 28 May 2015 01:25:54 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/b5%2F85%2F9d%2Fa3%2Fb5859da3-768d-4607-b3bd-23379e589d5f
+    uri: http://localhost:3000/annotations/3e%2F9a%2F61%2Fee%2F3e9a61ee-b125-4169-9dd4-2f5defb21142
     body:
       encoding: US-ASCII
       string: ''
@@ -2481,27 +2481,27 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 03c000b4-4a58-4fcd-a36c-3fd8b3f14e2a
+      - f22c1b70-c139-472f-9433-fad79fc13bb0
       X-Runtime:
-      - '0.335240'
+      - '0.246173'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:13 GMT
+      - Thu, 28 May 2015 01:25:55 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=V2NlSE1iNk1HWXVSV3N1R3grbVhmMnhJRG5tZ3U0c0gwL0hzS2huY296SVdFQzQyMS84bkI2SkJoQ1IzYjRVSlFnc0dEeHZQckRIZW1WUW1iL0Rub1VhYWl1T2VGVDJhMDJUUUZWQWVIK2wxaTRSSmZkTzNvMWlrblFCYTVySlVvRlJhUG13aitwcysyZ1M0N3lFNXN0MTE4MzZOaWpLclZPQXg2L0RRTVZuZUZxV1ptRlVTSGtJU0xnd3hhRUJGLS05RUZrQlliZm5uZWwxWFBYVnc2RW5nPT0%3D--ee46b065a795650980b3ba3d316ac447ea1b77c7;
+      - _internal_session=OWl0M1dxTEFXMVBNMmZ1WlZiUCt3RTBpenFUcGNhekM4Q3Y1dW1RTDV1dDRrajRWbUpkMUxCWnd4NkxmYk5LaTRuZkhwUnpzMy9uWS8rS0duaDNoeGYwcDdPR0s2a1R1OVpyWUl6dkd4Yk5HcWl3aVFBRDZnOGF4MWxvRHJhNkRicHpQNnZHQjdOb1FEQzNIbVVkamR6MDJkTENuRUd1NmIvLyt3Smx3akdDYnhkdzRJMkhybFFkT0REcUphOStULS11MDVGNzhnd0p2NmFnbTlLVmw2Zk1nPT0%3D--1e1bcf613689b46172768512eb4879eab3e085d7;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:13 GMT
+  recorded_at: Thu, 28 May 2015 01:25:55 GMT
 - request:
     method: get
-    uri: http://localhost:3000/annotations/b5%2F85%2F9d%2Fa3%2Fb5859da3-768d-4607-b3bd-23379e589d5f
+    uri: http://localhost:3000/annotations/3e%2F9a%2F61%2Fee%2F3e9a61ee-b125-4169-9dd4-2f5defb21142
     body:
       encoding: US-ASCII
       string: ''
@@ -2528,22 +2528,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 2ca3f6fa-bb40-45cb-b96b-c1022412e42f
+      - f54258be-ff53-4dea-9dda-e26293dc94ec
       X-Runtime:
-      - '0.039992'
+      - '0.022640'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:13 GMT
+      - Thu, 28 May 2015 01:25:55 GMT
       Content-Length:
       - '272'
       Connection:
       - Keep-Alive
     body:
       encoding: UTF-8
-      string: "<h2>error getting b5/85/9d/a3/b5859da3-768d-4607-b3bd-23379e589d5f
-        from LDP</h2>Discovered tombstone resource at /anno/b5/85/9d/a3/b5859da3-768d-4607-b3bd-23379e589d5f
-        {jcr:createdBy=bypassAdmin, jcr:primaryType=fedora:Tombstone, jcr:created=2015-05-18T13:06:13.562-07:00}"
+      string: "<h2>error getting 3e/9a/61/ee/3e9a61ee-b125-4169-9dd4-2f5defb21142
+        from LDP</h2>Discovered tombstone resource at /anno/3e/9a/61/ee/3e9a61ee-b125-4169-9dd4-2f5defb21142
+        {jcr:createdBy=bypassAdmin, jcr:primaryType=fedora:Tombstone, jcr:created=2015-05-27T18:25:54.991-07:00}"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:13 GMT
+  recorded_at: Thu, 28 May 2015 01:25:55 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/_delete_annotation/validates_the_annotation_ID.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/_delete_annotation/validates_the_annotation_ID.yml
@@ -29,13 +29,13 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 64a23603-58e9-4698-95b6-f8155a4dac15
+      - 3164254e-893e-4ffa-a5e2-d3ae85f1c403
       X-Runtime:
-      - '0.040965'
+      - '0.027083'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:08 GMT
+      - Thu, 28 May 2015 01:25:49 GMT
       Content-Length:
       - '1446'
       Connection:
@@ -60,5 +60,5 @@ http_interactions:
         \                                               \n<br/>                                                \n<br/>
         \                                               \n\n</body>\n</html>\n"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:08 GMT
+  recorded_at: Thu, 28 May 2015 01:25:49 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/_get_annotations/returns_an_RDF_Graph.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/_get_annotations/returns_an_RDF_Graph.yml
@@ -31,13 +31,13 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - ba1d97a7-886d-4962-8913-c8bf45b9c59a
+      - 3e9e087c-763f-4b3c-9e8a-1be121759386
       X-Runtime:
-      - '0.003257'
+      - '0.008375'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:13 GMT
+      - Thu, 28 May 2015 01:25:55 GMT
       Content-Length:
       - '94'
       Connection:
@@ -46,7 +46,7 @@ http_interactions:
       encoding: UTF-8
       string: <html><body>You are being <a href="http://localhost:3000/search">redirected</a>.</body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:13 GMT
+  recorded_at: Thu, 28 May 2015 01:25:55 GMT
 - request:
     method: get
     uri: http://localhost:3000/search
@@ -80,13 +80,13 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - cd143396-7101-4e77-b46a-7fbeee96cf0e
+      - 08bf7e84-84be-48c9-8628-3018429a8c6e
       X-Runtime:
-      - '0.025025'
+      - '0.029570'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:14 GMT
+      - Thu, 28 May 2015 01:25:55 GMT
       Content-Length:
       - '181'
       Connection:
@@ -95,7 +95,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"@context":"http://iiif.io/api/presentation/2/context.json","@type":"sc:AnnotationList","within":{"@type":"sc:Layer","total":0},"resources":[],"@id":"http://localhost:3000/search"}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:14 GMT
+  recorded_at: Thu, 28 May 2015 01:25:55 GMT
 - request:
     method: get
     uri: http://iiif.io/api/presentation/2/context.json
@@ -115,7 +115,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:02 GMT
+      - Thu, 28 May 2015 01:28:57 GMT
       Server:
       - Apache/2.2.15 (Red Hat)
       Last-Modified:
@@ -127,7 +127,7 @@ http_interactions:
       Cache-Control:
       - max-age=86400
       Expires:
-      - Tue, 19 May 2015 20:09:02 GMT
+      - Fri, 29 May 2015 01:28:57 GMT
       Content-Type:
       - application/ld+json
       Access-Control-Allow-Origin:
@@ -193,7 +193,7 @@ http_interactions:
         \   \"language\":    {\"@id\": \"dc:language\"},\n\t\t    \"value\":       {\"@id\":
         \"rdf:value\"},\n\t\t    \"label\":       {\"@id\": \"rdfs:label\"}\n\t\t}\n\t]\n}"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:14 GMT
+  recorded_at: Thu, 28 May 2015 01:25:55 GMT
 - request:
     method: get
     uri: http://iiif.io/api/presentation/2/context.json
@@ -213,7 +213,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:02 GMT
+      - Thu, 28 May 2015 01:28:57 GMT
       Server:
       - Apache/2.2.15 (Red Hat)
       Last-Modified:
@@ -225,7 +225,7 @@ http_interactions:
       Cache-Control:
       - max-age=86400
       Expires:
-      - Tue, 19 May 2015 20:09:02 GMT
+      - Fri, 29 May 2015 01:28:57 GMT
       Content-Type:
       - application/ld+json
       Access-Control-Allow-Origin:
@@ -291,5 +291,5 @@ http_interactions:
         \   \"language\":    {\"@id\": \"dc:language\"},\n\t\t    \"value\":       {\"@id\":
         \"rdf:value\"},\n\t\t    \"label\":       {\"@id\": \"rdfs:label\"}\n\t\t}\n\t]\n}"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:14 GMT
+  recorded_at: Thu, 28 May 2015 01:25:56 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/_get_annotations/returns_an_RDF_Graph_that_contains_an_AnnotationList.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/_get_annotations/returns_an_RDF_Graph_that_contains_an_AnnotationList.yml
@@ -31,13 +31,13 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 364b2de7-7cd3-4ae5-a7f9-708969e350ff
+      - 3fd5a4e3-1f29-44cb-989b-d6f7bd86b0a6
       X-Runtime:
-      - '0.003035'
+      - '0.003009'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:14 GMT
+      - Thu, 28 May 2015 01:25:56 GMT
       Content-Length:
       - '94'
       Connection:
@@ -46,7 +46,7 @@ http_interactions:
       encoding: UTF-8
       string: <html><body>You are being <a href="http://localhost:3000/search">redirected</a>.</body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:14 GMT
+  recorded_at: Thu, 28 May 2015 01:25:56 GMT
 - request:
     method: get
     uri: http://localhost:3000/search
@@ -80,13 +80,13 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 25b92e22-ece9-4d73-a56a-12734a773716
+      - 3f895d9d-45f6-4a58-a8b5-235c6833bfeb
       X-Runtime:
-      - '0.012135'
+      - '0.009898'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:14 GMT
+      - Thu, 28 May 2015 01:25:56 GMT
       Content-Length:
       - '181'
       Connection:
@@ -95,7 +95,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"@context":"http://iiif.io/api/presentation/2/context.json","@type":"sc:AnnotationList","within":{"@type":"sc:Layer","total":0},"resources":[],"@id":"http://localhost:3000/search"}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:14 GMT
+  recorded_at: Thu, 28 May 2015 01:25:56 GMT
 - request:
     method: get
     uri: http://iiif.io/api/presentation/2/context.json
@@ -115,7 +115,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:02 GMT
+      - Thu, 28 May 2015 01:28:58 GMT
       Server:
       - Apache/2.2.15 (Red Hat)
       Last-Modified:
@@ -127,7 +127,7 @@ http_interactions:
       Cache-Control:
       - max-age=86400
       Expires:
-      - Tue, 19 May 2015 20:09:02 GMT
+      - Fri, 29 May 2015 01:28:58 GMT
       Content-Type:
       - application/ld+json
       Access-Control-Allow-Origin:
@@ -193,7 +193,7 @@ http_interactions:
         \   \"language\":    {\"@id\": \"dc:language\"},\n\t\t    \"value\":       {\"@id\":
         \"rdf:value\"},\n\t\t    \"label\":       {\"@id\": \"rdfs:label\"}\n\t\t}\n\t]\n}"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:14 GMT
+  recorded_at: Thu, 28 May 2015 01:25:56 GMT
 - request:
     method: get
     uri: http://iiif.io/api/presentation/2/context.json
@@ -213,7 +213,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:02 GMT
+      - Thu, 28 May 2015 01:28:58 GMT
       Server:
       - Apache/2.2.15 (Red Hat)
       Last-Modified:
@@ -225,7 +225,7 @@ http_interactions:
       Cache-Control:
       - max-age=86400
       Expires:
-      - Tue, 19 May 2015 20:09:02 GMT
+      - Fri, 29 May 2015 01:28:58 GMT
       Content-Type:
       - application/ld+json
       Access-Control-Allow-Origin:
@@ -291,5 +291,5 @@ http_interactions:
         \   \"language\":    {\"@id\": \"dc:language\"},\n\t\t    \"value\":       {\"@id\":
         \"rdf:value\"},\n\t\t    \"label\":       {\"@id\": \"rdfs:label\"}\n\t\t}\n\t]\n}"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:14 GMT
+  recorded_at: Thu, 28 May 2015 01:25:56 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/_get_annotations/returns_an_annotation_list_with_an_annotation_created_by_a_prior_POST.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/_get_annotations/returns_an_annotation_list_with_an_annotation_created_by_a_prior_POST.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"8cfba80ee206028f3f2c46777fab7c18"
+      - W/"9d0d564c3432203463a01efcfd3c69a1"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 2d69bbd6-bea1-4dd6-9ca8-f3d86eaf78e1
+      - 18e61df2-e525-45ff-8987-e0d0b0838873
       X-Runtime:
-      - '1.807308'
+      - '2.285461'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:16 GMT
+      - Thu, 28 May 2015 01:25:58 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=RVptSERVNXM5YnByRTFYS2FXT3RHVG9oYUlxeHZJZW1jcTRkbWQvai9FSU5SYWxUQ0RKTFZkRm8zei9YREtxT21UYmd2VHRRVURJblFLL3dlYytIWEFEdGg3V2FxcURwSktMUVgvOTdCN0tWKzBOWkFYMkk5SjVOS0xpVVIyUENHTVQ2MUlBTmlxeEZJKzRlZk1HeW5uczFBTEt0Uk1uUXFqV2lzSmpyOUJJdytkWTZMbG0wcWRJN1BFb0pReEhoNWE0Y0lmRkZlR3lzS012NU5XYUdtWXhWNnRvZEY1aEZsTW9DUmlkWDlKQng5YzZRTllOc2dUdlZBMmJWSGxNai0tc251YTJrWm1PVW5jNk9xcFpJdVJVUT09--63b2db4c082fc0f6d05715763db01e5fc3c91b2e;
+      - _internal_session=dzQvY3FhZWhCWlYzRWVqU3Q4R1g5bldCUVJkeFdZeGlBRncvVXZIMVFtN3hySXJ5NHZ1ZUhOVzhpQXdYY2pJd0ZOU3cxSjJPTFlNRmxGUjFRcmdrZ25HcDdXd2dLMG50cldnOUNxNHZxYzVJMGkwWE0vT1NVdFJqdDgrS0pTVTVnOG1YYjRtWTQ3V3poN3BXQnJhS2NrazVTZ0FneUgzcWlhVHlRZU5KMzcwem1lOTV1dFR0U2d3a0FmSUFRaTZMOG9jdEFFK0VoK0M0amxQRWJjZXlxdWFtMUlaQUFRQy9ZcVRvdThLaG9iUjVKYkdzOW9rd2FTTnMrKzJvbXYwci0tV2V2akdtN0pLY2NtbUZHUldnNjRLUT09--c0cf1686fe5517403c938f373dd451da994c24d6;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310874467640","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/34/10/9b/76/34109b76-7ff4-48db-a5d4-4703e8c0042e","@type":"oa:Annotation","hasBody":"_:g70310874467640","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942035487240","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/4f/af/b9/0a/4fafb90a-cb89-4a61-bbb0-190fe53cc6b0","@type":"oa:Annotation","hasBody":"_:g69942035487240","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:16 GMT
+  recorded_at: Thu, 28 May 2015 01:25:58 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:16 GMT
+      - Thu, 28 May 2015 01:25:59 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:16 GMT
+      - Thu, 28 May 2015 07:25:59 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:16 GMT
+  recorded_at: Thu, 28 May 2015 01:25:59 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:16 GMT
+      - Thu, 28 May 2015 01:25:59 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:16 GMT
+      - Thu, 28 May 2015 07:25:59 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:16 GMT
+  recorded_at: Thu, 28 May 2015 01:25:59 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:16 GMT
+      - Thu, 28 May 2015 01:26:00 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:16 GMT
+      - Thu, 28 May 2015 07:26:00 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:16 GMT
+  recorded_at: Thu, 28 May 2015 01:26:00 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:06:17 GMT
+      - Thu, 28 May 2015 01:26:00 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:06:17 GMT
+      - Thu, 28 May 2015 07:26:00 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,7 +2451,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:17 GMT
+  recorded_at: Thu, 28 May 2015 01:26:00 GMT
 - request:
     method: get
     uri: http://localhost:3000/annotations/
@@ -2483,13 +2483,13 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 161c7fa6-b3d2-4ffa-afa0-704bbb5aef6a
+      - e0af1cfc-aee8-40eb-9535-eb4d1dddef71
       X-Runtime:
-      - '0.002922'
+      - '0.002703'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:17 GMT
+      - Thu, 28 May 2015 01:26:00 GMT
       Content-Length:
       - '94'
       Connection:
@@ -2498,7 +2498,7 @@ http_interactions:
       encoding: UTF-8
       string: <html><body>You are being <a href="http://localhost:3000/search">redirected</a>.</body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:17 GMT
+  recorded_at: Thu, 28 May 2015 01:26:00 GMT
 - request:
     method: get
     uri: http://localhost:3000/search
@@ -2528,27 +2528,27 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"b8c43a97907457eb0d3b6831c55a31b7"
+      - W/"5bf15f843911ce6cf075d85695446663"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 4137f1f1-aab0-4bd8-86b1-e35a68f2ec50
+      - 6f45d0fd-792d-4afe-8f4b-f50c207c9518
       X-Runtime:
-      - '1.569506'
+      - '1.669761'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:18 GMT
+      - Thu, 28 May 2015 01:26:02 GMT
       Content-Length:
       - '512'
       Connection:
       - Keep-Alive
     body:
       encoding: UTF-8
-      string: '{"@context":"http://iiif.io/api/presentation/2/context.json","@type":"sc:AnnotationList","within":{"@type":"sc:Layer","total":1},"resources":[{"@id":"http://your.triannon-server.com/annotations/34/10/9b/76/34109b76-7ff4-48db-a5d4-4703e8c0042e","@type":"oa:Annotation","motivation":"oa:commenting","on":"http://purl.stanford.edu/kq131cs7229","resource":{"@id":"_:b0","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+      string: '{"@context":"http://iiif.io/api/presentation/2/context.json","@type":"sc:AnnotationList","within":{"@type":"sc:Layer","total":1},"resources":[{"@id":"http://your.triannon-server.com/annotations/4f/af/b9/0a/4fafb90a-cb89-4a61-bbb0-190fe53cc6b0","@type":"oa:Annotation","motivation":"oa:commenting","on":"http://purl.stanford.edu/kq131cs7229","resource":{"@id":"_:b0","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
         love this!","format":"text/plain","language":"en"}}],"@id":"http://localhost:3000/search"}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:18 GMT
+  recorded_at: Thu, 28 May 2015 01:26:02 GMT
 - request:
     method: get
     uri: http://iiif.io/api/presentation/2/context.json
@@ -2568,7 +2568,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:07 GMT
+      - Thu, 28 May 2015 01:29:04 GMT
       Server:
       - Apache/2.2.15 (Red Hat)
       Last-Modified:
@@ -2580,7 +2580,7 @@ http_interactions:
       Cache-Control:
       - max-age=86400
       Expires:
-      - Tue, 19 May 2015 20:09:07 GMT
+      - Fri, 29 May 2015 01:29:04 GMT
       Content-Type:
       - application/ld+json
       Access-Control-Allow-Origin:
@@ -2646,7 +2646,7 @@ http_interactions:
         \   \"language\":    {\"@id\": \"dc:language\"},\n\t\t    \"value\":       {\"@id\":
         \"rdf:value\"},\n\t\t    \"label\":       {\"@id\": \"rdfs:label\"}\n\t\t}\n\t]\n}"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:18 GMT
+  recorded_at: Thu, 28 May 2015 01:26:02 GMT
 - request:
     method: get
     uri: http://iiif.io/api/presentation/2/context.json
@@ -2666,7 +2666,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:07 GMT
+      - Thu, 28 May 2015 01:29:04 GMT
       Server:
       - Apache/2.2.15 (Red Hat)
       Last-Modified:
@@ -2678,7 +2678,7 @@ http_interactions:
       Cache-Control:
       - max-age=86400
       Expires:
-      - Tue, 19 May 2015 20:09:07 GMT
+      - Fri, 29 May 2015 01:29:04 GMT
       Content-Type:
       - application/ld+json
       Access-Control-Allow-Origin:
@@ -2744,10 +2744,10 @@ http_interactions:
         \   \"language\":    {\"@id\": \"dc:language\"},\n\t\t    \"value\":       {\"@id\":
         \"rdf:value\"},\n\t\t    \"label\":       {\"@id\": \"rdfs:label\"}\n\t\t}\n\t]\n}"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:18 GMT
+  recorded_at: Thu, 28 May 2015 01:26:03 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/34%2F10%2F9b%2F76%2F34109b76-7ff4-48db-a5d4-4703e8c0042e
+    uri: http://localhost:3000/annotations/4f%2Faf%2Fb9%2F0a%2F4fafb90a-cb89-4a61-bbb0-190fe53cc6b0
     body:
       encoding: US-ASCII
       string: ''
@@ -2774,22 +2774,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - ca6d05d7-5dfa-4fdf-a423-e7bb881f0901
+      - bf3e35e0-9f8c-44c8-bc50-0143c28320fa
       X-Runtime:
-      - '0.248550'
+      - '0.227728'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:06:19 GMT
+      - Thu, 28 May 2015 01:26:03 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=Qzc4UnVTT0hEMzdMc0FqenJQQWppQkpObWYrSFZBaUFHV1dWc2dJZmVWVDREQmNOeVVzZXVzQ1lsVHBiL1prZHRiRmw1Qzd2SXYybHJvU0wyaG45NUlmdTFBMVNUeStvRjRNOVFSdTNvYTVYZmV1elBpRFhjQmhJOE4ycE5kVWF4R0x3SUNBMmtaZU43aUZZWWdkMy9FbnU4WDNia3hjUWRZSlFwbDkxa0VoYjN6dXlNbXpPUHpNZWFJeGV0bVpILS1aam1YTVhmQzlJby9TQmNROFN5ejhnPT0%3D--a283c20f14cb8d853bd226fa3015907ecd9b3aef;
+      - _internal_session=SU9aWVVGVG1MdGZrMVN3WFFBMjdmYWRDR1BhNk1QNDhMNitiellYYWF3UFo2TXVBSnh1bTQ0a0RXRU52Z21BdlBTYm4yOG1lcUhFSjVCOWZGdks3T1pYMkxzL0xIYVBWRjIvMW5JNm1qSWdOQTJPdVYzMkZyTjZpeEJRSXZTSjRaYkgrYk9XbHBkSFVvUjJsaVBzRTgvRHhWYjRiZ0pSbmhLU1lmS0p6MmwwNGtlVk1TR0d5RUlDWHBYaXFOdlFPLS1Pa1VWWTN4Z1pocEUwKzF5TkJIc0x3PT0%3D--2260914b1124646fa44d868e0ab49c37898572ef;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:06:19 GMT
+  recorded_at: Thu, 28 May 2015 01:26:03 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/_post_annotation/does_not_raise_an_error_when_submitting_a_valid_open_annotation.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/_post_annotation/does_not_raise_an_error_when_submitting_a_valid_open_annotation.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"3cbc6006cf1b30e293495c34155684e2"
+      - W/"c40489212f1632af38de85095586ac91"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 2bb73345-bf67-44b2-8e33-c629a15953c6
+      - dcf4269e-f3e3-41cb-a853-b419c667c951
       X-Runtime:
-      - '1.677503'
+      - '2.312365'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:09:14 GMT
+      - Thu, 28 May 2015 01:30:50 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=VzE2d0xlNEpBcHhxTVIyZUtzMDB5NVY0Ly9sVW9oY2I2NEY0NExRQ0ZqL1dpWU0vYmVVVUovMVI5cUJjeE84NVlhVFRnaVpqaW5nWGJPYlhnaXZmOEE0cmMrU0FUdjNla3EyaFNzMUZrYUUyWXMxd2VjeVdPb0E0YjhaaExSMUVVV3RobDJ3R0VQRGF5N0ZyMzBoQzN5WW9BdUhnUVJTZnpZVStmSWJMTm5NYjBYUFNkRHZkZjc5cXdGa1JvcnFqL2wvYUF6R3hzTkkvWUhvRGtEQTdRR3pqTjVqeFAxWWFNN1dhVEwwRmo2cFpDWEkyMXFLeE9BM254aFpHeVllVy0tSXJkYzJZMktWZVE2clBnRWdDeGVOUT09--ca5c8993f4ddd479289f270fc3f084f367c08d14;
+      - _internal_session=WDdzcDFxYXZuT210RElibWphamhOZ25oK0VtQS9TUzhrdDlsUnJEWHUrZ2pHa0dBdTJVL1Rra0FmUFpxWGN6UHp2SE51NnhmY1FBTlVKc2krTzMrS2dFRTA0SzNqMzVjSlVFdFlQbDFpZzg3cHFUMXUzbFBnZ1cvUk9Xcnd4S2lHYzl1ZjNsZ3IzclBLTGxTU2VlbkU4YzJRdWdoWityTytIRlM0THIvS2ozcDZDTXgwa2tqbzlMcEEvSzhhREJzQUNPVTlOR0xIQzI4UzZMaGJDU1pLNVFLUEd3S25mcFJhdjZIemJ0dGZwdmtab1RiNWNJM3hKNHFjSnE2R0xkbi0tbWtIZlU3YzU1UzVtSFJXRndnTzF4dz09--1eada0e4b7c31305a0b47d44133faf1c15792577;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310846064840","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/10/28/b0/ff/1028b0ff-92c0-4bd7-ae72-9a88ab3b67b8","@type":"oa:Annotation","hasBody":"_:g70310846064840","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942033844520","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/a3/ff/a2/68/a3ffa268-fef6-4a89-b116-d0307eb824d8","@type":"oa:Annotation","hasBody":"_:g69942033844520","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:14 GMT
+  recorded_at: Thu, 28 May 2015 01:30:50 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:14 GMT
+      - Thu, 28 May 2015 01:30:50 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:14 GMT
+      - Thu, 28 May 2015 07:30:50 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:14 GMT
+  recorded_at: Thu, 28 May 2015 01:30:50 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:14 GMT
+      - Thu, 28 May 2015 01:30:50 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:14 GMT
+      - Thu, 28 May 2015 07:30:50 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:15 GMT
+  recorded_at: Thu, 28 May 2015 01:30:51 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:15 GMT
+      - Thu, 28 May 2015 01:30:51 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:15 GMT
+      - Thu, 28 May 2015 07:30:51 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:15 GMT
+  recorded_at: Thu, 28 May 2015 01:30:51 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:15 GMT
+      - Thu, 28 May 2015 01:30:51 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:15 GMT
+      - Thu, 28 May 2015 07:30:51 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:15 GMT
+  recorded_at: Thu, 28 May 2015 01:30:52 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/10%2F28%2Fb0%2Fff%2F1028b0ff-92c0-4bd7-ae72-9a88ab3b67b8
+    uri: http://localhost:3000/annotations/a3%2Fff%2Fa2%2F68%2Fa3ffa268-fef6-4a89-b116-d0307eb824d8
     body:
       encoding: US-ASCII
       string: ''
@@ -2481,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 0d58a7e5-88cb-436f-8216-9996926ca290
+      - 68d01a78-24dd-4a2f-95a4-4d0742828f83
       X-Runtime:
-      - '0.232045'
+      - '0.151745'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:09:16 GMT
+      - Thu, 28 May 2015 01:30:52 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=dW9ocWkrVlFGdWhEWklqS1praHU0cWwvRjVnbmxqdzdoMWtzMDFwbERiLzJtemM2d2pxMlV2RE1HZHJiTWkvUy9JWTdGRHhuWkdxWXY1T1lnYXhlZXF3YnpYWHF6SnlFbHk5UTRLTDFOZTEzZ0VZNm10YmlFL3lLeDJHQVh6UkpWdmVKZmliRlJlZzFHUXV3YVpQc2RkSUh4bEttdENrUW5uUDh5WklJNUZaR2F1NXNiZXRRL3kyQlJKbUxlaUpzLS1LNWF1OHZPRzg1VVFFMGYrK2tXZ1pnPT0%3D--044b5f2b16c5d02c2fc2e839b948ca69a0846a4f;
+      - _internal_session=K2xqM0NMQ01Ma3VrRHd5QTQzci9xMzZCenZiRDk2eFJEaXQ0aVUweFdrR2FQUDI1RUNZK1RFUTZ4WkNaeUpzUVpSTkg4R2RGbmZXTTMyUUlxOWRHQ3hRYkh5MCszd2p1VlcxNXdZMmdTVWJkSjFFOENXa0JENDRKRGc1aHFJOEVSZXA1dU1BbzQ3N3dCa2JUM09NcnlhMXpPZjZBYUpoN0c5QmdyRmJjSm42K2RWeXQzMjVOMXl0N25HZ2dyb1drLS1IaUhiZEtyMlFoaUQxdG9BNW5KNVRnPT0%3D--847035c6d5fa4e2ff3ebfe84d0e5631bb5c672b1;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:16 GMT
+  recorded_at: Thu, 28 May 2015 01:30:52 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/_post_annotation/logs_exceptions.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/_post_annotation/logs_exceptions.yml
@@ -25,15 +25,15 @@ http_interactions:
       Content-Type:
       - text/html; charset=utf-8
       Content-Length:
-      - '152196'
+      - '152203'
       X-Request-Id:
-      - c94bd9c1-6425-44ec-ac33-f856cf247851
+      - 75a664ad-7bc9-45f0-b3c1-ccdcfa0423b2
       X-Runtime:
-      - '0.449579'
+      - '0.239530'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:25:49 GMT
+      - Thu, 28 May 2015 01:31:03 GMT
       Connection:
       - Keep-Alive
     body:
@@ -77,7 +77,7 @@ http_interactions:
         \   }\n  </script>\n</head>\n<body>\n\n<header>\n  <h1>Template is missing</h1>\n</header>\n\n<div
         id=\"container\">\n  <h2>Missing template triannon/annotations/new, triannon/application/new
         with {:locale=&gt;[:en], :formats=&gt;[:jsonld], :variants=&gt;[], :handlers=&gt;[:erb,
-        :builder, :raw, :ruby, :coffee, :jbuilder]}. Searched in:\n  * &quot;/data/src/dlss/ld4l_data/annotations/triannon/spec/internal/app/views&quot;\n
+        :builder, :raw, :ruby, :coffee, :jbuilder, :haml]}. Searched in:\n  * &quot;/data/src/dlss/ld4l_data/annotations/triannon/spec/internal/app/views&quot;\n
         \ * &quot;/data/src/dlss/ld4l_data/annotations/triannon/app/views&quot;\n</h2>\n\n
         \     <div class=\"source \" id=\"frame-source-0\">\n      <div class=\"info\">\n
         \       Extracted source (around line <strong>#46</strong>):\n      </div>\n
@@ -1668,7 +1668,7 @@ http_interactions:
         &quot;gzip, deflate&quot;\nREMOTE_ADDR: &quot;127.0.0.1&quot;\nREMOTE_HOST:
         &quot;127.0.0.1&quot;\nSERVER_NAME: &quot;localhost&quot;\nSERVER_PROTOCOL:
         &quot;HTTP/1.1&quot;</pre></div>\n</div>\n\n<h2 style=\"margin-top: 30px\">Response</h2>\n<p><b>Headers</b>:</p>
-        <pre>None</pre>\n\n</div>\n\n\n</body>\n</html>\n<div id=\"console\"\n  data-remote-path='console/repl_sessions/fac52f1b2e9b8ecf497ee799cb6747fe'\n
+        <pre>None</pre>\n\n</div>\n\n\n</body>\n</html>\n<div id=\"console\"\n  data-remote-path='console/repl_sessions/63a8af0397be526a98b861e616fe5e6a'\n
         \ data-initial-prompt='>> '>\n</div>\n\n\n<script type=\"text/javascript\">\n(function()
         {\n  // DOM helpers\nfunction hasClass(el, className) {\n  var regex = new
         RegExp('(?:^|\\\\s)' + className + '(?!\\\\S)', 'g');\n  return el.className.match(regex);\n}\n\nfunction
@@ -1865,7 +1865,7 @@ http_interactions:
         \   resizerElement.addEventListener('mouseup', recordConsoleElementHeight);\n
         \ });\n});\n\n}).call(this);\n</script>\n\n"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:25:49 GMT
+  recorded_at: Thu, 28 May 2015 01:31:03 GMT
 - request:
     method: post
     uri: http://localhost:3000/annotations/
@@ -1891,15 +1891,15 @@ http_interactions:
       Content-Type:
       - text/html; charset=utf-8
       Content-Length:
-      - '152196'
+      - '152203'
       X-Request-Id:
-      - 619fed3a-3a32-4de5-8c77-2fda13697a56
+      - 9d073325-beaf-43bb-843a-c0c5cfe74123
       X-Runtime:
-      - '0.299375'
+      - '0.213683'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:25:50 GMT
+      - Thu, 28 May 2015 01:31:04 GMT
       Connection:
       - Keep-Alive
     body:
@@ -1943,7 +1943,7 @@ http_interactions:
         \   }\n  </script>\n</head>\n<body>\n\n<header>\n  <h1>Template is missing</h1>\n</header>\n\n<div
         id=\"container\">\n  <h2>Missing template triannon/annotations/new, triannon/application/new
         with {:locale=&gt;[:en], :formats=&gt;[:jsonld], :variants=&gt;[], :handlers=&gt;[:erb,
-        :builder, :raw, :ruby, :coffee, :jbuilder]}. Searched in:\n  * &quot;/data/src/dlss/ld4l_data/annotations/triannon/spec/internal/app/views&quot;\n
+        :builder, :raw, :ruby, :coffee, :jbuilder, :haml]}. Searched in:\n  * &quot;/data/src/dlss/ld4l_data/annotations/triannon/spec/internal/app/views&quot;\n
         \ * &quot;/data/src/dlss/ld4l_data/annotations/triannon/app/views&quot;\n</h2>\n\n
         \     <div class=\"source \" id=\"frame-source-0\">\n      <div class=\"info\">\n
         \       Extracted source (around line <strong>#46</strong>):\n      </div>\n
@@ -3534,7 +3534,7 @@ http_interactions:
         &quot;gzip, deflate&quot;\nREMOTE_ADDR: &quot;127.0.0.1&quot;\nREMOTE_HOST:
         &quot;127.0.0.1&quot;\nSERVER_NAME: &quot;localhost&quot;\nSERVER_PROTOCOL:
         &quot;HTTP/1.1&quot;</pre></div>\n</div>\n\n<h2 style=\"margin-top: 30px\">Response</h2>\n<p><b>Headers</b>:</p>
-        <pre>None</pre>\n\n</div>\n\n\n</body>\n</html>\n<div id=\"console\"\n  data-remote-path='console/repl_sessions/ee8912f02a105dda9bd9c022b3caaf01'\n
+        <pre>None</pre>\n\n</div>\n\n\n</body>\n</html>\n<div id=\"console\"\n  data-remote-path='console/repl_sessions/5a12e2b28402bc3e5f132a67bdd46f22'\n
         \ data-initial-prompt='>> '>\n</div>\n\n\n<script type=\"text/javascript\">\n(function()
         {\n  // DOM helpers\nfunction hasClass(el, className) {\n  var regex = new
         RegExp('(?:^|\\\\s)' + className + '(?!\\\\S)', 'g');\n  return el.className.match(regex);\n}\n\nfunction
@@ -3731,7 +3731,7 @@ http_interactions:
         \   resizerElement.addEventListener('mouseup', recordConsoleElementHeight);\n
         \ });\n});\n\n}).call(this);\n</script>\n\n"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:25:50 GMT
+  recorded_at: Thu, 28 May 2015 01:31:04 GMT
 - request:
     method: post
     uri: http://localhost:3000/annotations/
@@ -3757,15 +3757,15 @@ http_interactions:
       Content-Type:
       - text/html; charset=utf-8
       Content-Length:
-      - '152196'
+      - '152203'
       X-Request-Id:
-      - a4ce889f-ea70-4db0-851a-06770793b216
+      - 4b4e762c-c45e-41d3-b887-850408f8492b
       X-Runtime:
-      - '0.263309'
+      - '0.255538'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:25:52 GMT
+      - Thu, 28 May 2015 01:31:07 GMT
       Connection:
       - Keep-Alive
     body:
@@ -3809,7 +3809,7 @@ http_interactions:
         \   }\n  </script>\n</head>\n<body>\n\n<header>\n  <h1>Template is missing</h1>\n</header>\n\n<div
         id=\"container\">\n  <h2>Missing template triannon/annotations/new, triannon/application/new
         with {:locale=&gt;[:en], :formats=&gt;[:jsonld], :variants=&gt;[], :handlers=&gt;[:erb,
-        :builder, :raw, :ruby, :coffee, :jbuilder]}. Searched in:\n  * &quot;/data/src/dlss/ld4l_data/annotations/triannon/spec/internal/app/views&quot;\n
+        :builder, :raw, :ruby, :coffee, :jbuilder, :haml]}. Searched in:\n  * &quot;/data/src/dlss/ld4l_data/annotations/triannon/spec/internal/app/views&quot;\n
         \ * &quot;/data/src/dlss/ld4l_data/annotations/triannon/app/views&quot;\n</h2>\n\n
         \     <div class=\"source \" id=\"frame-source-0\">\n      <div class=\"info\">\n
         \       Extracted source (around line <strong>#46</strong>):\n      </div>\n
@@ -5400,7 +5400,7 @@ http_interactions:
         &quot;gzip, deflate&quot;\nREMOTE_ADDR: &quot;127.0.0.1&quot;\nREMOTE_HOST:
         &quot;127.0.0.1&quot;\nSERVER_NAME: &quot;localhost&quot;\nSERVER_PROTOCOL:
         &quot;HTTP/1.1&quot;</pre></div>\n</div>\n\n<h2 style=\"margin-top: 30px\">Response</h2>\n<p><b>Headers</b>:</p>
-        <pre>None</pre>\n\n</div>\n\n\n</body>\n</html>\n<div id=\"console\"\n  data-remote-path='console/repl_sessions/87ab03b6260c5ed29f94e6b87d11cc86'\n
+        <pre>None</pre>\n\n</div>\n\n\n</body>\n</html>\n<div id=\"console\"\n  data-remote-path='console/repl_sessions/0280893691edff2061aba16c2fa048df'\n
         \ data-initial-prompt='>> '>\n</div>\n\n\n<script type=\"text/javascript\">\n(function()
         {\n  // DOM helpers\nfunction hasClass(el, className) {\n  var regex = new
         RegExp('(?:^|\\\\s)' + className + '(?!\\\\S)', 'g');\n  return el.className.match(regex);\n}\n\nfunction
@@ -5597,5 +5597,5 @@ http_interactions:
         \   resizerElement.addEventListener('mouseup', recordConsoleElementHeight);\n
         \ });\n});\n\n}).call(this);\n</script>\n\n"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:25:52 GMT
+  recorded_at: Thu, 28 May 2015 01:31:07 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/_post_annotation/logs_exceptions_for_RestClient_Exception.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/_post_annotation/logs_exceptions_for_RestClient_Exception.yml
@@ -25,15 +25,15 @@ http_interactions:
       Content-Type:
       - text/html; charset=utf-8
       Content-Length:
-      - '152196'
+      - '152203'
       X-Request-Id:
-      - 8774e6f0-72dd-4707-9c8d-9239177edb1e
+      - 19ef165a-737d-4f16-9096-f7f237d33376
       X-Runtime:
-      - '0.505227'
+      - '0.308750'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:30:56 GMT
+      - Thu, 28 May 2015 01:30:56 GMT
       Connection:
       - Keep-Alive
     body:
@@ -77,7 +77,7 @@ http_interactions:
         \   }\n  </script>\n</head>\n<body>\n\n<header>\n  <h1>Template is missing</h1>\n</header>\n\n<div
         id=\"container\">\n  <h2>Missing template triannon/annotations/new, triannon/application/new
         with {:locale=&gt;[:en], :formats=&gt;[:jsonld], :variants=&gt;[], :handlers=&gt;[:erb,
-        :builder, :raw, :ruby, :coffee, :jbuilder]}. Searched in:\n  * &quot;/data/src/dlss/ld4l_data/annotations/triannon/spec/internal/app/views&quot;\n
+        :builder, :raw, :ruby, :coffee, :jbuilder, :haml]}. Searched in:\n  * &quot;/data/src/dlss/ld4l_data/annotations/triannon/spec/internal/app/views&quot;\n
         \ * &quot;/data/src/dlss/ld4l_data/annotations/triannon/app/views&quot;\n</h2>\n\n
         \     <div class=\"source \" id=\"frame-source-0\">\n      <div class=\"info\">\n
         \       Extracted source (around line <strong>#46</strong>):\n      </div>\n
@@ -1668,7 +1668,7 @@ http_interactions:
         &quot;gzip, deflate&quot;\nREMOTE_ADDR: &quot;127.0.0.1&quot;\nREMOTE_HOST:
         &quot;127.0.0.1&quot;\nSERVER_NAME: &quot;localhost&quot;\nSERVER_PROTOCOL:
         &quot;HTTP/1.1&quot;</pre></div>\n</div>\n\n<h2 style=\"margin-top: 30px\">Response</h2>\n<p><b>Headers</b>:</p>
-        <pre>None</pre>\n\n</div>\n\n\n</body>\n</html>\n<div id=\"console\"\n  data-remote-path='console/repl_sessions/afed1390762e0ae6820f588ad4e9df5c'\n
+        <pre>None</pre>\n\n</div>\n\n\n</body>\n</html>\n<div id=\"console\"\n  data-remote-path='console/repl_sessions/f27c6dd7039d5518e85e75519ff2de5b'\n
         \ data-initial-prompt='>> '>\n</div>\n\n\n<script type=\"text/javascript\">\n(function()
         {\n  // DOM helpers\nfunction hasClass(el, className) {\n  var regex = new
         RegExp('(?:^|\\\\s)' + className + '(?!\\\\S)', 'g');\n  return el.className.match(regex);\n}\n\nfunction
@@ -1865,7 +1865,7 @@ http_interactions:
         \   resizerElement.addEventListener('mouseup', recordConsoleElementHeight);\n
         \ });\n});\n\n}).call(this);\n</script>\n\n"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:30:56 GMT
+  recorded_at: Thu, 28 May 2015 01:30:56 GMT
 - request:
     method: post
     uri: http://localhost:3000/annotations/
@@ -1891,15 +1891,15 @@ http_interactions:
       Content-Type:
       - text/html; charset=utf-8
       Content-Length:
-      - '152196'
+      - '152203'
       X-Request-Id:
-      - 47ef9622-5bcb-4b89-8abd-3cc2aa93e83f
+      - a9daa3d9-8964-4fb5-858b-d7d8960ace4a
       X-Runtime:
-      - '0.257700'
+      - '0.223821'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:30:58 GMT
+      - Thu, 28 May 2015 01:30:58 GMT
       Connection:
       - Keep-Alive
     body:
@@ -1943,7 +1943,7 @@ http_interactions:
         \   }\n  </script>\n</head>\n<body>\n\n<header>\n  <h1>Template is missing</h1>\n</header>\n\n<div
         id=\"container\">\n  <h2>Missing template triannon/annotations/new, triannon/application/new
         with {:locale=&gt;[:en], :formats=&gt;[:jsonld], :variants=&gt;[], :handlers=&gt;[:erb,
-        :builder, :raw, :ruby, :coffee, :jbuilder]}. Searched in:\n  * &quot;/data/src/dlss/ld4l_data/annotations/triannon/spec/internal/app/views&quot;\n
+        :builder, :raw, :ruby, :coffee, :jbuilder, :haml]}. Searched in:\n  * &quot;/data/src/dlss/ld4l_data/annotations/triannon/spec/internal/app/views&quot;\n
         \ * &quot;/data/src/dlss/ld4l_data/annotations/triannon/app/views&quot;\n</h2>\n\n
         \     <div class=\"source \" id=\"frame-source-0\">\n      <div class=\"info\">\n
         \       Extracted source (around line <strong>#46</strong>):\n      </div>\n
@@ -3534,7 +3534,7 @@ http_interactions:
         &quot;gzip, deflate&quot;\nREMOTE_ADDR: &quot;127.0.0.1&quot;\nREMOTE_HOST:
         &quot;127.0.0.1&quot;\nSERVER_NAME: &quot;localhost&quot;\nSERVER_PROTOCOL:
         &quot;HTTP/1.1&quot;</pre></div>\n</div>\n\n<h2 style=\"margin-top: 30px\">Response</h2>\n<p><b>Headers</b>:</p>
-        <pre>None</pre>\n\n</div>\n\n\n</body>\n</html>\n<div id=\"console\"\n  data-remote-path='console/repl_sessions/ca2c73a9c5f2e2ae33f362aadbcdac37'\n
+        <pre>None</pre>\n\n</div>\n\n\n</body>\n</html>\n<div id=\"console\"\n  data-remote-path='console/repl_sessions/6e8c1b95af8e5aa03eeee5e20fa7e3c1'\n
         \ data-initial-prompt='>> '>\n</div>\n\n\n<script type=\"text/javascript\">\n(function()
         {\n  // DOM helpers\nfunction hasClass(el, className) {\n  var regex = new
         RegExp('(?:^|\\\\s)' + className + '(?!\\\\S)', 'g');\n  return el.className.match(regex);\n}\n\nfunction
@@ -3731,7 +3731,7 @@ http_interactions:
         \   resizerElement.addEventListener('mouseup', recordConsoleElementHeight);\n
         \ });\n});\n\n}).call(this);\n</script>\n\n"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:30:58 GMT
+  recorded_at: Thu, 28 May 2015 01:30:58 GMT
 - request:
     method: post
     uri: http://localhost:3000/annotations/
@@ -3757,15 +3757,15 @@ http_interactions:
       Content-Type:
       - text/html; charset=utf-8
       Content-Length:
-      - '152196'
+      - '152203'
       X-Request-Id:
-      - e174b92f-5dd5-4119-9b80-f143f0a4a578
+      - 723c3c89-2953-4379-a999-53983e02a02b
       X-Runtime:
-      - '0.254352'
+      - '0.221335'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:31:00 GMT
+      - Thu, 28 May 2015 01:31:00 GMT
       Connection:
       - Keep-Alive
     body:
@@ -3809,7 +3809,7 @@ http_interactions:
         \   }\n  </script>\n</head>\n<body>\n\n<header>\n  <h1>Template is missing</h1>\n</header>\n\n<div
         id=\"container\">\n  <h2>Missing template triannon/annotations/new, triannon/application/new
         with {:locale=&gt;[:en], :formats=&gt;[:jsonld], :variants=&gt;[], :handlers=&gt;[:erb,
-        :builder, :raw, :ruby, :coffee, :jbuilder]}. Searched in:\n  * &quot;/data/src/dlss/ld4l_data/annotations/triannon/spec/internal/app/views&quot;\n
+        :builder, :raw, :ruby, :coffee, :jbuilder, :haml]}. Searched in:\n  * &quot;/data/src/dlss/ld4l_data/annotations/triannon/spec/internal/app/views&quot;\n
         \ * &quot;/data/src/dlss/ld4l_data/annotations/triannon/app/views&quot;\n</h2>\n\n
         \     <div class=\"source \" id=\"frame-source-0\">\n      <div class=\"info\">\n
         \       Extracted source (around line <strong>#46</strong>):\n      </div>\n
@@ -5400,7 +5400,7 @@ http_interactions:
         &quot;gzip, deflate&quot;\nREMOTE_ADDR: &quot;127.0.0.1&quot;\nREMOTE_HOST:
         &quot;127.0.0.1&quot;\nSERVER_NAME: &quot;localhost&quot;\nSERVER_PROTOCOL:
         &quot;HTTP/1.1&quot;</pre></div>\n</div>\n\n<h2 style=\"margin-top: 30px\">Response</h2>\n<p><b>Headers</b>:</p>
-        <pre>None</pre>\n\n</div>\n\n\n</body>\n</html>\n<div id=\"console\"\n  data-remote-path='console/repl_sessions/b1a04b1940469991c44e02a639594607'\n
+        <pre>None</pre>\n\n</div>\n\n\n</body>\n</html>\n<div id=\"console\"\n  data-remote-path='console/repl_sessions/4f4966978fe371d8f1542c7b15a312a7'\n
         \ data-initial-prompt='>> '>\n</div>\n\n\n<script type=\"text/javascript\">\n(function()
         {\n  // DOM helpers\nfunction hasClass(el, className) {\n  var regex = new
         RegExp('(?:^|\\\\s)' + className + '(?!\\\\S)', 'g');\n  return el.className.match(regex);\n}\n\nfunction
@@ -5597,5 +5597,5 @@ http_interactions:
         \   resizerElement.addEventListener('mouseup', recordConsoleElementHeight);\n
         \ });\n});\n\n}).call(this);\n</script>\n\n"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:31:00 GMT
+  recorded_at: Thu, 28 May 2015 01:31:00 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/_post_annotation/returns_a_RestClient_Response_object.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/_post_annotation/returns_a_RestClient_Response_object.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"8c229d2350c1648cbc02c937633742d7"
+      - W/"975ee6a96f2ace784b2d87256129c087"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - e73ce63a-29f8-425e-826c-677fa149c44d
+      - 1ddd47ef-f95d-42ad-ad7c-c89610fb8709
       X-Runtime:
-      - '1.788124'
+      - '2.124826'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:09:17 GMT
+      - Thu, 28 May 2015 01:30:54 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=UXB2UmJGa3pIUm90STZBR25Pcis4TGVuNWlFbFBWallSYTM0M0tyN1pIWGNQWWNzdVZoeEt5V3U1ZmFkRXBJekUrUG4zcVdvUUc0VG1JYVV3UmhyTXNGVFlvZWFMWndZcGVGVG1ZWlZ3LzhBdmZTcWZtd1FBUzdHQkI3M1Nqby9WRnRScWZlWGoxRnIrQ00xNnk1RU5BdmliQnhRYThHSUxlVkpodHhxMFNHV0gwbWtXaGVNMVpkK21xZ1NRVXQ5b3N4L0ZkZUhnNFQ0QzhlMHZ4bDNOQlcvZnNta2Zsd3VOSkpVdngxeFVGNTdOOUYyOEVDRU5rM3pSeEVSQXNMby0tYkx0UWZRRzBrclhOSUVaR01obnhWZz09--d88829bfd2c992f27f38b693beb122c836532c44;
+      - _internal_session=bFVRc1N5M3NRcEZpOFZscFBFU1JETmJyWVFaUVRXT0I1S2I0T2VwaGdlbGMyUkZDZk9mU1dsQ2N1ZTlOVnJ2b0hueUF5UHNxWEN0ZXVTVGkrb0Z6WDFmMlIzU1JmQ0N6T0xSL08yay91REgrYXlOZDI0dEtOZ0tucHZ0T2JhZEg5NmkyK1ZmUHhiZ3lWdGNtSjJrNUxMWDZlK1JzNHpOVm5PQTJEaGNRdHh2Vkp6dHYvc2cyU3lIRC9ZeGRFcmVIb3hOaVd2T09YRDJINE1QMUVkWWNmeHJQd25OVFd6NFFOdWxGZ3Zrd0dCcHJIdC9qK0hJT2pGS1k0c25WdHhxTC0tV3E1MGhldC9BQmd2cWhpeitZako2Zz09--7f471895eac3dd048f25d77d479655e8c8364804;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310875105740","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/6e/54/8f/43/6e548f43-bd98-4373-ad30-f147d42d55ab","@type":"oa:Annotation","hasBody":"_:g70310875105740","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69941854690120","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/b8/91/24/39/b8912439-a86a-4a6e-b421-6637523f8c0b","@type":"oa:Annotation","hasBody":"_:g69941854690120","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:17 GMT
+  recorded_at: Thu, 28 May 2015 01:30:54 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:18 GMT
+      - Thu, 28 May 2015 01:30:54 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:18 GMT
+      - Thu, 28 May 2015 07:30:54 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:18 GMT
+  recorded_at: Thu, 28 May 2015 01:30:54 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:18 GMT
+      - Thu, 28 May 2015 01:30:54 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:18 GMT
+      - Thu, 28 May 2015 07:30:54 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:18 GMT
+  recorded_at: Thu, 28 May 2015 01:30:55 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:18 GMT
+      - Thu, 28 May 2015 01:30:55 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:18 GMT
+      - Thu, 28 May 2015 07:30:55 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:18 GMT
+  recorded_at: Thu, 28 May 2015 01:30:55 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:18 GMT
+      - Thu, 28 May 2015 01:30:55 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:18 GMT
+      - Thu, 28 May 2015 07:30:55 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:19 GMT
+  recorded_at: Thu, 28 May 2015 01:30:56 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/6e%2F54%2F8f%2F43%2F6e548f43-bd98-4373-ad30-f147d42d55ab
+    uri: http://localhost:3000/annotations/b8%2F91%2F24%2F39%2Fb8912439-a86a-4a6e-b421-6637523f8c0b
     body:
       encoding: US-ASCII
       string: ''
@@ -2481,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 7b4c0f63-1509-4545-8d7d-164a0916cd0e
+      - f4dbb09c-2f49-4f61-87a9-2cc6857d9334
       X-Runtime:
-      - '0.199093'
+      - '0.181579'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:09:19 GMT
+      - Thu, 28 May 2015 01:30:56 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=eSt2d2RVcnpSQjVlcU9mbFh1cjdIbEdzcHBqdSthRFFYVHNBWlRKQXpJZXZubUVaREEyVlQvd0NoUzQ2ZXI2eTd0YUtTVCtpN2gvU28wdmtQMm93ZkFUbXRVZHVDTDliUW1FUXR1YlNPVXh5dmZVeSs2T201NWdiMjgwd0RUOU1veG5VTEVGS2lGQ2hCOFArcDFXamZJNkJxZmRlVkJJR0lOWDhCOExwYWVqa2M2cWRxcW96SVhRYlk5WHRmaklzLS1VRERCRVNMUWhNaEtXU2p0REtLTERBPT0%3D--b369bb86742e844f0e9fa6fef5392b63d200a7f3;
+      - _internal_session=L1J3cW5JMGJsSzQwN0ZYeWdPY292dHJ3cG8wKzdZalRVd1BIYVVRYlA5RkoyMGcyLzJwQnlJcmpESXloaWZXQWppUHJsU0FmaXkzL0huS3BpMldrRWVjYUZtR3VkWWt5R0ZxSGtwOFJ4Q09xWFRSSW1SbTZiT0NEUTZlcmFOMTBadXJ3TWF4QnZHbzM3UVlya2ZQaSt4SHpJNFlNakpab0duUEVZcjBYTWRLdVJSRDNuYmZuZ210RTE3b0NITk1yLS1YamFpWmVUNUZKbTRFZHhVWC9ybmxnPT0%3D--e90f11bfee4a71f73b0ba0614c061d9b762928b7;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:19 GMT
+  recorded_at: Thu, 28 May 2015 01:30:56 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/response_processing_utilities/_annotation_id/returns_a_String_ID_from_the_RDF_URI_of_an_annotation.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/response_processing_utilities/_annotation_id/returns_a_String_ID_from_the_RDF_URI_of_an_annotation.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"8347c771ad41aabefd263e0fa9bd8399"
+      - W/"599d0d5ba2be19c5a8f9595607f194fe"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - edb2991e-5fa7-44e7-ada4-efadfe05d416
+      - d12da210-b2d2-4d6d-9b28-d504f4b81527
       X-Runtime:
-      - '1.698250'
+      - '2.095930'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:09:43 GMT
+      - Thu, 28 May 2015 01:31:39 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=YzZZSkdVeXFjUTZjK3dNSmlnQll6TXJwTVBVU3FKM0JwazNiUWptS1BtanZOUmJGSmYxN2FtUFVCVlFtWUx1NmxLRlJkdVdjZ1AzTVkydEVvUjQrak1uY2RoMTBSRVBFbVNIaXJuUi9CSmhiem9aekJpQW1aTk44SWJhczBjWUg2NndGeDJvckZNSkJwaFdtRDRITUkvMTRTajNuYmhiOTM0U1RINk44ZjZYNURCRzhhbmZlZGNNRWQrN2V0am5pbXNSR2hRUlNUa3A3WUFVb09yNnk4cW11TGxPK0VLS3FDRHp1RGpIL25nNEFmajF6K1pMck1OWHRkQ0FNSk1EUS0tb1JyU0hhUTFHa1BiWXMyR21KYUJWUT09--0ced0d5313859b5b9b3ef0af6ace7d142799b9d1;
+      - _internal_session=ZXdHbDVUb051NVJpZm40WmFHajVoSzZxWU5kbGxQY0w4c2gzS3hHQVJzdTM4VzZhU0dzWXRTeHdpcWxsaVJwMXZxTmJSSXNsWUFhcHQ2cmN0bXFXNTJ5aU5LS3Q1a2x3NlcrTGVMZVhjQmpZQ2gybnI4WE5wTTE0T0pXYjlhZUJJOEFQNk9hU2xmczY4bGxrY1Q2c280SVN4RlU3c0xvZEc5VkdDeTJCYXpLTU5VVzJnbjhyaE9xaDJ6ZVMzSlZwWC93VURGRE5aeWIydkFLbnU2UjJvQjVVU0lUb0w0SUdYWWh0NzgvTnRBMEJsZ0REcEZsOGdmSjY5V0Mxb0MvTS0tWGdYUExydDIvYjgzQitiYTZpWlNndz09--119a926426605b304592a2658e81b6947361ea6a;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310854148900","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/17/97/b5/20/1797b520-1ae8-43e6-8309-db3550fc4406","@type":"oa:Annotation","hasBody":"_:g70310854148900","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69941855878980","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/e4/ca/64/9f/e4ca649f-6222-488c-a978-15ec4345c129","@type":"oa:Annotation","hasBody":"_:g69941855878980","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:43 GMT
+  recorded_at: Thu, 28 May 2015 01:31:39 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:43 GMT
+      - Thu, 28 May 2015 01:31:39 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:43 GMT
+      - Thu, 28 May 2015 07:31:39 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:44 GMT
+  recorded_at: Thu, 28 May 2015 01:31:39 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:44 GMT
+      - Thu, 28 May 2015 01:31:39 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:44 GMT
+      - Thu, 28 May 2015 07:31:39 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:44 GMT
+  recorded_at: Thu, 28 May 2015 01:31:40 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:44 GMT
+      - Thu, 28 May 2015 01:31:40 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:44 GMT
+      - Thu, 28 May 2015 07:31:40 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:44 GMT
+  recorded_at: Thu, 28 May 2015 01:31:40 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:44 GMT
+      - Thu, 28 May 2015 01:31:40 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:44 GMT
+      - Thu, 28 May 2015 07:31:40 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:45 GMT
+  recorded_at: Thu, 28 May 2015 01:31:41 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/17%2F97%2Fb5%2F20%2F1797b520-1ae8-43e6-8309-db3550fc4406
+    uri: http://localhost:3000/annotations/e4%2Fca%2F64%2F9f%2Fe4ca649f-6222-488c-a978-15ec4345c129
     body:
       encoding: US-ASCII
       string: ''
@@ -2481,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - cbfd54a1-ec6b-4fb4-99ef-9d560fa7eccb
+      - 14666bde-fa4d-4e03-a83b-79ba1d46aa8a
       X-Runtime:
-      - '0.213893'
+      - '0.178999'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:09:45 GMT
+      - Thu, 28 May 2015 01:31:41 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=WlRJbXBtTW40ODNGVmt2ZXZEdEdqdFhFMnZsWHc5L2tvYWk2THFaNEZFT2orVlluZ05mQTQ2cWdSUFJ6UHg3b0dEbDRZbzBKd2I0R2taTXZ6TjB0SjZJUDRRbkRnN0NDakFQV01MOTZKcG50VnpYMkNXMjhyY3JjRHBjQ2lFNWtvNnJhR2RhK2J5UVdqNGhHMkl3ZXltaG0xUlc4dHdqdDlxdCtlUHlzeEZVMWxOSk9PSmtjYkUxVTVlYU5xblRYLS1yZ1VEN0E2dVIyb2tGbVc5VmZqMUl3PT0%3D--3e1c43abd4bb285f42e8aab40d596800612c131c;
+      - _internal_session=V2QzbEJpNXZ3R1pIazE4V2xNZkVmYmhsZnpCRGFyejZ3VzgySFM5UGd6QUVOaVpNaFY3Nk5kbXU1ZFFEUlYwYWNYRGZITTVzUXVHVk9rcG5ZdUVNV2sxRVNzWGhVUzBlU3I3aUIzOVIvck5jbG5WQjBJVHExaldZc3Zjb0F4OTFDSW1tc1FiUGhyV1RvRjZ0WjkxQ0VQdjRqSFNkeDFHMU9abGJ2dWt1V3BsSmNreDhFVTdOeEdBcWYxdlZiVkxKLS1aTkNjT3FSSlJ4ajE5VjJMcFBoNlpBPT0%3D--30b60efdda1e37512e5714f2adfade9f76b90743;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:45 GMT
+  recorded_at: Thu, 28 May 2015 01:31:41 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/response_processing_utilities/_annotation_id/returns_a_String_ID_that_is_not_empty.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/response_processing_utilities/_annotation_id/returns_a_String_ID_that_is_not_empty.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"6a4131c404f1fbcbc4a8b8947f5f3ff2"
+      - W/"3a4267fabf8d2535356b2a0967bf0f0d"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 83fafc38-7e49-43fb-a9e1-156c9160c1c8
+      - 1b00fc4e-8218-4e69-9689-4e9e06e3bdc9
       X-Runtime:
-      - '2.696814'
+      - '2.109318'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:09:48 GMT
+      - Thu, 28 May 2015 01:31:43 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=Ujdic1psNzRBT1dhZDdMR29oRU5STnZMTVBVSXhGWGh6NmZCZitEUHBqVTljZFo5azVyaFovdml3R3Jqb1RrelllUUg5VGsvUmJ3YUJodmhubUg5aW04dFNST25EVndYaXdzY1EwYlNHVEoyNW4wVzNxZHA4Rm9jVnlHUnk2Rlk4Mi85V1pkQ1RRMWxJQ3BRZVNLampCbVd1K2IrQnlrb3RGYkg3Wkdob3lEQ0xMTVNVVlhMTDk0dHNGejJNeFJCaERUQ1ZXQk9FaGRja0trbHFoQURNemRBeFJvQ2VmYWVSV0NPZEZiVU9pbkxPdHZ4V0hkYlZxNVlHUE9RR3dyNC0tYWhHa3gwaDNpMmt4QTBDaE9pb2o4UT09--0b9626cfd9345ff90e14b92348cb020e55728e41;
+      - _internal_session=eWVHaFBvK0pSUWhpelZST21lZHBrd0FhcFhFajF5SnNNQS9WU0RvaDdIYmlWdmdHYkl3VlRtbm1MMVR0T05lYXovVGM0RTVBQ0V4dTN1d3YwWmdYemlxem52amRhcXRJeVpzUnRtQUwvQUYyalIyV3AyMmNDUlNTSjYzVi9wREdrR0FRVmF1Z1NOVjh1YmNQNTRNZ3FtdkttdmxqZ3FvZkFtandMdVBuNEFwbW4vaVlyVmFvRVJPaXlNS2lGZ0Zma0dWdHVnbm1vTElNY2VKdFRvRFV2Z1BzWFBRRWQrbTZjc1kyV0dzVWRrdnlyWDN3c1Y1NEswTkpLQkIvWnJMNy0tMDNkY1V2UEx2RDRDbmFNM3Faak1lZz09--85292d4ffac17aeb1b5befd45b8aa172ce32c375;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310878917520","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/ae/ba/ab/aa/aebaabaa-6c8b-4247-8253-198dff252967","@type":"oa:Annotation","hasBody":"_:g70310878917520","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942000747060","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/8c/ad/75/03/8cad7503-095d-4754-9921-e1d31fcf8bf1","@type":"oa:Annotation","hasBody":"_:g69942000747060","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:48 GMT
+  recorded_at: Thu, 28 May 2015 01:31:43 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:48 GMT
+      - Thu, 28 May 2015 01:31:43 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:48 GMT
+      - Thu, 28 May 2015 07:31:43 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:48 GMT
+  recorded_at: Thu, 28 May 2015 01:31:43 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:48 GMT
+      - Thu, 28 May 2015 01:31:44 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:48 GMT
+      - Thu, 28 May 2015 07:31:44 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:48 GMT
+  recorded_at: Thu, 28 May 2015 01:31:44 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:48 GMT
+      - Thu, 28 May 2015 01:31:44 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:48 GMT
+      - Thu, 28 May 2015 07:31:44 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:49 GMT
+  recorded_at: Thu, 28 May 2015 01:31:44 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:49 GMT
+      - Thu, 28 May 2015 01:31:45 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:49 GMT
+      - Thu, 28 May 2015 07:31:45 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:49 GMT
+  recorded_at: Thu, 28 May 2015 01:31:45 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/ae%2Fba%2Fab%2Faa%2Faebaabaa-6c8b-4247-8253-198dff252967
+    uri: http://localhost:3000/annotations/8c%2Fad%2F75%2F03%2F8cad7503-095d-4754-9921-e1d31fcf8bf1
     body:
       encoding: US-ASCII
       string: ''
@@ -2481,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - d302484c-3ec0-4792-b5ee-48b86a5bb81e
+      - 68c42dd5-5c45-4428-9254-98a775be013b
       X-Runtime:
-      - '0.190797'
+      - '0.190423'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:09:49 GMT
+      - Thu, 28 May 2015 01:31:45 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=UDErdUQ1UHBqQmVUTElsdHVTbkJkSGwzUExqejZXYzY1b3BzSUpjWkw1MUtOc1gybFJOYnNQcWRDeThmL01LMlVzdzdHMlNTRWFEclFMaWx0cXZleVo0TXNUQXZVc05rUGJHS05sbVVOcjlSQ3c4SVV5TE1iQjlDcm9VTHJmdWVQODJOMEFtZHJEMCtLd0tvaDNKR1k0bjhXdGVDOXhNa1dXVCtKSGhDWkx3QkZ6ZktuWGJVcStZeGRCNzRyQnMzLS1CWmlPTlRreVYrMGJmTXRtMTA0UEhRPT0%3D--2cd621b601320076dd5b4ec38f582ff97e31ff5c;
+      - _internal_session=QnJZRE9sWVRSbUY1Vk1NNDN3dHV3Wk5BV3lBcVVrMlZCc05ZSjhUeXJZWWlqRXVYQnB4K29lcy8vb3d5dGkydDlEaER5QWpoUVRqSHRidTg4K01oaGxsWkkzNGowSkYrQ01wK0pMc3Nnbi9YUDc2VTk1dGV3Z29NTUJ4MFZzUG9TUVFNbDk5ME93YlBubUtBR0hzZ2FFRXFIUnQyMG4wMXFPQm9oREVWR0lheDBJbFdnZVB1WGppVEoyandmdmpVLS16ZFUyTmFYNFgrM3ZQdThNWkljb3ZnPT0%3D--8cb5d17718e5f212aaafdb8729bb9236258bb131;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:49 GMT
+  recorded_at: Thu, 28 May 2015 01:31:45 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/response_processing_utilities/_annotation_uris/returns_an_RDF_URI_that_is_a_valid_URI.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/response_processing_utilities/_annotation_uris/returns_an_RDF_URI_that_is_a_valid_URI.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"5feb34e4832b02b348839520bfc58409"
+      - W/"123a6a0046caa1a86749430dfc52460d"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 4242de62-b096-4cf3-9242-198d3aab0a6a
+      - f7b1fc93-27f7-4e82-ac84-b15cb1047c09
       X-Runtime:
-      - '2.624414'
+      - '2.217591'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:09:40 GMT
+      - Thu, 28 May 2015 01:31:35 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=citTUjd6R090ZmRpK0pPRXUyeDd4SXBaWFpncVBmWDAzTEg0SWRabFg4aWRPaU5iRlRVMEI2MFpYeVhmZjUwdEgxaFBCNFJRbVhndDZ5Z2xnUVpRV1JKL2E3SG41d2lvcFdQSGlFVnBjc0JLbXRhOXM1NVZkeHdRM04yeitQRTRScEJOdHlSR1c3Nk1ZcVlBSWl5RFJBRFBhYm9ZMjlNM29DY2hUVVlVVkNIbGtMNHpseHM2MEVuTEk5M3dpQ3BHRXMydlpKemw1RlpLUDBraFRyNHM0cUhTdzVwMHBTTTVVSlFsbksyMzhWeUJDRzFWOUF0ODhFZU5UTnNKOHZMdS0tcUQrSytJT0hGL281QWVxS1Y5ZHNCdz09--00861b128bcef77216ab5037372e7d704aeafc84;
+      - _internal_session=dUFrUldVaEw2TnBHZWNlNHkyMElkbTlZU3VzeFBpN3hhWGxqTk9aVVkyWmtiK1djK2xMQkpLWVpSR0x2NktCb3FweFJkbUZ1U1ZTRWpXUFB5cURHK0V1d2t4UlJOS29Pd2owbUs5dkIwTk5wVGs0VVlJY0xYUGlOdWRMQkNYR1dSamppSTVpMFpxQmZ4dVJnSWVGRnRGV2RCUlFBeUIrMGI1N3pkdzkvcVY2aHlWMWdMSFRpK29JVXNGT3ZISGtNbXo3VjYzN3BudEZhVjRaK0w5Z0NlNlZZb3hGTXVrcVk4SitITXNEWWxyRkh5M1lza3pvb3RNeHpFYkIzZ0VwVS0tWjJHeWkxZUxiQmM2d29GcDVtd09qUT09--b451c80dc7e4b6aa1ddc58014dc7c4c3a10ea09b;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310878874760","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/87/6d/d5/c5/876dd5c5-15e1-4a98-b331-56dacf0a94aa","@type":"oa:Annotation","hasBody":"_:g70310878874760","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69941857912580","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/e7/3f/28/5f/e73f285f-6fec-452f-9255-170e0f672f15","@type":"oa:Annotation","hasBody":"_:g69941857912580","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:40 GMT
+  recorded_at: Thu, 28 May 2015 01:31:35 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:40 GMT
+      - Thu, 28 May 2015 01:31:35 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:40 GMT
+      - Thu, 28 May 2015 07:31:35 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:40 GMT
+  recorded_at: Thu, 28 May 2015 01:31:35 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:40 GMT
+      - Thu, 28 May 2015 01:31:35 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:40 GMT
+      - Thu, 28 May 2015 07:31:35 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:41 GMT
+  recorded_at: Thu, 28 May 2015 01:31:36 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:41 GMT
+      - Thu, 28 May 2015 01:31:36 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:41 GMT
+      - Thu, 28 May 2015 07:31:36 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:41 GMT
+  recorded_at: Thu, 28 May 2015 01:31:36 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:41 GMT
+      - Thu, 28 May 2015 01:31:36 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:41 GMT
+      - Thu, 28 May 2015 07:31:36 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:41 GMT
+  recorded_at: Thu, 28 May 2015 01:31:37 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/87%2F6d%2Fd5%2Fc5%2F876dd5c5-15e1-4a98-b331-56dacf0a94aa
+    uri: http://localhost:3000/annotations/e7%2F3f%2F28%2F5f%2Fe73f285f-6fec-452f-9255-170e0f672f15
     body:
       encoding: US-ASCII
       string: ''
@@ -2481,27 +2481,27 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 7a6ed2cb-e186-4580-beae-16921b28d10a
+      - 8ff2a9cd-e5d2-4102-a1d1-a4bd442536b1
       X-Runtime:
-      - '0.196192'
+      - '0.243593'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:09:42 GMT
+      - Thu, 28 May 2015 01:31:37 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=ZDl3Q0cyUlR0Nk45eEJYV3NONytRajVYeWtTZFo2eGFlRVEySDlvZmdhMXcraWdZamIyTWtXSWVlVSt5SjNPU3FUNHBGY1IyMTR5THlXMWpFV0o3cDU1VkppZWV4YUZWTmtoMVV6UFMvREU1WkJTTDhCaXNUT3hxZVFjTFpwMXU4QjJpUlcwVlQ2eFFnOGd5Mmo4UFlUMDdwbUc4aEtkRVpheW53ZXZQZlZOQ0lmMEl0U1dUdTFuUkRwTkJBSVZELS15ajEyMzlpOTJXNGFwV1lWWWQ5ZGh3PT0%3D--859d4ceb0b3152a3e81ca0b8e5f0ac7522283b03;
+      - _internal_session=MmozUkpYMTlLRDBYVVJSVWZVam16aDRkdExTVC9ZRjR1clJTQ2ZTR0xnZDlRVG1tL25TeTBxcHJ1WUh0RWlFNFMvb2NrNmxvYVlPVGtrMnU0TVhNdzBzWE1jU3ZFc2p2eHJrRFRoQXhzSldwZWlUNFhjOTBrZVVtNkdVVVQzQUtHbFNoYkNGODdJSjYyYW0zWFBVU1Y2NkhSVnZqbTFHMHpuU0ZPYUllSGlxTjJBYVkzTHVxUlp1UitRdXBqVVVuLS1YeURYeVJ2VWtiWkgzQkYySit5Y3RnPT0%3D--949eb9de63eb5f4781116c86d6e1ae7230e6c5f2;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:42 GMT
+  recorded_at: Thu, 28 May 2015 01:31:37 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/87%2F6d%2Fd5%2Fc5%2F876dd5c5-15e1-4a98-b331-56dacf0a94aa
+    uri: http://localhost:3000/annotations/e7%2F3f%2F28%2F5f%2Fe73f285f-6fec-452f-9255-170e0f672f15
     body:
       encoding: US-ASCII
       string: ''
@@ -2528,13 +2528,13 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 7ad353e1-ee94-48ff-b2fb-29593c306365
+      - 5b05347f-192b-41a4-bf58-e039fe78e3e6
       X-Runtime:
-      - '0.021903'
+      - '0.021169'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:09:42 GMT
+      - Thu, 28 May 2015 01:31:37 GMT
       Content-Length:
       - '272'
       Connection:
@@ -2543,9 +2543,9 @@ http_interactions:
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
-      string: "<h2>error getting 87/6d/d5/c5/876dd5c5-15e1-4a98-b331-56dacf0a94aa
-        from LDP</h2>Discovered tombstone resource at /anno/87/6d/d5/c5/876dd5c5-15e1-4a98-b331-56dacf0a94aa
-        {jcr:createdBy=bypassAdmin, jcr:primaryType=fedora:Tombstone, jcr:created=2015-05-18T13:09:41.995-07:00}"
+      string: "<h2>error getting e7/3f/28/5f/e73f285f-6fec-452f-9255-170e0f672f15
+        from LDP</h2>Discovered tombstone resource at /anno/e7/3f/28/5f/e73f285f-6fec-452f-9255-170e0f672f15
+        {jcr:createdBy=bypassAdmin, jcr:primaryType=fedora:Tombstone, jcr:created=2015-05-27T18:31:37.291-07:00}"
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:42 GMT
+  recorded_at: Thu, 28 May 2015 01:31:37 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/response_processing_utilities/_annotation_uris/returns_an_array_of_RDF_URI_from_an_RDF_Graph_of_an_annotation.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/response_processing_utilities/_annotation_uris/returns_an_array_of_RDF_URI_from_an_RDF_Graph_of_an_annotation.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"5e7c2bf81d4a50b79b80a82b279e11d4"
+      - W/"95a37469501d5104c949b89497643ffa"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 23ceebe2-3853-48cc-8ecb-3a6151dc6027
+      - 49678792-7451-49c8-8073-be78e298447e
       X-Runtime:
-      - '1.639153'
+      - '2.160934'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:09:36 GMT
+      - Thu, 28 May 2015 01:31:31 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=UUtVQTBqbWxqWnpnd0dDSXRTR3JMT3ZaTXVZdlptSFhiaTFIejkzZmZicUxrRWNGamVFeWVXL25aZUVpdXl6UHlIb3VRNzZnZVJnbUFheEV1TzJhVEZjRWhPZ3FvQTVvcUUrZWlHbUZ0bXA1S3QxbnVpblRUNGlpSFBERTdxcnRCZ3BFTWtudGRJSlJBb25pWlhSOGlWRUp0TVFmTDdMQ2RDME8zV3VrQlE3a20xZkIzbXI1VWR1L1IybHBpM3RBdFhKOTFRdkQ3aGp6aGFLMzJadmY5UWQrK0lJY1RyTk5LUmFIN20vODJSRzY4V1gxbkJmeUFxZGdiYXY0ZXo5Si0tbzF3NlNndVBrSUs0SlBZazhUUHlHZz09--b5dd8f0f82c9be92d96a6ab7f2c3eda8900633b2;
+      - _internal_session=WjVuTEg3UnJubW4wK2tTNlFmanBPNi9URXgxa0VrRE1DelhNVHFvU1JIT2p6Q3JnYldDdEZmUFlpNlQyaDg1ZmdyUWhHRnpjVi9wRnJwRlltVmtHbVNIZ0VGV3FRaThvVm9JcVVzazFhVlFsTzM1VHJRZldyTmgxVU1QMTRvMnYxWkY2VDZRRGwwL1lkSHhEQmF1ek82SU5JdjZMUE1JMy9CY0xtQzY0ZE8wbkVrcEkxTmtuUVpiTDh5aDc0bTVnZ0FjUit5c0p3NkdDOWlHYkJTN0Z2YlE2VHc2TDdIVzhMLzBNT3Jva2FOSGppZVQzTndGZ2RpUGJmb3pzY0VrbS0tVWFjSytpMFpWdUVYZlpxZlJGSzdYUT09--3ea71922a0f0ea1da2e5d4c4031fd95b2603b888;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310853254000","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/af/63/2b/47/af632b47-a8f4-4616-92da-c3aa819ef1d4","@type":"oa:Annotation","hasBody":"_:g70310853254000","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942034920580","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/e6/76/53/1c/e676531c-3c86-4c26-b994-d133a401ea49","@type":"oa:Annotation","hasBody":"_:g69942034920580","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:36 GMT
+  recorded_at: Thu, 28 May 2015 01:31:31 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:36 GMT
+      - Thu, 28 May 2015 01:31:31 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:36 GMT
+      - Thu, 28 May 2015 07:31:31 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:36 GMT
+  recorded_at: Thu, 28 May 2015 01:31:31 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:36 GMT
+      - Thu, 28 May 2015 01:31:31 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:36 GMT
+      - Thu, 28 May 2015 07:31:31 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:37 GMT
+  recorded_at: Thu, 28 May 2015 01:31:31 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:37 GMT
+      - Thu, 28 May 2015 01:31:32 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:37 GMT
+      - Thu, 28 May 2015 07:31:32 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:37 GMT
+  recorded_at: Thu, 28 May 2015 01:31:32 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:37 GMT
+      - Thu, 28 May 2015 01:31:32 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:37 GMT
+      - Thu, 28 May 2015 07:31:32 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:37 GMT
+  recorded_at: Thu, 28 May 2015 01:31:32 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/af%2F63%2F2b%2F47%2Faf632b47-a8f4-4616-92da-c3aa819ef1d4
+    uri: http://localhost:3000/annotations/e6%2F76%2F53%2F1c%2Fe676531c-3c86-4c26-b994-d133a401ea49
     body:
       encoding: US-ASCII
       string: ''
@@ -2481,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - e714ecda-f335-46c1-bb18-bb3fe9c44c34
+      - c3a321ae-cc01-433e-a3dd-de67fb0d18b0
       X-Runtime:
-      - '0.186758'
+      - '0.201441'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:09:37 GMT
+      - Thu, 28 May 2015 01:31:33 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=YW1vblNLYkZUaVo1Ny96eXB2NG9Xcnk0N2V6WElNTWh1N2NHZ1dGY1BXVnpJZGZXU1I5U1VmUEh0c2FZODJ4azU2SXhVRXBQQnRPdWxVcjN3VXhlSWcwNUVTUGxDMFVDYXZGRW5ZNXZ3R0dZS2hmS1NnbGp4YkppUEtkUXZxbll1TmlkMFEvQnFOdkNVREtReFdFTjlTWCtMbjhpb29zSVRIZ1d4N1VqdmpJNzZHcGN2VHVCWkMwSjhPMlArOWJSLS1pb0drRndqTm9iU3YvYWpsWExMWS93PT0%3D--8f8eb06d1414d13c13a3f7eb273f58504a11874a;
+      - _internal_session=eDc3NXlWVzhjaWV4N0xZbHA4cnhIa2RGZld6L1pTMVIyeGxUdEtBc1lVaVZIV1VEeENobTVEaHZhVWVWYXgvSGoxcGxLOVUzVC9ydHhoWituaWNMOHNYcjIzQUFQL2Rkd0htU0hjNzVCbjF3ZkcrS0daTjdkZUtaOElaZWZOcUVIOTJ6RE4xcTZwQ2phMHZhZ3d1eGxVTDBkT05hQUUramxiNlNreStucTREd2szSDdBK3A1aUhBOUtocElmRE81LS14Y0o3WlZCOWwyV0NaYVJ1T0FwWmJRPT0%3D--a83e130e5e7f10198525dbd737f3d74db6036b38;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:37 GMT
+  recorded_at: Thu, 28 May 2015 01:31:33 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/response_processing_utilities/_response2graph/accepts_a_RestClient_Response_instance.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/response_processing_utilities/_response2graph/accepts_a_RestClient_Response_instance.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"c6a28d4e672f5bf03d98f68df00a74f6"
+      - W/"6b4b82fa11f379b81659cb7bc14f055e"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - c0dfe1a6-0b80-4d2a-9505-261e5bf9c06b
+      - 14bc1190-6b66-4746-a735-31f26126b07b
       X-Runtime:
-      - '1.619984'
+      - '2.686521'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:09:21 GMT
+      - Thu, 28 May 2015 01:31:12 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=OWFiSHlmT2svcVlmRjhmcGlUMzF6Uk1aZUdYSSs2S3hmMGlCNEdTdllwVHRCdlZ0ekZDdWw2RENoMUltTUJUZDVlSmVLWHhzOEpEQnJZeC9KQnVKSlg1VlNnZjhYc3NQNWtsREhwNnJramkwclB2bVI5eU5IOVFNNnlaRkU0UlFkdzV4Rmo3aHNrMFcvWmNxSkFyUzhaQWhCSlRCbWs2am54WmdOaHU4U1k1UkpYOG9LNEU2RkpleUtGRE5BQ2t2SXpYQytRWU5HTDQ1aFZJS3IwY040YW05N3U3NVBEV2IyQ2tLZlhhNFZrK2ROYmhxS3pHUmEyQk1CbXZtT1pvSC0tcTJvcUI3Vm5mRWtNbE5SamE3VytsQT09--e9b815d08352dbf8f10e0b01999f3c101a900584;
+      - _internal_session=aDd4UDlVT2FTQzcwVmkreCtpQUltRnZsNENlbk5MSUp4M0gyN2NCbWxCVy9oODJFV1AxNjBhd1I3NmNSU3ErQVJkVFRFWmZqMGhRakNERDliUEpSYU8vSjNYTVJLR0RDYjVCZlZsVkxDNEg0REVpQWlTbVdkMEwrUlZFVFJDNll1djlrR3N5WjNHQ0lkckJoVzVoVXhZRktxTFMyYUtXYmMyWnlXNjk1OEw1T0dmbVZQWnhNdGxiOEpENkRLYldweVM3N1VKZzhlUnBNWU13UFMxTmw3bmYxcGpGNFl2dU50RmdhUXdWUjZYdGN5VE1FdTIwZEY2VzZQM3paUDJYVi0tdk5wVEgxYnZqODVEcmFZOXpEc3I3Zz09--8e7d92588dad6d3779518160787cf7c38d93746f;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310850849700","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/b2/3a/a4/d9/b23aa4d9-9d8c-4ec1-bea2-a44454a523cf","@type":"oa:Annotation","hasBody":"_:g70310850849700","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69941860437900","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/3f/f6/df/7f/3ff6df7f-5ea9-4a83-a8c9-adffc187adce","@type":"oa:Annotation","hasBody":"_:g69941860437900","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:21 GMT
+  recorded_at: Thu, 28 May 2015 01:31:12 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:21 GMT
+      - Thu, 28 May 2015 01:31:12 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:21 GMT
+      - Thu, 28 May 2015 07:31:12 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:21 GMT
+  recorded_at: Thu, 28 May 2015 01:31:13 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:21 GMT
+      - Thu, 28 May 2015 01:31:13 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:21 GMT
+      - Thu, 28 May 2015 07:31:13 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:21 GMT
+  recorded_at: Thu, 28 May 2015 01:31:13 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:22 GMT
+      - Thu, 28 May 2015 01:31:13 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:22 GMT
+      - Thu, 28 May 2015 07:31:13 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:22 GMT
+  recorded_at: Thu, 28 May 2015 01:31:13 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:22 GMT
+      - Thu, 28 May 2015 01:31:14 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:22 GMT
+      - Thu, 28 May 2015 07:31:14 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,7 +2451,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:22 GMT
+  recorded_at: Thu, 28 May 2015 01:31:14 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -2471,7 +2471,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:22 GMT
+      - Thu, 28 May 2015 01:31:14 GMT
       Server:
       - Apache/2
       Location:
@@ -2479,7 +2479,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:22 GMT
+      - Thu, 28 May 2015 07:31:14 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -2495,7 +2495,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:22 GMT
+  recorded_at: Thu, 28 May 2015 01:31:14 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -2517,7 +2517,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:22 GMT
+      - Thu, 28 May 2015 01:31:15 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -2531,7 +2531,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:22 GMT
+      - Thu, 28 May 2015 07:31:15 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -3649,7 +3649,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:24 GMT
+  recorded_at: Thu, 28 May 2015 01:31:15 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -3669,7 +3669,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:24 GMT
+      - Thu, 28 May 2015 01:31:15 GMT
       Server:
       - Apache/2
       Location:
@@ -3677,7 +3677,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:24 GMT
+      - Thu, 28 May 2015 07:31:15 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -3693,7 +3693,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:24 GMT
+  recorded_at: Thu, 28 May 2015 01:31:15 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -3715,7 +3715,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:24 GMT
+      - Thu, 28 May 2015 01:31:16 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -3729,7 +3729,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:24 GMT
+      - Thu, 28 May 2015 07:31:16 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -4847,10 +4847,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:24 GMT
+  recorded_at: Thu, 28 May 2015 01:31:16 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/b2%2F3a%2Fa4%2Fd9%2Fb23aa4d9-9d8c-4ec1-bea2-a44454a523cf
+    uri: http://localhost:3000/annotations/3f%2Ff6%2Fdf%2F7f%2F3ff6df7f-5ea9-4a83-a8c9-adffc187adce
     body:
       encoding: US-ASCII
       string: ''
@@ -4877,22 +4877,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 17c97c3c-1057-4abe-80f9-40a28f190bc7
+      - fc198361-d555-4391-a1c0-57da7666003a
       X-Runtime:
-      - '0.178756'
+      - '0.182566'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:09:24 GMT
+      - Thu, 28 May 2015 01:31:16 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=Z3RBckJTVFM0WDVJWjIyUVYzTFFLbkxsU3RxSWl3cWFMS2FYTk9saFNCZXlBMlJRZnFJakNHWmkySmJ2NU41ZE54Vm1oR3FjY0pYUHk3UDB6WnZGUFJWN0xXQ2doU1FLSUhQbEtlQWhNQkoyWTJQaVZFNHdQUzk5OWV6N3RiWFNPa0h0cTV2QzN6RVkrend1dFdPRSs5NGYxSkNyUVpjUjcyeWlMdDVPbUp5cjBRSU5SOHZwbVEra3dTWVl0MHc0LS14bFh3WDVwT24yK3JrRVdWYy9VdUNnPT0%3D--93f15d2914989f1fe8076ce902f72e35e98b931d;
+      - _internal_session=M2VGZWE5dFQ3cEpzeXBMcmR4b1Zoay9OUlQvdHFsT21ZdTZjak5mekRibUtpdUZ2K2R5QWtMd1krSmF4UVlhd0t0dWNWQTd2Z3BicVZDN0VqRmMvZmhsMFRnakZaelVKNW4zbGJLcGxNc1F2blJOKzJRYnlOVGZuNWhYTHhFQm5wQmQ3dU84REtleG1zK0ZqWUdONlBsdkFheUJJRzdSN0d5dTJIdkJmM2xmMXpvNVlLV25LbXpaelFTSURJQXJQLS1TaEtpeFdKQ1JPQ0p3Nm95RlMzSWtBPT0%3D--3bb0d350967c81a3010ec44a0ef496a25e00ce16;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:24 GMT
+  recorded_at: Thu, 28 May 2015 01:31:16 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/response_processing_utilities/_response2graph/raises_ArgumentError_when_given_an_empty_String.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/response_processing_utilities/_response2graph/raises_ArgumentError_when_given_an_empty_String.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"4f4ba37bffe6153be52abe28563ba373"
+      - W/"7f5adfe5c585a52d164433ef3cacea59"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 3f09d186-4e77-4242-b0ff-ccce85100448
+      - cc4adb21-18de-498e-936e-fab772a6c9bb
       X-Runtime:
-      - '1.641738'
+      - '2.032516'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:09:29 GMT
+      - Thu, 28 May 2015 01:31:22 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=NFByUHNhU2RrVkJXc3ZtS2M4QmE5UzFTeUs3OHVFcEhRV1JBeW1ZS2djNmVhbDArSWlZZXh5Yi9zcGJKcTZmQnhTSWpQQ3B3djVsVUpzUS85TE9lN3FZTFlnOG1pOE16aGVRbWlLWHpOM0Z5Nmp2cHhaMzhRYis1aVZ4c3J6YU1Pb0NLblBiNlVUeWYvcFVqR3pWeFYyZnl6YldtZjVCU21BclJEcUFIUURKY05YWGQ3eVR1SVZUcC9MRWZ1dzIzVHVxdnFFbEpXNkQxcU5xMFpCdHp1Q013M0hWaDVrdG4rTHpSSDlTQXVubFZQcWxYZityM1BpWUNoOTBUOTVsaS0tU1NwNUpoQVpudFFUaTltRjNNMzZ1Zz09--8dd65c0bf1fe438a799fa62968c6951698b82f94;
+      - _internal_session=ZlhIR05IcUo3REVzWmt4cWtoTUh2emVUbEIxSU82ZWVPOTNGRC9wRm5kQWtMeE1KL2Y2ZEFTdUg2UWM5bSs2SVhqVmlhZFMyY0pYU1RpMkl2QVBpOVU3U2preXFERTVuR3JPV29CYTBNYU8xRWh6MytFQWoveEJzN1hxZlVPQXc1a1hMZlFla1JyLzBuZm9MbFo2cHkxTjJURnAvaW5UVWFrc2V6SG1TZVJjS1pNUXl6eHZNRXhiS244SHgxUzlXcjM3NTRwUThhcmVuYkFvenRJZFN3QzdlQWxLdTJmZHlocnB1SU10MmtGVmpNbzlmdW4vVHBDTjd4b2dsNUNtKy0tZWg4enZPVVdtalpFSkFXOU81Rnk3Zz09--c4fff4f7f7174586dd900aa85623730bc049e19f;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310852268780","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/9d/71/19/87/9d711987-f607-4f61-9c7f-df0f797a5751","@type":"oa:Annotation","hasBody":"_:g70310852268780","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69941860136740","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/c9/36/05/b4/c93605b4-25a4-4119-9e50-0aaf47f006c0","@type":"oa:Annotation","hasBody":"_:g69941860136740","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:29 GMT
+  recorded_at: Thu, 28 May 2015 01:31:22 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:30 GMT
+      - Thu, 28 May 2015 01:31:22 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:30 GMT
+      - Thu, 28 May 2015 07:31:22 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:30 GMT
+  recorded_at: Thu, 28 May 2015 01:31:23 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:30 GMT
+      - Thu, 28 May 2015 01:31:23 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:30 GMT
+      - Thu, 28 May 2015 07:31:23 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:30 GMT
+  recorded_at: Thu, 28 May 2015 01:31:23 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:30 GMT
+      - Thu, 28 May 2015 01:31:23 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:30 GMT
+      - Thu, 28 May 2015 07:31:23 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:30 GMT
+  recorded_at: Thu, 28 May 2015 01:31:23 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:30 GMT
+      - Thu, 28 May 2015 01:31:24 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:30 GMT
+      - Thu, 28 May 2015 07:31:24 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:31 GMT
+  recorded_at: Thu, 28 May 2015 01:31:24 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/9d%2F71%2F19%2F87%2F9d711987-f607-4f61-9c7f-df0f797a5751
+    uri: http://localhost:3000/annotations/c9%2F36%2F05%2Fb4%2Fc93605b4-25a4-4119-9e50-0aaf47f006c0
     body:
       encoding: US-ASCII
       string: ''
@@ -2481,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 362166aa-818b-4d88-9d59-c109935d7a85
+      - d3e6e71a-dc62-43bf-a9c0-5a73dfb7ed7e
       X-Runtime:
-      - '0.234384'
+      - '0.197540'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:09:31 GMT
+      - Thu, 28 May 2015 01:31:24 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=RHpOT3dzT1FFa2t1ZDlrUVZCVlVHTDVZV0hSWGtqRVNOR0VEUkdFcHlBc1FVRmYxeTlNNHlNWHo4QTlWUytFV1N4eGMyeWlwZldwRWZDR0U1K05zOFhXajJXRTNKdVl0MzBJbEMwQmE0WndlL0tPZ25qMmFER2JKTDVaUU9oSjBsakNDNUlBSGQzcE8vZDRoVUhpajJxR0NpQm5UQVh3ZmhLMHc0bnBxdHZaL2NWVUROREFTcTREZUpmWDNkMUlwLS05K1UyamExSEE3YUJDWGg3ZjFVd0FnPT0%3D--708ec54618700fae4d0b52e0703007f3b19d279a;
+      - _internal_session=bzcveWVOZms1OXIybE9DNlVEMTlHa1BTd204QjNZQXlPbUxZTXR0R3B3SFF3eGcrb05meHZZWEZtek1kSXM2MVJEeWhpTHZDeUxBM25ESTNydTQzb1lQRHl6Q3pTM3lrR2k5WjNieWVibmtSUm5VdXRvcklWc3Q5eFZJREFkS1lpYTFzTW5PTEJrOVg2ME1Qb0ZIdlpwUFgycjB4MjQxVGNXQlFjK1BkTWU0aHlsN3g2dW56RzkybklvbkNYY1lMLS0zS2ZORWx2TDcrdkcybE9jS1VGRlR3PT0%3D--0543ffed7742bb86ed11242759bb4ca2f95159a8;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:31 GMT
+  recorded_at: Thu, 28 May 2015 01:31:24 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/response_processing_utilities/_response2graph/raises_ArgumentError_when_given_nil.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/response_processing_utilities/_response2graph/raises_ArgumentError_when_given_nil.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"68d10f9a6e0ed8273b3c61e525865aae"
+      - W/"2308067402cce0938759058dedc24e82"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - be40a655-88a4-4676-b89e-240d825ad1eb
+      - 4b9a02c6-a348-4858-b5a6-f2af336f3565
       X-Runtime:
-      - '1.706891'
+      - '1.936377'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:09:26 GMT
+      - Thu, 28 May 2015 01:31:18 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=Qk84YTE2bDIyY3RhTDhpU2ZFNzBEUVhvVkJXOVFneU1wT3paNlh4R1VWQmlnRmlpMzlXa05BRXpHMWRKdU5jUVMxcktzdFhkNU01RjlFSjBmTjd2VHVHSTRpMFR6VXhLN1Vub2xYa2J3dWpPMXg4YmxBQWZSb1FDRCtJNXdzMGp5azJEMjNoV2p2dG1McEVEdGNTN1lEb2JRTEdaMkk2Q0hIYUlNa0pKL3pXcU9jcUM5NG8rY1FRalAvcTRyOU51S3l6b1dsYzEvMDdCOG54UDZ4UFB0VlM2d2o5WExiRDNpK1lvbXMzVW9taExPbG5rM2VheU5Ec2FRbU9jb1hmZy0tRUZNRlNPWUY2dlRhcDRpYVFSSUFHZz09--c8000be05c0e65e39303aea57d02b07d887d8434;
+      - _internal_session=b0FCMEVhNDlGbFV2UjFXRUJpV0JTbW1yaDI1NXVqd1pOMUR1MVhkYmtwQmVJWnZQVFFJd1Q0VEkxSndKNWZOSWhKWlZFQnNUUy9PWDFtSDNvSDhPbFNaQkZPclNjOGh2bHlMOFZwZnpwblJIY0JCR3EremxJUG5sdENvMkNkZ3Bsd0tOWVJIcFhXOHVZM05lQlREVFNsRmU1b2lqeHZpc3RYWXh5ZkM4V0ltZVV1dmRSbm9WSlliQ1dZd25SejBESlBDVEhBOEhPOE9YSWFlandSRGNEZWxWckl5akdYS3AvajlaOUw4YThYbGEySkdlb25yd01PK2RTRFhiZHhvWS0tRERlSGJRVjBTcy9naXZ4Zkl5bGo3Zz09--9fbc3341018a8323526da774e64ee9e6f9aa02df;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310876641600","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/cb/46/b1/0c/cb46b10c-c2e6-4103-86fe-e5da6cea172e","@type":"oa:Annotation","hasBody":"_:g70310876641600","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69941858412940","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/5e/24/19/b0/5e2419b0-3113-4059-9cc7-e40d88dc9ef8","@type":"oa:Annotation","hasBody":"_:g69941858412940","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:26 GMT
+  recorded_at: Thu, 28 May 2015 01:31:18 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:26 GMT
+      - Thu, 28 May 2015 01:31:18 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:26 GMT
+      - Thu, 28 May 2015 07:31:18 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:26 GMT
+  recorded_at: Thu, 28 May 2015 01:31:18 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:26 GMT
+      - Thu, 28 May 2015 01:31:19 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:26 GMT
+      - Thu, 28 May 2015 07:31:19 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:27 GMT
+  recorded_at: Thu, 28 May 2015 01:31:19 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:27 GMT
+      - Thu, 28 May 2015 01:31:19 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:27 GMT
+      - Thu, 28 May 2015 07:31:19 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:27 GMT
+  recorded_at: Thu, 28 May 2015 01:31:19 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:27 GMT
+      - Thu, 28 May 2015 01:31:20 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:27 GMT
+      - Thu, 28 May 2015 07:31:20 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:27 GMT
+  recorded_at: Thu, 28 May 2015 01:31:20 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/cb%2F46%2Fb1%2F0c%2Fcb46b10c-c2e6-4103-86fe-e5da6cea172e
+    uri: http://localhost:3000/annotations/5e%2F24%2F19%2Fb0%2F5e2419b0-3113-4059-9cc7-e40d88dc9ef8
     body:
       encoding: US-ASCII
       string: ''
@@ -2481,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 2f2476e3-cf0f-4e70-af9b-a340f8600515
+      - 54beaa7d-ff49-4787-8273-37717e07dd33
       X-Runtime:
-      - '0.232798'
+      - '0.204070'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:09:28 GMT
+      - Thu, 28 May 2015 01:31:20 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=SkxmQTNmdFRDdE9GQmRBc1pJTW40TFRUTVZLVGNpR1FGSUZkN0lhTFlBbmhERkVJN1d4RkdWVlp1SDZ2QzRCQTRlaytLV3R1L0NBMU5UR1dFRE05eElONjhlemlKNDRNL3RVb2NlU2dVMUIrUnZZenlSUFgraEpzSmVQeDFSakF3c2dOdkhNZzQ2VWkxR3M2RTlENm5ybE05K1VNVktRZGkrb3RjcHA0OFdCZ1hPN05sZXpDSnhYWFBnVjdiVHZYLS1ZUUFoeHRyRWRDTWZ5TUxNM3pCelV3PT0%3D--fd1bae954b41f7d9ea2481e74de050f35979a8ed;
+      - _internal_session=YjdvN2p6NS9PU00xS0xUQ1I3VHFJdDhSTVl1REhGU0ZsM08xZ1NZRWxSTmxkamtmcE1JOVVBRFFOdW5DRzNIM0tlY2F6NHdjVVA1WmVPSHF3OXF4c3d3UUpWYjhJTytRVVJzcU9Sb2gvaW1mRi91bVdkQ0hvbjFOakRFeXhudVFiWk9aTVowL1A4OTgxdUNkUzYybGFrQmRNWjlldU9VbVVzNzQxQ21SVGg0MVFaZHpoQVV3MUozdWtjMHVjVEMrLS1lbDBTUkhFa2N1YnJKQUcwU2h4NUdnPT0%3D--5ca50b5161120e09fa1f7bc0db3a641583fc58e4;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:28 GMT
+  recorded_at: Thu, 28 May 2015 01:31:20 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/TriannonClient/response_processing_utilities/_response2graph/returns_an_RDF_Graph.yml
+++ b/spec/fixtures/vcr_cassettes/TriannonClient/response_processing_utilities/_response2graph/returns_an_RDF_Graph.yml
@@ -31,31 +31,31 @@ http_interactions:
       Content-Type:
       - application/ld+json; charset=utf-8
       Etag:
-      - W/"ca780a5fe7badf2d36f31b42549f4d5f"
+      - W/"26ba86d0cfc60ae2313d486bcb61fd02"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 745643d7-8506-4437-aa37-c86bc8335b6f
+      - 0eeda84a-36e3-412c-9625-83d1b650820c
       X-Runtime:
-      - '1.642145'
+      - '2.109423'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:09:33 GMT
+      - Thu, 28 May 2015 01:31:26 GMT
       Content-Length:
       - '443'
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=UTE0K3FJcVBtdEtoK3B5Vmx0RHBsSE55aDBIa0F1SGw3STI0aUNTQzdtbVhYdkFqM1lNR014OXRoTUM5blV4QTB2NW96VGxmcERJanV4Ui9xNG95VjY5Ykl1YUg2UUJSc0Q2bjh4RU12NjVFbEVQK3Q1WE1MakwrZXFnanQ4aDZxQ2M5Z21RcXFqN25YVE05SjJETWdhdGlXdGYvU0hyd2pFblJhOXl5VGNFeFl3cmRMc3dYVklNZHdnTFA1OUV2V05QT3R6d0pHOWw1T0xPVUF3ZWF2dkVLL2dseGlHRFFJV0hXU1VRNXdzZUF3QWtSc25JUmlSSmh2eVdIYXFEby0tQlhDcmpFRjhvNnZ2cEgrZGVZNzBuUT09--7c59fea1c313e9c454a40a68a46d060f823cbb29;
+      - _internal_session=SENYMGdLWjBHSzgrRU5lSEU5ZUR3Zk1pc1dqVlU3NDJyMjVtRmpkT3FZUTVHaml1YUQ2T2xFbkY5ajVyeTV4dkFpU0Z1SW15YzBMUWwxOE1XZDZUSk5YenFxemwwQlY0ZkJ3OXkwVlRpN3ovMVlndFVyQWl1Zks4OFY1eWVlb1dLRHNMZmhQSWlQVlQxbDZIZVhaaFRBQUFMalM2UzhwVlB3RDhEZkhKRXlSYjNpSWhDcXhOMjdqQmJzSTk2cGZLMkZFc0liRXBRYVkxMWFpTUJIRWV2M2RxSE1VUWE3Y0k5d1FaOW5paEtmd1p3RTd0a1JKaTVMVXVEMWNVMjM5YS0tQ2l6ZXBCWE9TcEp3UjF1WWRGMUtRQT09--50e5e373c41e223161954628c276c6f21108b80f;
         path=/; HttpOnly
       - request_method=POST; path=/
     body:
       encoding: UTF-8
-      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70310877876340","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/a2/32/7c/21/a2327c21-d161-43bc-88b0-a2201472cdd3","@type":"oa:Annotation","hasBody":"_:g70310877876340","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
+      string: '{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g69942009326280","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/10/0b/a3/af/100ba3af-e0c6-4655-aa59-a133b7c81187","@type":"oa:Annotation","hasBody":"_:g69942009326280","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}'
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:33 GMT
+  recorded_at: Thu, 28 May 2015 01:31:26 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -75,7 +75,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:33 GMT
+      - Thu, 28 May 2015 01:31:26 GMT
       Server:
       - Apache/2
       Location:
@@ -83,7 +83,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:33 GMT
+      - Thu, 28 May 2015 07:31:26 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -99,7 +99,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:33 GMT
+  recorded_at: Thu, 28 May 2015 01:31:27 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:33 GMT
+      - Thu, 28 May 2015 01:31:27 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:33 GMT
+      - Thu, 28 May 2015 07:31:27 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -1253,7 +1253,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:33 GMT
+  recorded_at: Thu, 28 May 2015 01:31:27 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa-context-20130208.json
@@ -1273,7 +1273,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:33 GMT
+      - Thu, 28 May 2015 01:31:27 GMT
       Server:
       - Apache/2
       Location:
@@ -1281,7 +1281,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:33 GMT
+      - Thu, 28 May 2015 07:31:27 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -1297,7 +1297,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:33 GMT
+  recorded_at: Thu, 28 May 2015 01:31:27 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1319,7 +1319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 May 2015 20:09:34 GMT
+      - Thu, 28 May 2015 01:31:28 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1333,7 +1333,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 19 May 2015 02:09:34 GMT
+      - Thu, 28 May 2015 07:31:28 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Access-Control-Allow-Origin:
@@ -2451,10 +2451,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:34 GMT
+  recorded_at: Thu, 28 May 2015 01:31:28 GMT
 - request:
     method: delete
-    uri: http://localhost:3000/annotations/a2%2F32%2F7c%2F21%2Fa2327c21-d161-43bc-88b0-a2201472cdd3
+    uri: http://localhost:3000/annotations/10%2F0b%2Fa3%2Faf%2F100ba3af-e0c6-4655-aa59-a133b7c81187
     body:
       encoding: US-ASCII
       string: ''
@@ -2481,22 +2481,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 6ec62e89-adcd-425c-bfed-b2e8d9f407cd
+      - c5cda6f6-b2e6-4d08-8360-f306fa886189
       X-Runtime:
-      - '0.206951'
+      - '0.196551'
       Server:
       - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
       Date:
-      - Mon, 18 May 2015 20:09:34 GMT
+      - Thu, 28 May 2015 01:31:28 GMT
       Connection:
       - Keep-Alive
       Set-Cookie:
-      - _internal_session=Mm5GK1paSkpuMUV2OWFxYzg2dHlFLzU5RldWa0xPdmlvYVVvS2ZkVE1yYWxodXk3UjI5L09YR0FTemF3TFcwZzR2VE9ZUDhlWlNYRGYrUEo4amdjclVzLzBtVTIrdEdqSVZhVXpsWU51d01HYWhVeUtPZjdiTlY1RWs0YXp5Q0pKMXBZVXNQUURjZ25BMWdNalRuQUJpMjYrUkdodVF3Vi94U1IxenFzWFg3cE5oaEdEZEFWZFNzblhLRFpURDk2LS1lNjlsQlRTSXU5NkFIakp5a0VBZUhRPT0%3D--2008f27f51041bbe6b8bd0bbc5ee8b5ce64a64a4;
+      - _internal_session=SngrT2dyNzZsb2VHWGdsS0xXZ3NHeUxWRjhmanFsRmRFRy9od3BqbmZxN0RTUDI5THNJRTdIWXBZcW9lNENKeERxR280dFdmVjhsSjU4UTdWZG5HMnlpOUNCVW5zdWpmbHE2Tis0ZStMaGxUTG1oUnBMeVJRUEZtSGFrdkR3TzA5Q1ZwSEM5T0h0SkMzMm1wTktJamdrMGRDUkdrcnBmUVhtUEprWWZvUHRuWm1iT2JZZDB0ZjdENG4waWh4K21VLS1WME9kZWNTcHdvcG5xalJRRUNxUk1BPT0%3D--c572ea0057a90a6752c2dbfc47f71d9f77abaa45;
         path=/; HttpOnly
       - request_method=DELETE; path=/
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 May 2015 20:09:34 GMT
+  recorded_at: Thu, 28 May 2015 01:31:28 GMT
 recorded_with: VCR 2.9.3

--- a/spec/lib/triannon-client/configuration_spec.rb
+++ b/spec/lib/triannon-client/configuration_spec.rb
@@ -36,6 +36,22 @@ module TriannonClient
       end
     end
 
+    describe '#container' do
+      it 'default value is an empty string' do
+        ENV['TRIANNON_CONTAINER'] = nil
+        config = Configuration.new
+        expect(config.container).to be_empty
+      end
+    end
+
+    describe '#container=' do
+      it 'can set value' do
+        config = Configuration.new
+        config.container = 'secret'
+        expect(config.container).to eql('secret')
+      end
+    end
+
     describe '#user' do
       it 'default value is an empty string' do
         ENV['TRIANNON_USER'] = nil
@@ -68,21 +84,38 @@ module TriannonClient
       end
     end
 
-    describe '#container' do
+    describe '#oauth_client' do
       it 'default value is an empty string' do
-        ENV['TRIANNON_CONTAINER'] = nil
+        ENV['TRIANNON_OAUTH_ID'] = nil
         config = Configuration.new
-        expect(config.container).to be_empty
+        expect(config.oauth_client).to be_empty
       end
     end
 
-    describe '#container=' do
+    describe '#oauth_client=' do
       it 'can set value' do
         config = Configuration.new
-        config.container = 'secret'
-        expect(config.container).to eql('secret')
+        config.oauth_client = 'fred'
+        expect(config.oauth_client).to eql('fred')
       end
     end
+
+    describe '#oauth_secret' do
+      it 'default value is an empty string' do
+        ENV['TRIANNON_OAUTH_SECRET'] = nil
+        config = Configuration.new
+        expect(config.oauth_secret).to be_empty
+      end
+    end
+
+    describe '#oauth_secret=' do
+      it 'can set value' do
+        config = Configuration.new
+        config.oauth_secret = 'secret'
+        expect(config.oauth_secret).to eql('secret')
+      end
+    end
+
 
   end
 end

--- a/triannon-client.gemspec
+++ b/triannon-client.gemspec
@@ -21,6 +21,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'dotenv'
   # HTTP and RDF clients
   s.add_dependency 'rest-client'
+  # Add oauth support using the oauth gem
+  s.add_dependency 'oauth'
   s.add_dependency 'linkeddata'
   # Use pry for console and debugging
   s.add_dependency 'pry'


### PR DESCRIPTION
This PR is a work in progress (available for review, but not for merging yet).  It will explore OAuth support in rest-client, which indicates that it can support Oauth using an ‘oauth’ gem (not sure if it’s oath2), see:
- https://github.com/rest-client/rest-client#hook

Related information (for my reference):
- http://stackoverflow.com/questions/11724912/posting-in-oauth-with-client-credentials-with-doorkeeper 
- http://blog.stakeventures.com/articles/2008/02/23/developing-oauth-clients-in-ruby 
