### PR TITLE
Log exceptions for argument errors and unsupported content types

### DIFF
--- a/lib/triannon-client.rb
+++ b/lib/triannon-client.rb
@@ -1,13 +1,6 @@
 require 'dotenv'
 Dotenv.load
 
-# pry must be available when the client is configured to run in debug mode,
-# where it will fall into a pry console for rescue blocks.
-if ENV['DEBUG']
-  require 'pry'
-  require 'pry-doc'
-end
-
 # require rest client prior to linkeddata, so the latter can use it.
 require 'rest-client'
 # If a proxy is present, RestClient needs explicit configuration to use it.

--- a/lib/triannon-client/configuration.rb
+++ b/lib/triannon-client/configuration.rb
@@ -22,7 +22,7 @@ module TriannonClient
     attr_accessor :client_pass
 
     def initialize
-      @debug = env_boolean('DEBUG')
+      self.debug = env_boolean('DEBUG')
 
       @host = ENV['TRIANNON_HOST'] || 'http://localhost:3000'
       # @user = ENV['TRIANNON_USER'] || '' # triannon doesn't support basic auth
@@ -58,7 +58,17 @@ module TriannonClient
       ENV[var].to_s.upcase == 'TRUE' rescue false
     end
 
+    def debug=(bool)
+      raise ArgumentError unless [true, false].include?(bool)
+      @debug = bool
+      if @debug
+        # pry must be available when the client is configured to run in debug
+        # mode, where it will fall into a pry console for rescue blocks.
+        require 'pry'
+        require 'pry-doc'
+      end
+    end
+
   end
 
 end
-

--- a/spec/lib/triannon-client/configuration_spec.rb
+++ b/spec/lib/triannon-client/configuration_spec.rb
@@ -21,9 +21,22 @@ module TriannonClient
     end
 
     describe '#debug=' do
-      it 'can set value' do
+      it 'can set boolean value' do
         config.debug = true
         expect(config.debug).to be_truthy
+      end
+      it 'loads pry in debug mode' do
+        config.debug = true
+        defined?(Pry) == true
+      end
+      it 'does not load pry outside debug mode' do
+        config.debug = false
+        defined?(Pry) == false
+      end
+      it 'raises ArgumentError for non-boolean values' do
+        expect{config.debug='abc'}.to raise_error(ArgumentError)
+        expect{config.debug=nil}.to raise_error(ArgumentError)
+        expect{config.debug=0}.to raise_error(ArgumentError)
       end
     end
 

--- a/spec/lib/triannon-client/triannon_client_delete_spec.rb
+++ b/spec/lib/triannon-client/triannon_client_delete_spec.rb
@@ -65,10 +65,12 @@ RSpec.shared_examples "delete annotations" do |auth_required|
     expect(tc).to receive(:check_id)
     tc.delete_annotation('checking_anno_id')
   end
-  it 'raises ArgumentError for an invalid annotation ID' do
+  it 'logs ArgumentError for an invalid annotation ID' do
     expect_any_instance_of(RestClient::Resource).not_to receive(:delete)
-    expect { tc.delete_annotation('')  }.to raise_error(ArgumentError)
-    expect { tc.delete_annotation(nil) }.to raise_error(ArgumentError)
+    expect(tc.config.logger).to receive(:error).with(/Invalid ID/).exactly(3).times
+    expect(tc.delete_annotation('')).to be false
+    expect(tc.delete_annotation(0)).to be false
+    expect(tc.delete_annotation(nil)).to be false
   end
   it 'uses RestClient::Resource.delete to DELETE a valid annotation ID' do
     expect_any_instance_of(RestClient::Resource).to receive(:delete)

--- a/spec/lib/triannon-client/triannon_client_read_spec.rb
+++ b/spec/lib/triannon-client/triannon_client_read_spec.rb
@@ -30,6 +30,8 @@ describe 'TriannonClientREAD', :vcr do
   end
 
   def cannot_get_anno_with_content_type(content_type)
+    expect(tc).to receive(:check_content_type)
+    expect(tc).not_to receive(:response2graph)
     graph = tc.get_annotation(@anno[:id], content_type)
     graph_is_empty(graph)
   end
@@ -260,6 +262,10 @@ describe 'TriannonClientREAD', :vcr do
       end # using default content type
 
       context 'using custom content type' do
+        it 'raises ArgumentError for unsupported content types' do
+          expect{tc.send(:check_content_type,'abc')}.to raise_error(ArgumentError)
+        end
+
         # Content types could be supported for RDF::Format.content_types.keys,
         # but not all of them are supported.  The supported content types for
         # triannon are defined in
@@ -273,6 +279,7 @@ describe 'TriannonClientREAD', :vcr do
         # json as:    ["application/json", "text/x-json", "application/jsonrequest"]
         # xml as:     ["application/xml", "text/xml", "application/x-xml"]
         # html
+
 
         # The client supports any format in RDF::Format.content_types, so the
         # following are not included (as of July 2015):

--- a/spec/lib/triannon-client/triannon_client_read_spec.rb
+++ b/spec/lib/triannon-client/triannon_client_read_spec.rb
@@ -199,6 +199,12 @@ describe 'TriannonClientREAD', :vcr do
 
     describe "annotation by ID" do
 
+      def invalid_annotation_id(id)
+        expect(tc.config.logger).to receive(:error).with(/Invalid ID/)
+        g = tc.get_annotation(id)
+        graph_is_empty(g)
+      end
+
       context 'using default content type' do
 
         it 'checks the annotation ID' do
@@ -206,14 +212,14 @@ describe 'TriannonClientREAD', :vcr do
           graph = tc.get_annotation(@anno[:id])
           graph_contains_statements(graph)
         end
-        it 'raises an argument error with a nil ID' do
-          expect{tc.get_annotation(nil)}.to raise_error(ArgumentError)
+        it 'returns empty graph and logs exception with a nil ID' do
+          invalid_annotation_id(nil)
         end
-        it 'raises an argument error with an integer ID' do
-          expect{tc.get_annotation(0)}.to raise_error(ArgumentError)
+        it 'returns empty graph and logs exception with an integer ID' do
+          invalid_annotation_id(0)
         end
-        it 'raises an argument error with an empty string ID' do
-          expect{tc.get_annotation('')}.to raise_error(ArgumentError)
+        it 'returns empty graph and logs exception with an empty string ID' do
+          invalid_annotation_id('')
         end
         it 'requests an open annotation by ID, using JSON-LD content' do
           jsonld = TriannonClient::TriannonClient::JSONLD_TYPE


### PR DESCRIPTION
This is a relatively trivial change to enable logging for common exceptions.  The purpose is to allow the DMS ETL to continue while logging exceptions.  The failures are available to any app using the client as either a `false` response or an empty RDF::Graph.
